### PR TITLE
Detect deadlocks

### DIFF
--- a/tests/test_switch.ml
+++ b/tests/test_switch.ml
@@ -253,3 +253,10 @@ let%expect_test "sub_return" =
     (Failure "Child error")
     x = 0
     ok |}]
+
+let%expect_test "deadlock" =
+  run (fun sw ->
+      let p, _ = Promise.create () in
+      Promise.await ~sw p
+    );
+  [%expect {| Deadlock detected: no events scheduled but main function hasn't returned |}]


### PR DESCRIPTION
Previously, the scheduler returned whenever there were no pending events. This could be because the main function had finished, but it could also happen if the system was deadlocked.

Now, the scheduler raises an exception if it finishes while the main thread is still running, which should make the problem clearer.