### PR TITLE
Convert expect tests to MDX

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,8 +18,8 @@
  (synopsis "Eio implementation for Linux using io-uring")
  (description
    "An eio implementation for Linux using io-uring.")
- (conflicts (ocaml-variants (= "4.12.0+domains")))
  (depends
+  (ocaml-variants (= "4.12.0+domains+effects"))
   (ctf (= :version))
   (fibreslib (= :version))
   (eio (= :version))

--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,6 @@
   (fibreslib (= :version))
   (eio (= :version))
   (alcotest (and (>= 1.4.0) :with-test))
-  (ppx_expect :with-test)
   (mdx :with-test)
   (logs (>= 0.7.0))
   (fmt (>= 0.8.9))

--- a/eunix.opam
+++ b/eunix.opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.8"}
+  "ocaml-variants" {= "4.12.0+domains+effects"}
   "ctf" {= version}
   "fibreslib" {= version}
   "eio" {= version}
@@ -20,9 +21,6 @@ depends: [
   "uring"
   "bheap" {>= "2.0.0"}
   "odoc" {with-doc}
-]
-conflicts: [
-  "ocaml-variants" {= "4.12.0+domains"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/eunix.opam
+++ b/eunix.opam
@@ -13,7 +13,6 @@ depends: [
   "fibreslib" {= version}
   "eio" {= version}
   "alcotest" {>= "1.4.0" & with-test}
-  "ppx_expect" {with-test}
   "mdx" {with-test}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}

--- a/tests/dune
+++ b/tests/dune
@@ -13,14 +13,9 @@
  (modules basic_eunix)
  (libraries logs.fmt fmt.tty eurcp_lib))
 
-(library
-  (name eio_expect_tests)
-  (optional) ; Otherwise, dune tries to build this even when not running tests
-  (package eunix)
-  (modules test_switch)
-  (inline_tests)
-  (preprocess (pps ppx_expect))
-  (libraries eunix))
+(mdx
+  (packages eunix)
+  (files test_switch.md))
 
 (test
  (name test)


### PR DESCRIPTION
This looks a bit nicer and avoids pulling in two separate expect-test frameworks.