### PR TITLE
Add `Switch.sub_opt`

### DIFF
--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -27,14 +27,21 @@ module Std : sig
         If the switch is turned off before it returns, [top] re-raises the switch's exception(s).
         @raise Multiple_exceptions If [turn_off] is called more than once. *)
 
-    val sub : ?on_release:(unit -> unit) -> sw:t -> on_error:(exn -> 'a) -> (t -> 'a) -> 'a
-    (** [sub ~sw ~on_error fn] is like [top fn], but the new switch is a child of [sw], so that
-        cancelling [sw] also cancels the child (but not the other way around).
+    val sub : ?on_release:(unit -> unit) -> t -> on_error:(exn -> 'a) -> (t -> 'a) -> 'a
+    (** [sub sw ~on_error fn] is like [top fn], but the new switch is a child of [t], so that
+        cancelling [t] also cancels the child (but not the other way around).
         If [fn] raises an exception then it is passed to [on_error].
         If you only want to use [sub] to wait for a group of threads to finish, but not to contain
         errors, you can use [~on_error:raise].
         @param on_release Register this function with [Switch.on_release sub] once the sub-switch is created.
                           If creating the sub-switch fails, run it immediately. *)
+
+    val sub_opt : ?on_release:(unit -> unit) -> t option -> (t -> 'a) -> 'a
+    (** Run a function with a new switch, optionally a child of another switch.
+        [sub_opt (Some sw)] is [sub sw ~on_error:raise].
+        [sub None] is [top].
+        @param on_release Register this function with [Switch.on_release sub] once the new switch is created.
+                          If creating the switch fails, run it immediately. *)
 
     val check : t -> unit
     (** [check t] checks that [t] is still on.

--- a/lib_eio/fibre.ml
+++ b/lib_eio/fibre.ml
@@ -41,7 +41,7 @@ let fork_sub_ignore ?on_release ~sw ~on_error f =
     invalid_arg "Switch finished!"
   );
   let f () =
-    try Switch.sub ?on_release ~sw ~on_error f
+    try Switch.sub ?on_release sw ~on_error f
     with ex ->
       Switch.turn_off sw ex;
       raise ex

--- a/lib_eio/switch.ml
+++ b/lib_eio/switch.ml
@@ -193,7 +193,7 @@ let on_release t fn =
     let _ : _ Lwt_dllist.node = Lwt_dllist.add_r fn t.on_release in
     ()
 
-let sub ?on_release:release ~sw ~on_error fn =
+let sub ?on_release:release sw ~on_error fn =
   match sw.state with
   | Finished ->
     (* Can't create child switch. Run release hooks immediately. *)
@@ -220,3 +220,12 @@ let sub ?on_release:release ~sw ~on_error fn =
     | exception ex ->
       Waiters.remove_waiter !w;
       on_error ex
+
+let sub_opt ?on_release:release t fn =
+  match t with
+  | Some t -> sub ?on_release:release ~on_error:raise t fn
+  | None ->
+    top (fun child ->
+        Option.iter (on_release child) release;
+        fn child
+      )

--- a/tests/test_switch.md
+++ b/tests/test_switch.md
@@ -315,7 +315,7 @@ A child error handler deals with the exception:
 ```ocaml
 # run (fun sw ->
       let print ex = traceln "%s" (Printexc.to_string ex); 0 in
-      let x = Switch.sub ~sw ~on_error:print (fun _sw -> failwith "Child error") in
+      let x = Switch.sub sw ~on_error:print (fun _sw -> failwith "Child error") in
       traceln "x = %d" x
     )
 Failure("Child error")
@@ -454,7 +454,7 @@ We release when `fork_sub_ignore` fails due to parent switch being invalid:
 ```ocaml
 # run (fun sw ->
     let copy = ref sw in
-    Switch.sub ~sw ~on_error:raise (fun sub -> copy := sub);
+    Switch.sub sw ~on_error:raise (fun sub -> copy := sub);
     fork_sub_ignore_resource !copy
   )
 Allocate resource


### PR DESCRIPTION
Also, change `Switch.sub` so that the switch isn't a named argument. This makes it easier to use as `Switch.sub sw @@ ...` without complaints about the missing optional argument.