### PR TITLE
Rename Obj.Effect_handlers to EffectHandlers

### DIFF
--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -1,4 +1,4 @@
-open Obj.Effect_handlers
+open EffectHandlers
 
 module Std = struct
   module Promise = Promise

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -532,7 +532,7 @@ end
 (** API for use by the scheduler implementation. *)
 module Private : sig
   module Effects : sig
-    open Obj.Effect_handlers 
+    open EffectHandlers
 
     type 'a enqueue = ('a, exn) result -> unit
     (** A function provided by the scheduler to reschedule a previously-suspended thread. *)

--- a/lib_eio/fibre.ml
+++ b/lib_eio/fibre.ml
@@ -1,4 +1,4 @@
-open Obj.Effect_handlers
+open EffectHandlers
 
 type _ eff += Fork : (unit -> 'a) -> 'a Promise.t eff
 

--- a/lib_eio/suspend.ml
+++ b/lib_eio/suspend.ml
@@ -1,4 +1,4 @@
-open Obj.Effect_handlers
+open EffectHandlers
 
 type 'a enqueue = ('a, exn) result -> unit
 type _ eff += Suspend : (Ctf.id -> 'a enqueue -> unit) -> 'a eff

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -18,8 +18,8 @@ let src = Logs.Src.create "eio_linux" ~doc:"Effect-based IO system for Linux/io-
 module Log = (val Logs.src_log src : Logs.LOG)
 
 open Eio.Std
-open Obj.Effect_handlers
-open Obj.Effect_handlers.Deep 
+open EffectHandlers
+open EffectHandlers.Deep
 
 module Suspended = Eunix.Suspended
 module Zzz = Eunix.Zzz

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -18,8 +18,8 @@ let src = Logs.Src.create "eio_luv" ~doc:"Eio backend using luv"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 open Eio.Std
-open Obj.Effect_handlers 
-open Obj.Effect_handlers.Deep 
+open EffectHandlers
+open EffectHandlers.Deep
 
 (* SIGPIPE makes no sense in a modern application. *)
 let () = Sys.(set_signal sigpipe Signal_ignore)

--- a/lib_eunix/suspended.ml
+++ b/lib_eunix/suspended.ml
@@ -1,4 +1,4 @@
-open Obj.Effect_handlers.Deep
+open EffectHandlers.Deep
 
 type 'a t = {
   tid : Ctf.id;


### PR DESCRIPTION
ocaml-multicore/ocaml-multicore#687 moved the effect handlers module out of `Obj` and so eio no longer builds on the main 4.12+domains branch.

Apologies if this is not the right thing to do - I haven't been following all the multicore discussion, just looking forward to trying it out :).