### PR TITLE
Clean up the network APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ let main ~network ~addr =
 # run @@ fun env ->
   main
     ~network:(Eio.Stdenv.network env)
-    ~addr:Unix.(ADDR_INET (inet_addr_loopback, 8080))
+    ~addr:(`Tcp (Unix.inet_addr_loopback, 8080))
 Server ready...
 Connecting to server...
 Server accepted connection from client

--- a/README.md
+++ b/README.md
@@ -376,8 +376,7 @@ We can test them in a single process using `Fibre.both`:
 ```ocaml
 let main ~network ~addr =
   Switch.top @@ fun sw ->
-  let server = Eio.Network.bind network ~sw ~reuse_addr:true addr in
-  Eio.Network.Listening_socket.listen server 5;
+  let server = Eio.Network.listen network ~sw ~reuse_addr:true ~backlog:5 addr in
   traceln "Server ready...";
   Fibre.both ~sw
     (fun () -> run_server ~sw server)

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -125,13 +125,18 @@ end
 
 module Network = struct
   module Sockaddr = struct
-    type t = Unix.sockaddr
+    type inet_addr = Unix.inet_addr
+
+    type t = [
+      | `Unix of string
+      | `Tcp of inet_addr * int
+    ]
 
     let pp f = function
-      | Unix.ADDR_UNIX path ->
+      | `Unix path ->
         Format.fprintf f "unix:%s" path
-      | Unix.ADDR_INET (addr, port) ->
-        Format.fprintf f "inet:%s:%d" (Unix.string_of_inet_addr addr) port
+      | `Tcp (addr, port) ->
+        Format.fprintf f "tcp:%s:%d" (Unix.string_of_inet_addr addr) port
   end
 
   module Listening_socket = struct

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -142,7 +142,6 @@ module Network = struct
   module Listening_socket = struct
     class virtual t = object
       method virtual close : unit
-      method virtual listen : int -> unit
       method virtual accept_sub :
         sw:Switch.t ->
         on_error:(exn -> unit) ->
@@ -150,16 +149,15 @@ module Network = struct
         unit
     end
 
-    let listen (t : #t) = t#listen
     let accept_sub ~sw (t : #t) = t#accept_sub ~sw
   end
 
   class virtual t = object
-    method virtual bind : reuse_addr:bool -> sw:Switch.t -> Sockaddr.t -> Listening_socket.t
+    method virtual listen : reuse_addr:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> Listening_socket.t
     method virtual connect : sw:Switch.t -> Sockaddr.t -> <Flow.two_way; Flow.close>
   end
 
-  let bind ?(reuse_addr=false) ~sw (t:#t) = t#bind ~reuse_addr ~sw
+  let listen ?(reuse_addr=false) ~backlog ~sw (t:#t) = t#listen ~reuse_addr ~backlog ~sw
   let connect ~sw (t:#t) = t#connect ~sw
 end
 

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -32,6 +32,8 @@ module Generic = struct
 end
 
 module Flow = struct
+  type shutdown_command = [ `Receive | `Send | `All ]
+
   class type close = object
     method close : unit
   end
@@ -115,7 +117,7 @@ module Flow = struct
     inherit read
     inherit write
 
-    method virtual shutdown : Unix.shutdown_command -> unit
+    method virtual shutdown : shutdown_command -> unit
   end
 
   let shutdown (t : #two_way) = t#shutdown

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -276,7 +276,12 @@ end
 
 module Network : sig
   module Sockaddr : sig
-    type t = Unix.sockaddr
+    type inet_addr = Unix.inet_addr
+
+    type t = [
+      | `Unix of string
+      | `Tcp of inet_addr * int
+    ]
 
     val pp : Format.formatter -> t -> unit
   end

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -289,15 +289,12 @@ module Network : sig
   module Listening_socket : sig
     class virtual t : object
       method virtual close : unit
-      method virtual listen : int -> unit
       method virtual accept_sub :
         sw:Switch.t ->
         on_error:(exn -> unit) ->
         (sw:Switch.t -> <Flow.two_way; Flow.close> -> Sockaddr.t -> unit) ->
         unit
     end
-
-    val listen : #t -> int -> unit
 
     val accept_sub :
       sw:Switch.t ->
@@ -311,14 +308,15 @@ module Network : sig
   end
 
   class virtual t : object
-    method virtual bind : reuse_addr:bool -> sw:Switch.t -> Sockaddr.t -> Listening_socket.t
+    method virtual listen : reuse_addr:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> Listening_socket.t
     method virtual connect : sw:Switch.t -> Sockaddr.t -> <Flow.two_way; Flow.close>
   end
 
-  val bind : ?reuse_addr:bool -> sw:Switch.t -> #t -> Sockaddr.t -> Listening_socket.t
-  (** [bind ~sw t addr] is a new listening socket bound to local address [addr].
+  val listen : ?reuse_addr:bool -> backlog:int -> sw:Switch.t -> #t -> Sockaddr.t -> Listening_socket.t
+  (** [listen ~sw ~backlog t addr] is a new listening socket bound to local address [addr].
       The new socket will be closed when [sw] finishes, unless closed manually first.
       For (non-abstract) Unix domain sockets, the path will be removed afterwards.
+      @param backlog The number of pending connections that can be queued up (see listen(2)).
       @param reuse_addr Set the [Unix.SO_REUSEADDR] socket option.
                         For Unix paths, also remove any stale left-over socket. *)
 

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -215,6 +215,8 @@ end
 
 (** Byte streams. *)
 module Flow : sig
+  type shutdown_command = [ `Receive | `Send | `All ]
+
   class type close = object
     method close : unit
   end
@@ -266,10 +268,10 @@ module Flow : sig
     inherit read
     inherit write
 
-    method virtual shutdown : Unix.shutdown_command -> unit
+    method virtual shutdown : shutdown_command -> unit
   end
 
-  val shutdown : #two_way -> Unix.shutdown_command -> unit
+  val shutdown : #two_way -> shutdown_command -> unit
 end
 
 module Network : sig

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -317,7 +317,10 @@ module Network : sig
 
   val bind : ?reuse_addr:bool -> sw:Switch.t -> #t -> Sockaddr.t -> Listening_socket.t
   (** [bind ~sw t addr] is a new listening socket bound to local address [addr].
-      The new socket will be closed when [sw] finishes, unless closed manually first. *)
+      The new socket will be closed when [sw] finishes, unless closed manually first.
+      For (non-abstract) Unix domain sockets, the path will be removed afterwards.
+      @param reuse_addr Set the [Unix.SO_REUSEADDR] socket option.
+                        For Unix paths, also remove any stale left-over socket. *)
 
   val connect : sw:Switch.t -> #t -> Sockaddr.t -> <Flow.two_way; Flow.close>
   (** [connect ~sw t addr] is a new socket connected to remote address [addr].

--- a/lib_eunix/eunix.ml
+++ b/lib_eunix/eunix.ml
@@ -574,8 +574,6 @@ module Objects = struct
 
     method close = FD.close fd
 
-    method listen n = Unix.listen (FD.get "listen" fd) n
-
     method accept_sub ~sw ~on_error fn =
       let client, client_addr = accept_loose_fd ~sw fd in
       Fibre.fork_sub_ignore ~sw ~on_error
@@ -592,7 +590,7 @@ module Objects = struct
   let network = object
     inherit Eio.Network.t
 
-    method bind ~reuse_addr ~sw listen_addr =
+    method listen ~reuse_addr ~backlog ~sw listen_addr =
       let socket_domain, socket_type, addr =
         match listen_addr with
         | `Unix path         ->
@@ -617,6 +615,7 @@ module Objects = struct
         Unix.setsockopt sock_unix Unix.SO_REUSEADDR true;
       let sock = FD.of_unix ~sw ~seekable:false sock_unix in
       Unix.bind sock_unix addr;
+      Unix.listen sock_unix backlog;
       listening_socket sock
 
     method connect ~sw addr =

--- a/lib_eunix/eunix.ml
+++ b/lib_eunix/eunix.ml
@@ -560,7 +560,10 @@ module Objects = struct
         with End_of_file -> ()
 
     method shutdown cmd =
-      Unix.shutdown (FD.get "shutdown" fd) cmd
+      Unix.shutdown (FD.get "shutdown" fd) @@ match cmd with
+      | `Receive -> Unix.SHUTDOWN_RECEIVE
+      | `Send -> Unix.SHUTDOWN_SEND
+      | `All -> Unix.SHUTDOWN_ALL
   end
 
   let source fd = (flow fd :> source)

--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -17,7 +17,7 @@ let run (fn : network:Eio.Network.t -> Switch.t -> unit) =
   | Failure msg -> print_endline msg
   | ex -> print_endline (Printexc.to_string ex)
 
-let addr = Unix.(ADDR_INET (inet_addr_loopback, 8081))
+let addr = `Tcp (Unix.inet_addr_loopback, 8081)
 
 let read_all ?sw flow =
   let b = Buffer.create 100 in

--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -36,7 +36,7 @@ let run_client ~sw ~network ~addr =
   traceln "Connecting to server...";
   let flow = Eio.Network.connect ~sw network addr in
   Eio.Flow.copy_string "Hello from client" flow;
-  Eio.Flow.shutdown flow Unix.SHUTDOWN_SEND;
+  Eio.Flow.shutdown flow `Send;
   let msg = read_all ~sw flow in
   traceln "Client received: %S" msg
 ```

--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -60,8 +60,7 @@ let run_server ~sw socket =
   done
 
 let test_address addr ~network sw =
-  let server = Eio.Network.bind network ~sw ~reuse_addr:true addr in
-  Eio.Network.Listening_socket.listen server 5;
+  let server = Eio.Network.listen network ~sw ~reuse_addr:true ~backlog:5 addr in
   Fibre.both ~sw
     (fun () -> run_server ~sw server)
     (fun () ->
@@ -115,8 +114,7 @@ Cancelling the read:
 ```ocaml
 # run @@ fun ~network sw ->
   Switch.top @@ fun read_switch ->
-  let server = Eio.Network.bind network ~sw ~reuse_addr:true addr in
-  Eio.Network.Listening_socket.listen server 5;
+  let server = Eio.Network.listen network ~sw ~reuse_addr:true ~backlog:5 addr in
   Fibre.both ~sw
     (fun () ->
       Eio.Network.Listening_socket.accept_sub server ~sw (fun ~sw flow _addr ->
@@ -146,8 +144,7 @@ Calling accept when the switch is already off:
 
 ```ocaml
 # run @@ fun ~network sw ->
-  let server = Eio.Network.bind network ~sw ~reuse_addr:true addr in
-  Eio.Network.Listening_socket.listen server 5;
+  let server = Eio.Network.listen network ~sw ~reuse_addr:true ~backlog:5 addr in
   Switch.turn_off sw (Failure "Simulated error");
   Eio.Network.Listening_socket.accept_sub server ~sw (fun ~sw:_ _flow _addr -> assert false)
     ~on_error:raise

--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -58,12 +58,8 @@ let run_server ~sw socket =
       | ex -> traceln "Error handling connection: %s" (Printexc.to_string ex)
     );
   done
-```
 
-Handling one connection, then cancelling the server:
-
-```ocaml
-# run @@ fun ~network sw ->
+let test_address addr ~network sw =
   let server = Eio.Network.bind network ~sw ~reuse_addr:true addr in
   Eio.Network.Listening_socket.listen server 5;
   Fibre.both ~sw
@@ -73,6 +69,38 @@ Handling one connection, then cancelling the server:
       traceln "Client finished - cancelling server";
       Switch.turn_off sw (Failure "Test is over")
     )
+```
+
+Handling one connection, then cancelling the server:
+
+```ocaml
+# run (test_address addr)
+Connecting to server...
+Server accepted connection from client
+Server received: "Hello from client"
+Client received: "Bye"
+Client finished - cancelling server
+Test is over
+- : unit = ()
+```
+
+Handling one connection on a Unix domain socket:
+
+```ocaml
+# run (test_address (`Unix "/tmp/eio-test.sock"))
+Connecting to server...
+Server accepted connection from client
+Server received: "Hello from client"
+Client received: "Bye"
+Client finished - cancelling server
+Test is over
+- : unit = ()
+```
+
+Handling one connection on an abstract Unix domain socket:
+
+```ocaml
+# run (test_address (`Unix "\x00/tmp/eio-test.sock"))
 Connecting to server...
 Server accepted connection from client
 Server received: "Hello from client"


### PR DESCRIPTION
- Rename `bind` to `listen` and make `backlog` an argument to that.
  This avoids the problem of forgetting to call `listen`, and makes the name "listening socket" correct.

- Remove Unix domain socket paths when the switch finishes. If `reuse_addr` is given, also clean up left-over paths when binding.

- Replace `Unix.shutdown_command` with our own type in the Eio API. This is to make Eio portable to more systems.

- Replace `Unix.sockaddr` with our own type. For now, the API still uses `Unix.inet_addr`, but that should go too at some point.