### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Then you'll need to install this library (and `utop` if you want to try it inter
 git clone --recursive https://github.com/ocaml-multicore/eio.git
 cd eio
 opam pin -yn ./ocaml-uring
-opam pin -yn .
+sed -i '/dune" "subst/d' *.opam
+opam pin -yn -k path .
 opam depext -i eio_main utop
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ You will need a version of the OCaml compiler with effects.
 You can get one like this:
 
 ```
-opam switch create 4.12.0+domains+effects --packages=ocaml-variants.4.12.0+domains+effects --repositories=multicore=git+https://github.com/ocaml-multicore/multicore-opam.git,default
+opam switch create 4.12.0+domains+effects --repositories=multicore=git+https://github.com/ocaml-multicore/multicore-opam.git,default
+opam pin add -yn ppxlib 0.22.0+effect-syntax
+opam pin add -yn ocaml-migrate-parsetree 2.1.0+effect-syntax
 ```
 
 Then you'll need to install this library (and `utop` if you want to try it interactively):
@@ -625,6 +627,10 @@ as will using multiple domains.
 Note that `traceln` is unusual. Although it writes (by default) to stderr, it will not switch fibres.
 Instead, if the OS is not ready to receive trace output, the whole domain is paused until it is ready.
 This means that adding `traceln` to deterministic code will not affect its scheduling.
+
+In particular, if you test your code by providing (deterministic) mocks then the tests will be deterministic.
+An easy way to write tests is by having the mocks call `traceln` and then comparing the trace output with the expected output.
+See Eio's own tests for examples, e.g. [tests/test_switch.md](tests/test_switch.md).
 
 ## Further reading
 

--- a/dune-project
+++ b/dune-project
@@ -60,5 +60,5 @@
  (description
   "Selects an appropriate Eio backend for the current platform.")
  (depends
-  (eunix (= :version))))
+  (eio_linux (= :version))))
 (using mdx 0.1)

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "eunix" {= version}
+  "eio_linux" {= version}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
It is now necessary to pin the effects versions of ppxlib and ocaml-migrate-parsetree manually.

Also, add a note about using determinism for tests.