### PR TITLE
Add `Switch.on_release` to auto-close FDs

### DIFF
--- a/fibreslib/fibre.ml
+++ b/fibreslib/fibre.ml
@@ -1,10 +1,24 @@
-effect Fork  : Switch.t * bool * (unit -> 'a) -> 'a Promise.t
+effect Fork  : (unit -> 'a) -> 'a Promise.t
 let fork ~sw ~exn_turn_off f =
-  perform (Fork (sw, exn_turn_off, f))
+  let f () =
+    Switch.with_op sw @@ fun () ->
+    try f ()
+    with ex ->
+      if exn_turn_off then Switch.turn_off sw ex;
+      raise ex
+  in
+  perform (Fork f)
 
-effect Fork_ignore : Switch.t * (unit -> unit) -> unit
+effect Fork_ignore : (unit -> unit) -> unit
 let fork_ignore ~sw f =
-  perform (Fork_ignore (sw, f))
+  let f () =
+    Switch.with_op sw @@ fun () ->
+    try f ()
+    with ex ->
+      Switch.turn_off sw ex;
+      raise ex
+  in
+  perform (Fork_ignore f)
 
 effect Yield : unit
 let yield ?sw () =
@@ -20,5 +34,17 @@ let both ~sw f g =
   Promise.await x;
   Switch.check sw
 
-let fork_sub_ignore ~sw ~on_error f =
-  fork_ignore ~sw (fun () -> Switch.sub ~sw ~on_error f)
+let fork_sub_ignore ?on_release ~sw ~on_error f =
+  if Switch.is_finished sw then (
+    (* If the switch is finished then we have no way to report the error after forking,
+       so do it now. *)
+    Option.iter (fun f -> f ()) on_release;
+    invalid_arg "Switch finished!"
+  );
+  let f () =
+    try Switch.sub ?on_release ~sw ~on_error f
+    with ex ->
+      Switch.turn_off sw ex;
+      raise ex
+  in
+  perform (Fork_ignore f)

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -125,19 +125,22 @@ module Network = struct
     let listen (t : #t) = t#listen
 
     (** [accept t fn] waits for a new connection to [t] and then runs [fn ~sw flow client_addr] in a new fibre,
-        created with [Fibre.fork_sub_ignore]. *)
+        created with [Fibre.fork_sub_ignore].
+        [flow] will be closed automatically when the sub-switch is finished, if not already closed by then. *)
     let accept_sub (t : #t) = t#accept_sub
   end
 
   class virtual t = object
-    method virtual bind : reuse_addr:bool -> Unix.sockaddr -> Listening_socket.t
-    method virtual connect : Unix.sockaddr -> <Flow.two_way; Flow.close>
+    method virtual bind : reuse_addr:bool -> sw:Switch.t -> Unix.sockaddr -> Listening_socket.t
+    method virtual connect : sw:Switch.t -> Unix.sockaddr -> <Flow.two_way; Flow.close>
   end
 
-  (** [bind ~sw t addr] is a new listening socket bound to local address [addr]. *)
+  (** [bind ~sw t addr] is a new listening socket bound to local address [addr].
+      The new socket will be closed when [sw] finishes, unless closed manually first. *)
   let bind ?(reuse_addr=false) (t:#t) = t#bind ~reuse_addr
 
-  (** [connect t addr] is a new socket connected to remote address [addr]. *)
+  (** [connect t ~sw addr] is a new socket connected to remote address [addr].
+      The new socket will be closed when [sw] finishes, unless closed manually first. *)
   let connect (t:#t) = t#connect
 end
 

--- a/tests/basic_eunix.ml
+++ b/tests/basic_eunix.ml
@@ -1,6 +1,7 @@
 (* basic tests using effects *)
 
 open Eunix
+open Fibreslib
 module Int63 = Optint.Int63
 
 let setup_log level =
@@ -10,22 +11,21 @@ let setup_log level =
 
 let () =
   setup_log (Some Logs.Debug);
-  let fd = Unix.handle_unix_error (Eunix.openfile "test.txt" Unix.[O_RDONLY]) 0 in
-  run (fun _stdenv ->
-    let buf = alloc () in
-    let _ = read_exactly fd buf 5 in
-    print_endline (Uring.Region.to_string ~len:5 buf);
-    let _ = read_exactly fd ~file_offset:(Int63.of_int 3) buf 3 in
-    print_endline (Uring.Region.to_string ~len:3 buf);
-    free buf;
-  );
-  run (fun _stdenv ->
-    let buf = alloc () in
-    let _ = read_exactly fd buf 5 in
-    Logs.debug (fun l -> l "sleeping at %f" (Unix.gettimeofday ()));
-    sleep 1.0;
-    print_endline (Uring.Region.to_string ~len:5 buf);
-    let _ = read_exactly fd ~file_offset:(Int63.of_int 3) buf 3 in
-    print_endline (Uring.Region.to_string ~len:3 buf);
-    free buf;
-  );
+  run @@ fun _stdenv ->
+  Switch.top @@ fun sw ->
+  let fd = Unix.handle_unix_error (Eunix.openfile ~sw "test.txt" Unix.[O_RDONLY]) 0 in
+  let buf = alloc () in
+  let _ = read_exactly fd buf 5 in
+  print_endline (Uring.Region.to_string ~len:5 buf);
+  let _ = read_exactly fd ~file_offset:(Int63.of_int 3) buf 3 in
+  print_endline (Uring.Region.to_string ~len:3 buf);
+  free buf;
+  (* With a sleep: *)
+  let buf = alloc () in
+  let _ = read_exactly fd buf 5 in
+  Logs.debug (fun l -> l "sleeping at %f" (Unix.gettimeofday ()));
+  sleep 1.0;
+  print_endline (Uring.Region.to_string ~len:5 buf);
+  let _ = read_exactly fd ~file_offset:(Int63.of_int 3) buf 3 in
+  print_endline (Uring.Region.to_string ~len:3 buf);
+  free buf;


### PR DESCRIPTION
This allows attaching resources, such as file descriptors, to switches. When the switch is finished, you can be sure the resources have been freed.

This also fixes some FD leaks in the tests and README that this uncovered.