### PR TITLE
Add basic domain manager

### DIFF
--- a/lib_eunix/eunix.mli
+++ b/lib_eunix/eunix.mli
@@ -121,6 +121,7 @@ module Objects : sig
     stdout : sink;
     stderr : sink;
     network : Eio.Network.t;
+    domain_mgr : Eio.Domain_manager.t;
   >
 
   val get_fd : <has_fd; ..> -> FD.t

--- a/tests/dune
+++ b/tests/dune
@@ -15,7 +15,7 @@
 
 (mdx
   (packages eunix)
-  (files test_switch.md test_network.md))
+  (files test_switch.md test_network.md test_domains.md))
 
 (test
  (name test)

--- a/tests/test_domains.md
+++ b/tests/test_domains.md
@@ -1,0 +1,61 @@
+# Setting up the environment
+
+```ocaml
+# #require "eunix";;
+```
+
+```ocaml
+open Eio.Std
+
+let run (fn : Eio.Domain_manager.t -> unit) =
+  try
+    Eunix.run @@ fun env ->
+    fn (Eio.Stdenv.domain_mgr env);
+    print_endline "ok"
+  with
+  | Failure msg -> print_endline msg
+  | ex -> print_endline (Printexc.to_string ex)
+```
+
+# Test cases
+
+Spawning a second domain:
+
+```ocaml
+# run @@ fun mgr ->
+  let response = Eio.Domain_manager.run_compute_unsafe mgr (fun () -> "Hello from new domain") in
+  traceln "Got %S from spawned domain" response
+Got "Hello from new domain" from spawned domain
+ok
+- : unit = ()
+```
+
+The domain raises an exception:
+
+```ocaml
+# run @@ fun mgr ->
+  Eio.Domain_manager.run_compute_unsafe mgr (fun () -> failwith "Exception from new domain")
+Exception from new domain
+- : unit = ()
+```
+
+We can still run other fibres in the main domain while waiting:
+
+```ocaml
+# run @@ fun mgr ->
+  Switch.top @@ fun sw ->
+  Fibre.both ~sw
+    (fun () ->
+      traceln "Spawning new domain...";
+      let response = Eio.Domain_manager.run_compute_unsafe mgr (fun () -> "Hello from new domain") in
+      traceln "Got %S from spawned domain" response
+    )
+    (fun () ->
+      traceln "Other fibres can still run"
+    )
+Spawning new domain...
+Other fibres can still run
+Got "Hello from new domain" from spawned domain
+ok
+- : unit = ()
+```


### PR DESCRIPTION
Allows running a CPU-intensive task in another domain.

This is for compute tasks; it doesn't yet provide a nice API for running an event loop in the new domain. But you can run `Eio_main.run` manually for now.

This PR also adds a mutex to `traceln` to avoid overlapping output.