### PR TITLE
Getting EALREADY from cancel is not an error

### DIFF
--- a/lib_eunix/eunix.ml
+++ b/lib_eunix/eunix.ml
@@ -124,6 +124,8 @@ let cancel job =
   let res = perform (Cancel job) in
   if res = -2 then (
     Log.debug (fun f -> f "Cancel returned ENOENT - operation completed before cancel took effect")
+  ) else if res = -114 then (
+    Log.debug (fun f -> f "Cancel returned EALREADY - operation cancelled while already in progress")
   ) else if res <> 0 then (
     raise (Unix.Unix_error (Uring.error_of_errno res, "cancel", ""))
   )


### PR DESCRIPTION
This just means that Linux cancelled an active operation, rather than just removing it from a queue.

(see https://github.com/ocaml-multicore/ocaml-uring/pull/25)