### PR TITLE
Simplify suspend operation

### DIFF
--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -198,10 +198,10 @@ end
 
 module Private = struct
   module Effects = struct
-    effect Await = Switch.Await
+    type 'a enqueue = 'a Suspend.enqueue
+    effect Suspend = Suspend.Suspend
     effect Fork = Fibre.Fork
     effect Fork_ignore = Fibre.Fork_ignore
-    effect Yield = Fibre.Yield
   end
   module Waiters = Waiters
   module Switch = Switch

--- a/lib_eio/fibre.ml
+++ b/lib_eio/fibre.ml
@@ -20,9 +20,8 @@ let fork_ignore ~sw f =
   in
   perform (Fork_ignore f)
 
-effect Yield : unit
 let yield ?sw () =
-  perform Yield;
+  Suspend.enter (fun _id enqueue -> enqueue (Ok ()));
   Option.iter Switch.check sw
 
 let both ~sw f g =

--- a/lib_eio/suspend.ml
+++ b/lib_eio/suspend.ml
@@ -1,0 +1,3 @@
+type 'a enqueue = ('a, exn) result -> unit
+effect Suspend : (Ctf.id -> 'a enqueue -> unit) -> 'a
+let enter fn = perform (Suspend fn)


### PR DESCRIPTION
This replaces the old `Await` and `Yield` effects with a single `Suspend` effect. The new effect just asks the scheduler to run a
user-provided function in the scheduler's context.

This moves most of the logic to Eio, avoiding the need to duplicate it in each scheduler implementation.

Based on a suggestion by @kayceesrk.