### PR TITLE
Disable opam file generation due to dune bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ git clone --recursive https://github.com/ocaml-multicore/eio.git
 cd eio
 opam pin -yn ./ocaml-uring
 opam pin -yn .
-opam depext -i eio_main utop
+opam depext -i eio_main utop		# (for opam 2.0)
+opam install eio_main utop		# (for opam 2.1)
 ```
 
 To try out the examples interactively, run `utop` and `require` the `eio_main` library.

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ Then you'll need to install this library (and `utop` if you want to try it inter
 git clone --recursive https://github.com/ocaml-multicore/eio.git
 cd eio
 opam pin -yn ./ocaml-uring
-sed -i '/dune" "subst/d' *.opam
-opam pin -yn -k path .
+opam pin -yn .
 opam depext -i eio_main utop
 ```
 

--- a/ctf.opam
+++ b/ctf.opam
@@ -17,7 +17,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst" "--root" "."] {dev}
   [
     "dune"
     "build"

--- a/dune-project
+++ b/dune-project
@@ -72,5 +72,6 @@
  (description "Selects an appropriate Eio backend for the current platform.")
  (depends
   (eio_linux (= :version))
+  (mdx (and (>= 1.10.0) :with-test))
   (eio_luv (= :version))))
 (using mdx 0.1)

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,5 @@
 (lang dune 2.9)
 (name eunix)
-(generate_opam_files true)
 (source (github ocaml-multicore/eio))
 (license ISC)
 (authors "Anil Madhavapeddy" "Thomas Leonard")

--- a/eio.opam
+++ b/eio.opam
@@ -16,7 +16,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst" "--root" "."] {dev}
   [
     "dune"
     "build"

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -22,7 +22,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst" "--root" "."] {dev}
   [
     "dune"
     "build"

--- a/eio_luv.opam
+++ b/eio_luv.opam
@@ -21,7 +21,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst" "--root" "."] {dev}
   [
     "dune"
     "build"

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -12,6 +12,7 @@ depends: [
   "eio_linux" {= version & os = "linux"}
   "eio_luv" {= version}
   "odoc" {with-doc}
+  "mdx" {>= "1.10.0" & with-test}
 ]
 build: [
   [

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -14,7 +14,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst" "--root" "."] {dev}
   [
     "dune"
     "build"

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "eio_linux" {= version}
+  "eio_linux" {= version & os = "linux"}
   "eio_luv" {= version}
   "odoc" {with-doc}
 ]

--- a/eunix.opam
+++ b/eunix.opam
@@ -21,7 +21,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst" "--root" "."] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
The `sed` solution doesn't work on macos.

See https://github.com/ocaml/dune/pull/4806