### PR TITLE
Remove Eio.Private.Waiters and Eio.Private.Switch

### DIFF
--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -203,6 +203,5 @@ module Private = struct
     effect Fork = Fibre.Fork
     effect Fork_ignore = Fibre.Fork_ignore
   end
-  module Waiters = Waiters
   module Switch = Switch
 end

--- a/lib_eio/switch.ml
+++ b/lib_eio/switch.ml
@@ -2,6 +2,8 @@ exception Multiple_exceptions of exn list
 
 exception Cancelled of exn
 
+type hook = unit -> unit                (* A function to remove the hook *)
+
 let () =
   Printexc.register_printer @@ function
   | Multiple_exceptions exns -> Some ("Multiple exceptions:\n" ^ String.concat "\nand\n" (List.map Printexc.to_string exns))
@@ -21,6 +23,10 @@ type t = {
   on_release : (unit -> unit) Lwt_dllist.t;
   waiter : unit Waiters.t;              (* The main [top]/[sub] function may wait here for fibres to finish. *)
 }
+
+let null_hook = ignore
+
+let remove_hook h = h ()
 
 let check t =
   match t.state with

--- a/lib_eio/waiters.ml
+++ b/lib_eio/waiters.ml
@@ -2,8 +2,6 @@ type 'a t = (('a, exn) result -> unit) Lwt_dllist.t
 
 type waiter = unit -> unit
 
-let null = ignore
-
 let create = Lwt_dllist.create
 
 let add_waiter t cb =

--- a/lib_eio/waiters.mli
+++ b/lib_eio/waiters.mli
@@ -3,7 +3,6 @@ type 'a t
 type waiter = unit -> unit
 
 val create : unit -> 'a t
-val null : waiter
 val add_waiter : 'a t -> (('a, exn) result -> unit) -> waiter
 val wake_all : 'a t -> ('a, exn) result -> unit
 val wake_one : 'a t -> ('a, exn) result -> [`Ok | `Queue_empty]

--- a/lib_eunix/zzz.mli
+++ b/lib_eunix/zzz.mli
@@ -1,3 +1,5 @@
+open Eio.Std
+
 module Key : sig
   type t
 end
@@ -8,7 +10,7 @@ type t
 val create : unit -> t
 (** [create ()] is a fresh empty queue. *)
 
-val add : cancel_hook:Eio.Private.Waiters.waiter ref -> t -> float -> unit Suspended.t -> Key.t
+val add : cancel_hook:Switch.hook ref -> t -> float -> unit Suspended.t -> Key.t
 (** [add ~cancel_hook t time thread] adds a new event, due at [time], and returns its ID.
     [cancel_hook] will be released when the event is later returned by {!pop}. *)
 

--- a/tests/test_switch.md
+++ b/tests/test_switch.md
@@ -153,15 +153,15 @@ Turning off a switch runs the cancel callbacks, unless they've been removed by t
 
 ```ocaml
 # run (fun sw ->
-      let h1 = Eio.Private.Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 1") in
-      let h2 = Eio.Private.Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 2") in
-      let h3 = Eio.Private.Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 3") in
-      Eio.Private.Waiters.remove_waiter h2;
+      let h1 = Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 1") in
+      let h2 = Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 2") in
+      let h3 = Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 3") in
+      Switch.remove_hook h2;
       Switch.turn_off sw (Failure "Cancelled");
-      let h4 = Eio.Private.Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 4") in
-      Eio.Private.Waiters.remove_waiter h1;
-      Eio.Private.Waiters.remove_waiter h3;
-      Eio.Private.Waiters.remove_waiter h4
+      let h4 = Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 4") in
+      Switch.remove_hook h1;
+      Switch.remove_hook h3;
+      Switch.remove_hook h4
     )
 Cancel 3
 Cancel 1


### PR DESCRIPTION
Waiting is now handled inside the eio library. The type was only being used for removing switch hooks, so move those to Switch.

Also, make cancel hooks part of Switch's public API. We now handle exceptions from hooks and cope with hooks performing effects, so no need to restrict them.