### PR TITLE
add non-deterministic to abstract domain socket test

### DIFF
--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -89,8 +89,9 @@ Handling one connection on a Unix domain socket:
 Exception: Graceful_shutdown.
 ```
 
-Handling one connection on an abstract Unix domain socket:
+Handling one connection on an abstract Unix domain socket (this only works on Linux):
 
+<!-- $MDX non-deterministic=command -->
 ```ocaml
 # run (test_address (`Unix "\x00/tmp/eio-test.sock"))
 +Connecting to server...


### PR DESCRIPTION
The `eio_luv` library works well on macOS as far as I can tell 🎉 

It should be easy to setup with the fixes coming to `dune.2.9.1` with the `enabled_if`s. The only test that failed was the abstract domain socket one as they aren't supported on macOS. This PR disables that test from running on a regular `dune runtest` using `non-deterministic=command` (it might be a nice feature in mdx to support per block disabling depending on the OS). Alternatively if there are enough differences we could split out linux specific ones to a different `.md` document and use `enabled_if` in the `mdx` stanza?