### PR TITLE
Some API and README cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,12 +339,10 @@ let run_client ~sw ~network ~addr =
   traceln "Connecting to server...";
   let flow = Eio.Network.connect ~sw network addr in
   Eio.Flow.copy_string "Hello from client" flow;
-  Eio.Flow.close flow
+  Eio.Flow.shutdown flow `Send
 ```
 
 Note: The `flow` is attached to `sw` and will be closed automatically when it finishes.
-      The explicit `close` here just ensures it is closed promptly,
-      rather than waiting for the server to finish too.
 
 Here is a server that listens on `socket` and handles a single connection by reading a message:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ unreleased repository.
 * [Networking](#networking)
 * [Design note: object capabilities](#design-note-object-capabilities)
 * [Filesystem access](#filesystem-access)
+* [Time](#time)
 * [Multicore support](#multicore-support)
 * [Design note: thread-safety](#design-note-thread-safety)
 * [Design note: determinism](#design-note-determinism)
@@ -506,6 +507,24 @@ and this allows following symlinks within that sub-tree.
 A program that operates on the current directory will probably want to use `cwd`,
 whereas a program that accepts a path from the user will probably want to use `fs`,
 perhaps with `open_dir` to constrain all access to be within that directory.
+
+## Time
+
+The standard environment provides a clock with the usual POSIX time:
+
+```ocaml
+# Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  traceln "The time is now %f" (Eio.Time.now clock);
+  Eio.Time.sleep clock 1.0;
+  traceln "The time is now %f" (Eio.Time.now clock)
+The time is now 1623940778.270336
+The time is now 1623940779.270336
+- : unit = ()
+```
+
+You might like to replace this clock with a mock for tests.
+In fact, this README does just that - see [doc/prelude.ml](doc/prelude.ml) for the fake clock used in the example above!
 
 ## Multicore support
 

--- a/README.md
+++ b/README.md
@@ -335,9 +335,9 @@ Eio provides a simple high-level API for networking.
 Here is a client that connects to address `addr` using `network` and sends a message:
 
 ```ocaml
-let run_client ~sw ~network ~addr =
+let run_client ~sw ~net ~addr =
   traceln "Connecting to server...";
-  let flow = Eio.Network.connect ~sw network addr in
+  let flow = Eio.Net.connect ~sw net addr in
   Eio.Flow.copy_string "Hello from client" flow;
   Eio.Flow.shutdown flow `Send
 ```
@@ -348,7 +348,7 @@ Here is a server that listens on `socket` and handles a single connection by rea
 
 ```ocaml
 let run_server ~sw socket =
-  Eio.Network.Listening_socket.accept_sub socket ~sw (fun ~sw flow _addr ->
+  Eio.Net.accept_sub socket ~sw (fun ~sw flow _addr ->
     traceln "Server accepted connection from client";
     let b = Buffer.create 100 in
     Eio.Flow.copy flow (Eio.Flow.buffer_sink b);
@@ -366,19 +366,19 @@ Notes:
 We can test them in a single process using `Fibre.both`:
 
 ```ocaml
-let main ~network ~addr =
+let main ~net ~addr =
   Switch.top @@ fun sw ->
-  let server = Eio.Network.listen network ~sw ~reuse_addr:true ~backlog:5 addr in
+  let server = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:5 addr in
   traceln "Server ready...";
   Fibre.both ~sw
     (fun () -> run_server ~sw server)
-    (fun () -> run_client ~sw ~network ~addr)
+    (fun () -> run_client ~sw ~net ~addr)
 ```
 
 ```ocaml
 # Eio_main.run @@ fun env ->
   main
-    ~network:(Eio.Stdenv.network env)
+    ~net:(Eio.Stdenv.net env)
     ~addr:(`Tcp (Unix.inet_addr_loopback, 8080))
 Server ready...
 Connecting to server...
@@ -422,7 +422,7 @@ In an ocap language, we don't have to read the entire code-base to find the answ
   `run_server` does not get the full `network` access, so we probably don't need to read that code
   (we might want to check whether we granted other parties access to this port on our loopback network).
 - `run_client` does get `network`, so we do need to read that.
-  We could make that code easier to audit by passing it `(fun () -> Eio.Network.connect network addr)` instead of `network`.
+  We could make that code easier to audit by passing it `(fun () -> Eio.Net.connect network addr)` instead of `network`.
   Then we could see that `run_client` could only connect to our loopback address.
 
 Since OCaml is not an ocap language, code can ignore Eio and use the non-ocap APIs directly.

--- a/doc/prelude.ml
+++ b/doc/prelude.ml
@@ -3,8 +3,34 @@
 module Eio_main = struct
   open Eio.Std
 
+  let now = ref 1623940778.27033591
+
+  let fake_clock real_clock = object (_ : #Eio.Time.clock)
+    method now = !now
+    method sleep_until ?sw time =
+      (* The fake times are all in the past, so we just ask to wait until the
+         fake time is due and it will happen immediately. If we wait for
+         multiple times, they'll get woken in the right order. At the moment,
+         the scheduler only checks for expired timers when the run-queue is
+         empty, so this is a convenient way to wait for the system to be idle.
+         Will need revising if we make the scheduler fair at some point. *)
+      Eio.Time.sleep_until ?sw real_clock time;
+      now := max !now time
+  end
+
+  (* https://github.com/ocaml/ocaml/issues/10324 *)
+  let dontcrash = Sys.opaque_identity
+
   let run fn =
     Eio_main.run @@ fun env ->
-    try fn env
+    try
+      fn @@ object
+        method net        = dontcrash env#net
+        method stdin      = dontcrash env#stdin
+        method stdout     = dontcrash env#stdout
+        method cwd        = dontcrash env#cwd
+        method domain_mgr = dontcrash env#domain_mgr
+        method clock      = fake_clock env#clock
+      end
     with Failure msg -> traceln "Error: %s" msg
 end

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -169,10 +169,15 @@ end
 
 module Time = struct
   class virtual clock = object
-    method virtual sleep : ?sw:Switch.t -> float -> unit
+    method virtual now : float
+    method virtual sleep_until : ?sw:Switch.t -> float -> unit
   end
 
-  let sleep ?sw (t : #clock) d = t#sleep ?sw d
+  let now (t : #clock) = t#now
+
+  let sleep_until ?sw (t : #clock) time = t#sleep_until ?sw time
+
+  let sleep ?sw t d = sleep_until ?sw t (now t +. d)
 end
 
 module Dir = struct

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -123,7 +123,7 @@ module Flow = struct
   let shutdown (t : #two_way) = t#shutdown
 end
 
-module Network = struct
+module Net = struct
   module Sockaddr = struct
     type inet_addr = Unix.inet_addr
 
@@ -139,21 +139,19 @@ module Network = struct
         Format.fprintf f "tcp:%s:%d" (Unix.string_of_inet_addr addr) port
   end
 
-  module Listening_socket = struct
-    class virtual t = object
-      method virtual close : unit
-      method virtual accept_sub :
-        sw:Switch.t ->
-        on_error:(exn -> unit) ->
-        (sw:Switch.t -> <Flow.two_way; Flow.close> -> Sockaddr.t -> unit) ->
-        unit
-    end
-
-    let accept_sub ~sw (t : #t) = t#accept_sub ~sw
+  class virtual listening_socket = object
+    method virtual close : unit
+    method virtual accept_sub :
+      sw:Switch.t ->
+      on_error:(exn -> unit) ->
+      (sw:Switch.t -> <Flow.two_way; Flow.close> -> Sockaddr.t -> unit) ->
+      unit
   end
 
+  let accept_sub ~sw (t : #listening_socket) = t#accept_sub ~sw
+
   class virtual t = object
-    method virtual listen : reuse_addr:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> Listening_socket.t
+    method virtual listen : reuse_addr:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> listening_socket
     method virtual connect : sw:Switch.t -> Sockaddr.t -> <Flow.two_way; Flow.close>
   end
 
@@ -211,7 +209,7 @@ module Stdenv = struct
     stdin  : Flow.source;
     stdout : Flow.sink;
     stderr : Flow.sink;
-    network : Network.t;
+    net : Net.t;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
     fs : Dir.t;
@@ -221,7 +219,7 @@ module Stdenv = struct
   let stdin  (t : <stdin  : #Flow.source; ..>) = t#stdin
   let stdout (t : <stdout : #Flow.sink;   ..>) = t#stdout
   let stderr (t : <stderr : #Flow.sink;   ..>) = t#stderr
-  let network (t : <network : #Network.t; ..>) = t#network
+  let net (t : <net : #Net.t; ..>) = t#net
   let domain_mgr (t : <domain_mgr : #Domain_manager.t; ..>) = t#domain_mgr
   let clock (t : <clock : #Time.clock; ..>) = t#clock
   let fs (t : <fs : #Dir.t; ..>) = t#fs

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -363,8 +363,16 @@ end
 
 module Time : sig
   class virtual clock : object
-    method virtual sleep : ?sw:Switch.t -> float -> unit
+    method virtual now : float
+    method virtual sleep_until : ?sw:Switch.t -> float -> unit
   end
+
+  val now : #clock -> float
+  (** [now t] is the current time according to [t]. *)
+
+  val sleep_until : ?sw:Switch.t -> #clock -> float -> unit
+  (** [sleep_until t time] waits until the given time is reached.
+      @param sw The sleep is aborted if the switch is turned off. *)
 
   val sleep : ?sw:Switch.t -> #clock -> float -> unit
   (** [sleep t d] waits for [d] seconds.

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -299,7 +299,7 @@ module Flow : sig
   val shutdown : #two_way -> shutdown_command -> unit
 end
 
-module Network : sig
+module Net : sig
   module Sockaddr : sig
     type inet_addr = Unix.inet_addr
 
@@ -311,33 +311,31 @@ module Network : sig
     val pp : Format.formatter -> t -> unit
   end
 
-  module Listening_socket : sig
-    class virtual t : object
-      method virtual close : unit
-      method virtual accept_sub :
-        sw:Switch.t ->
-        on_error:(exn -> unit) ->
-        (sw:Switch.t -> <Flow.two_way; Flow.close> -> Sockaddr.t -> unit) ->
-        unit
-    end
-
-    val accept_sub :
+  class virtual listening_socket : object
+    method virtual close : unit
+    method virtual accept_sub :
       sw:Switch.t ->
-      #t ->
       on_error:(exn -> unit) ->
       (sw:Switch.t -> <Flow.two_way; Flow.close> -> Sockaddr.t -> unit) ->
       unit
-    (** [accept t fn] waits for a new connection to [t] and then runs [fn ~sw flow client_addr] in a new fibre,
-        created with [Fibre.fork_sub_ignore].
-        [flow] will be closed automatically when the sub-switch is finished, if not already closed by then. *)
   end
 
+  val accept_sub :
+    sw:Switch.t ->
+    #listening_socket ->
+    on_error:(exn -> unit) ->
+    (sw:Switch.t -> <Flow.two_way; Flow.close> -> Sockaddr.t -> unit) ->
+    unit
+  (** [accept socket fn] waits for a new connection to [socket] and then runs [fn ~sw flow client_addr] in a new fibre,
+      created with [Fibre.fork_sub_ignore].
+      [flow] will be closed automatically when the sub-switch is finished, if not already closed by then. *)
+
   class virtual t : object
-    method virtual listen : reuse_addr:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> Listening_socket.t
+    method virtual listen : reuse_addr:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> listening_socket
     method virtual connect : sw:Switch.t -> Sockaddr.t -> <Flow.two_way; Flow.close>
   end
 
-  val listen : ?reuse_addr:bool -> backlog:int -> sw:Switch.t -> #t -> Sockaddr.t -> Listening_socket.t
+  val listen : ?reuse_addr:bool -> backlog:int -> sw:Switch.t -> #t -> Sockaddr.t -> listening_socket
   (** [listen ~sw ~backlog t addr] is a new listening socket bound to local address [addr].
       The new socket will be closed when [sw] finishes, unless closed manually first.
       For (non-abstract) Unix domain sockets, the path will be removed afterwards.
@@ -430,7 +428,7 @@ module Stdenv : sig
     stdin  : Flow.source;
     stdout : Flow.sink;
     stderr : Flow.sink;
-    network : Network.t;
+    net : Net.t;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
     fs : Dir.t;
@@ -441,7 +439,7 @@ module Stdenv : sig
   val stdout : <stdout : #Flow.sink   as 'a; ..> -> 'a
   val stderr : <stderr : #Flow.sink   as 'a; ..> -> 'a
 
-  val network : <network : #Network.t as 'a; ..> -> 'a
+  val net : <net : #Net.t as 'a; ..> -> 'a
   val domain_mgr : <domain_mgr : #Domain_manager.t as 'a; ..> -> 'a
   val clock : <clock : #Time.clock as 'a; ..> -> 'a
 

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -630,7 +630,7 @@ module Objects = struct
   let sink   fd = (flow fd :> sink)
 
   let listening_socket fd = object
-    inherit Eio.Network.Listening_socket.t
+    inherit Eio.Net.listening_socket
 
     method close = FD.close fd
 
@@ -647,8 +647,8 @@ module Objects = struct
         ~on_release:(fun () -> FD.ensure_closed client)
   end
 
-  let network = object
-    inherit Eio.Network.t
+  let net = object
+    inherit Eio.Net.t
 
     method listen ~reuse_addr ~backlog ~sw listen_addr =
       let socket_domain, socket_type, addr =
@@ -694,7 +694,7 @@ module Objects = struct
     stdin  : source;
     stdout : sink;
     stderr : sink;
-    network : Eio.Network.t;
+    net : Eio.Net.t;
     domain_mgr : Eio.Domain_manager.t;
     clock : Eio.Time.clock;
     fs : Eio.Dir.t;
@@ -792,7 +792,7 @@ module Objects = struct
       method stdin  = Lazy.force stdin
       method stdout = Lazy.force stdout
       method stderr = Lazy.force stderr
-      method network = network
+      method net = net
       method domain_mgr = domain_mgr
       method clock = clock
       method fs = (fs :> Eio.Dir.t)

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -132,7 +132,7 @@ module Objects : sig
     stdin  : source;
     stdout : sink;
     stderr : sink;
-    network : Eio.Network.t;
+    net : Eio.Net.t;
     domain_mgr : Eio.Domain_manager.t;
     clock : Eio.Time.clock;
     fs : Eio.Dir.t;

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -44,8 +44,8 @@ end
 
 (** {1 Time functions} *)
 
-val sleep : ?sw:Switch.t -> float -> unit
-(** [sleep s] blocks until (at least) [s] seconds have passed.
+val sleep_until : ?sw:Switch.t -> float -> unit
+(** [sleep_until time] blocks until the current time is [time].
     @param sw Cancel the sleep if [sw] is turned off. *)
 
 (** {1 Memory allocation functions} *)

--- a/lib_eio_linux/tests/basic_eio_linux.ml
+++ b/lib_eio_linux/tests/basic_eio_linux.ml
@@ -24,7 +24,7 @@ let () =
   let buf = alloc () in
   let _ = read_exactly fd buf 5 in
   Logs.debug (fun l -> l "sleeping at %f" (Unix.gettimeofday ()));
-  sleep 1.0;
+  sleep_until (Unix.gettimeofday () +. 1.0);
   print_endline (Uring.Region.to_string ~len:5 buf);
   let _ = read_exactly fd ~file_offset:(Int63.of_int 3) buf 3 in
   print_endline (Uring.Region.to_string ~len:3 buf);


### PR DESCRIPTION
- Use `shutdown` instead of `close` in README example.
- `Network` is now `Net`. Flattened `Net.Listening_socket` into `Net`.
- Add `Time.now` and `Time.sleep_until`.
- Add time section to the README, plus a work-around for https://github.com/ocaml/ocaml/issues/10324.