### PR TITLE
Implicit cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This is an unreleased repository, as it's very much a work-in-progress.
 * [Testing with Mocks](#testing-with-mocks)
 * [Fibres](#fibres)
 * [Tracing](#tracing)
-* [Switches, Errors, and Cancellation](#switches-errors-and-cancellation)
+* [Cancellation](#cancellation)
+* [Switches](#switches)
 * [Design Note: Results vs Exceptions](#design-note-results-vs-exceptions)
 * [Performance](#performance)
 * [Networking](#networking)
@@ -153,8 +154,7 @@ Here's an example running two threads of execution (fibres) concurrently:
 
 ```ocaml
 let main _env =
-  Switch.top @@ fun sw ->
-  Fibre.both ~sw
+  Fibre.both
     (fun () -> for x = 1 to 3 do traceln "x = %d" x; Fibre.yield () done)
     (fun () -> for y = 1 to 3 do traceln "y = %d" y; Fibre.yield () done);;
 ```
@@ -204,17 +204,14 @@ The file is a ring buffer, so when it gets full, old events will start to be ove
 This shows the two counting threads and the lifetime of the `sw` switch.
 Note that the output from `traceln` appears in the trace as well as on the console.
 
-## Switches, Errors, and Cancellation
+## Cancellation
 
-A switch is used to group fibres together, so they can be cancelled or waited on together.
-This is a form of [structured concurrency][].
-
-Here's what happens if one of the two threads above fails:
+Every fibre has a cancellation context.
+If one of the `Fibre.both` fibres fails, the other is cancelled:
 
 ```ocaml
 # Eio_main.run @@ fun _env ->
-  Switch.top @@ fun sw ->
-  Fibre.both ~sw
+  Fibre.both
     (fun () -> for x = 1 to 3 do traceln "x = %d" x; Fibre.yield () done)
     (fun () -> failwith "Simulated error");;
 +x = 1
@@ -223,17 +220,27 @@ Exception: Failure "Simulated error".
 
 What happened here was:
 
-1. The first fibre ran, printed `x = 1` and yielded.
-2. The second fibre raised an exception.
-3. `Fibre.both` caught the exception and turned off the switch.
-4. The first thread's `yield` saw the switch was off and raised a `Cancelled` exception there.
-5. Once both threads had finished, `Fibre.both` re-raised the exception.
+1. `Fibre.both` created a new cancellation context for the child fibres.
+2. The first fibre ran, printed `x = 1` and yielded.
+3. The second fibre raised an exception.
+4. `Fibre.both` caught the exception and cancelled the context.
+5. The first thread's `yield` raised a `Cancelled` exception there.
+6. Once both threads had finished, `Fibre.both` re-raised the original exception.
 
-Switches can also be used to wait for threads even when there isn't an error. e.g.
+You should assume that any operation that can switch fibres can also raise a `Cancelled` exception if a sibling fibre crashes. 
+
+If you want to make an operation non-cancellable, wrap it with `Cancel.protect`
+(this creates a new context that isn't cancelled with its parent).
+
+## Switches
+
+A switch is used to group fibres together, so they can be waited on together.
+This is a form of [structured concurrency][].
+For example:
 
 ```ocaml
 # Eio_main.run @@ fun _env ->
-  Switch.top (fun sw ->
+  Switch.run (fun sw ->
     Fibre.fork_ignore ~sw
       (fun () -> for i = 1 to 3 do traceln "i = %d" i; Fibre.yield () done);
     traceln "First thread forked";
@@ -254,14 +261,30 @@ Switches can also be used to wait for threads even when there isn't an error. e.
 - : unit = ()
 ```
 
-`Switch.top` is used for top-level switches. You can also use `Fibre.fork_sub_ignore` to create a child sub-switch.
+`Switch.run fn` creates a new switch `sw` and runs `fn sw`.
+`fn` may spawn new fibres and attach them to the switch.
+It may also attach other resources such as open file handles.
+`Switch.run` waits until `fn` and all other attached fibres have finished, and then
+releases any attached resources (e.g. closing all attached file handles).
+
+If you call a function without giving it access to a switch,
+then when the function returns you can be sure that any fibres it spawned have finished,
+and any files it opened have been closed.
+So, a `Switch.run` puts a bound on the lifetime of things created within it,
+leading to clearer code and avoiding resource leaks.
+
+For example, `fork_ignore` creates a new fibre that continues running after `fork_ignore` returns,
+so it needs to take a switch argument.
+
+Every switch also creates a new cancellation context,
+and you can turn off the switch to cancel all fibres within it.
+
+You can also use `Fibre.fork_sub_ignore` to create a child sub-switch.
 Turning off the parent switch will also turn off the child switch, but turning off the child doesn't disable the parent.
 
 For example, a web-server might use one switch for the whole server and then create one sub-switch for each incoming connection.
 This allows you to end all fibres handling a single connection by turning off that connection's switch,
 or to exit the whole application using the top-level switch.
-
-If you want to make an operation non-cancellable, wrap it in a `Switch.top` to create a fresh switch.
 
 ## Design Note: Results vs Exceptions
 
@@ -334,11 +357,11 @@ Eio provides a simple high-level API for networking.
 Here is a client that connects to address `addr` using `network` and sends a message:
 
 ```ocaml
-let run_client ~sw ~net ~addr =
+let run_client ~net ~addr =
   traceln "Connecting to server...";
+  Switch.run @@ fun sw ->
   let flow = Eio.Net.connect ~sw net addr in
-  Eio.Flow.copy_string "Hello from client" flow;
-  Eio.Flow.shutdown flow `Send
+  Eio.Flow.copy_string "Hello from client" flow
 ```
 
 Note: the `flow` is attached to `sw` and will be closed automatically when it finishes.
@@ -346,13 +369,14 @@ Note: the `flow` is attached to `sw` and will be closed automatically when it fi
 Here is a server that listens on `socket` and handles a single connection by reading a message:
 
 ```ocaml
-let run_server ~sw socket =
+let run_server socket =
+  Switch.run @@ fun sw ->
   Eio.Net.accept_sub socket ~sw (fun ~sw flow _addr ->
     traceln "Server accepted connection from client";
     let b = Buffer.create 100 in
     Eio.Flow.copy flow (Eio.Flow.buffer_sink b);
     traceln "Server received: %S" (Buffer.contents b)
-  ) ~on_error:(fun ex -> traceln "Error handling connection: %s" (Printexc.to_string ex));
+  ) ~on_error:(traceln "Error handling connection: %a" Fmt.exn);
   traceln "(normally we'd loop and accept more connections here)"
 ```
 
@@ -366,12 +390,12 @@ We can test them in a single process using `Fibre.both`:
 
 ```ocaml
 let main ~net ~addr =
-  Switch.top @@ fun sw ->
+  Switch.run @@ fun sw ->
   let server = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:5 addr in
   traceln "Server ready...";
-  Fibre.both ~sw
-    (fun () -> run_server ~sw server)
-    (fun () -> run_client ~sw ~net ~addr)
+  Fibre.both
+    (fun () -> run_server server)
+    (fun () -> run_client ~net ~addr)
 ```
 
 ```ocaml
@@ -496,7 +520,7 @@ You can use `open_dir` (or `with_open_dir`) to create a restricted capability to
 - : unit = ()
 ```
 
-Please note: you only need to use `open_dir` if you want to create a new sandboxed environment.
+You only need to use `open_dir` if you want to create a new sandboxed environment.
 You can use a single directory object to access all paths beneath it,
 and this allows following symlinks within that subtree.
 
@@ -545,13 +569,12 @@ We can use `Eio.Domain_manager` to run this in a separate domain:
 
 ```ocaml
 let main ~domain_mgr =
-  Switch.top @@ fun sw ->
   let test n =
     traceln "sum 1..%d = %d" n
       (Eio.Domain_manager.run_compute_unsafe domain_mgr
         (fun () -> sum_to n))
   in
-  Fibre.both ~sw
+  Fibre.both
     (fun () -> test 100000)
     (fun () -> test 50000)
 ```

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -7,7 +7,7 @@ let main ~clock =
   n_fibres |> List.iter (fun n_fibres ->
       let n_iters = 1000000 / n_fibres in
       let t0 = Eio.Time.now clock in
-      Switch.top (fun sw ->
+      Switch.run (fun sw ->
           for _ = 1 to n_fibres do
             Fibre.fork_ignore ~sw (fun () ->
                 for _ = 1 to n_iters do

--- a/doc/prelude.ml
+++ b/doc/prelude.ml
@@ -7,14 +7,14 @@ module Eio_main = struct
 
   let fake_clock real_clock = object (_ : #Eio.Time.clock)
     method now = !now
-    method sleep_until ?sw time =
+    method sleep_until time =
       (* The fake times are all in the past, so we just ask to wait until the
          fake time is due and it will happen immediately. If we wait for
          multiple times, they'll get woken in the right order. At the moment,
          the scheduler only checks for expired timers when the run-queue is
          empty, so this is a convenient way to wait for the system to be idle.
          Will need revising if we make the scheduler fair at some point. *)
-      Eio.Time.sleep_until ?sw real_clock time;
+      Eio.Time.sleep_until real_clock time;
       now := max !now time
   end
 

--- a/lib_eio/cancel.ml
+++ b/lib_eio/cancel.ml
@@ -1,0 +1,104 @@
+open EffectHandlers
+
+exception Cancel_hook_failed of exn list
+
+exception Cancelled of exn
+
+let () =
+  Printexc.register_printer @@ function
+  | Cancel_hook_failed exns -> Some ("During cancellation:\n" ^ String.concat "\nand\n" (List.map Printexc.to_string exns))
+  | Cancelled ex -> Some ("Cancelled: " ^ Printexc.to_string ex)
+  | _ -> None
+
+type state =
+  | On of (exn -> unit) Lwt_dllist.t
+  | Cancelling of exn * Printexc.raw_backtrace
+  | Finished
+
+type t = {
+  mutable state : state;
+}
+
+(* A dummy value for bootstrapping *)
+let boot = {
+  state = Finished;
+}
+
+type _ eff += Set_cancel : t -> t eff
+
+let check t =
+  match t.state with
+  | On _ -> ()
+  | Cancelling (ex, _) -> raise (Cancelled ex)
+  | Finished -> invalid_arg "Cancellation context finished!"
+
+let get_error t =
+  match t.state with
+  | On _ -> None
+  | Cancelling (ex, _) -> Some (Cancelled ex)
+  | Finished -> Some (Invalid_argument "Cancellation context finished!")
+
+let is_finished t =
+  match t.state with
+  | Finished -> true
+  | On _ | Cancelling _ -> false
+
+let with_t fn =
+  let q = Lwt_dllist.create () in
+  let t = { state = On q } in
+  Fun.protect (fun () -> fn t)
+    ~finally:(fun () -> t.state <- Finished)
+
+let protect_full fn =
+  with_t @@ fun t ->
+  let x =
+    let old = perform (Set_cancel t) in
+    Fun.protect (fun () -> fn t)
+      ~finally:(fun () -> ignore (perform (Set_cancel old)))
+  in
+  check t;
+  x
+
+let protect fn = protect_full (fun (_ : t) -> fn ())
+
+let add_hook_unwrapped t hook =
+  match t.state with
+  | Finished -> invalid_arg "Cancellation context finished!"
+  | Cancelling (ex, _) -> protect (fun () -> hook ex); Hook.null
+  | On q ->
+    let node = Lwt_dllist.add_r hook q in
+    (fun () -> Lwt_dllist.remove node)
+
+let add_hook t hook = add_hook_unwrapped t (fun ex -> hook (Cancelled ex))
+
+let cancel t ex =
+  match t.state with
+  | Finished -> invalid_arg "Cancellation context finished!"
+  | Cancelling _ -> ()
+  | On q ->
+    let bt = Printexc.get_raw_backtrace () in
+    t.state <- Cancelling (ex, bt);
+    let rec aux () =
+      match Lwt_dllist.take_opt_r q with
+      | None -> []
+      | Some f ->
+        match f ex with
+        | () -> aux ()
+        | exception ex2 -> ex2 :: aux ()
+    in
+    match protect aux with
+    | [] -> ()
+    | exns -> raise (Cancel_hook_failed exns)
+
+let sub fn =
+  with_t @@ fun t ->
+  let x =
+    let old = perform (Set_cancel t) in
+    Fun.protect (fun () ->
+        let unhook = add_hook_unwrapped old (cancel t) in
+        Fun.protect (fun () -> fn t) ~finally:unhook
+      )
+      ~finally:(fun () -> ignore (perform (Set_cancel old)))
+  in
+  check t;
+  x

--- a/lib_eio/fibre.ml
+++ b/lib_eio/fibre.ml
@@ -1,7 +1,6 @@
 open EffectHandlers
 
 type _ eff += Fork : (unit -> 'a) -> 'a Promise.t eff
-type _ eff += Yield : unit eff
 
 let fork ~sw ~exn_turn_off f =
   let f () =
@@ -18,40 +17,54 @@ type _ eff += Fork_ignore : (unit -> unit) -> unit eff
 let fork_ignore ~sw f =
   let f () =
     Switch.with_op sw @@ fun () ->
-    try f ()
+    try
+      Cancel.protect_full @@ fun c ->
+      let hook = Switch.add_cancel_hook sw (Cancel.cancel c) in
+      Fun.protect f
+        ~finally:(fun () -> Hook.remove hook)
     with ex ->
-      Switch.turn_off sw ex;
-      raise ex
+      Switch.turn_off sw ex
   in
   perform (Fork_ignore f)
 
 let yield () =
-  perform Yield
+  let c = ref Cancel.boot in
+  Suspend.enter (fun fibre enqueue ->
+      c := fibre.cancel;
+      enqueue (Ok ())
+    );
+  Cancel.check !c
 
-let both ~sw f g =
-  let x = fork ~sw ~exn_turn_off:true f in
-  begin
-    try g ()
-    with ex -> Switch.turn_off sw ex
-  end;
-  ignore (Promise.await_result x : (unit, exn) result);
-  match sw.state with
-  | On _ -> ()
-  | Off (ex, bt) ->
-    Switch.raise_with_extras sw ex bt
-  | Finished -> assert false
+let both f g =
+  Cancel.sub @@ fun cancel ->
+  let f () =
+    try f ()
+    with ex -> Cancel.cancel cancel ex; raise ex
+  in
+  let x = perform (Fork f) in
+  match g () with
+  | () -> Promise.await x               (* [g] succeeds - just report [f]'s result *)
+  | exception gex ->
+    Cancel.cancel cancel gex;
+    match Cancel.protect (fun () -> Promise.await_result x) with
+    | Ok () | Error (Cancel.Cancelled _) -> raise gex    (* [g] fails, nothing to report for [f] *)
+    | Error fex ->
+      match gex with
+      | Cancel.Cancelled _ -> raise fex                         (* [f] fails, nothing to report for [g] *)
+      | _ -> raise (Multiple_exn.T [fex; gex])                  (* Both fail *)
 
 let fork_sub_ignore ?on_release ~sw ~on_error f =
-  if Switch.is_finished sw then (
-    (* If the switch is finished then we have no way to report the error after forking,
-       so do it now. *)
-    Option.iter (fun f -> f ()) on_release;
-    invalid_arg "Switch finished!"
-  );
-  let f () =
-    try Switch.sub ?on_release sw ~on_error f
-    with ex ->
-      Switch.turn_off sw ex;
-      raise ex
-  in
-  perform (Fork_ignore f)
+  let did_attach = ref false in
+  fork_ignore ~sw (fun () ->
+      try Switch.run (fun sw -> Option.iter (Switch.on_release sw) on_release; did_attach := true; f sw)
+      with ex ->
+        try on_error ex
+        with ex2 ->
+          Switch.turn_off sw ex;
+          Switch.turn_off sw ex2
+    );
+  if not !did_attach then (
+    Option.iter Cancel.protect on_release;
+    Switch.check sw;
+    assert false
+  )

--- a/lib_eio/hook.ml
+++ b/lib_eio/hook.ml
@@ -1,0 +1,5 @@
+type t = unit -> unit                (* A function to remove the hook *)
+
+let null = ignore
+
+let remove t = t ()

--- a/lib_eio/multiple_exn.ml
+++ b/lib_eio/multiple_exn.ml
@@ -1,0 +1,6 @@
+exception T of exn list
+
+let () =
+  Printexc.register_printer @@ function
+  | T exns -> Some ("Multiple exceptions:\n" ^ String.concat "\nand\n" (List.map Printexc.to_string exns))
+  | _ -> None

--- a/lib_eio/promise.ml
+++ b/lib_eio/promise.ml
@@ -31,27 +31,22 @@ let broken ex =
   Ctf.note_created id Ctf.Promise;
   { id; state = Broken ex }
 
-let await ?sw t =
-  Option.iter Switch.check sw;
+let await_result t =
   match t.state with
   | Fulfilled x ->
     Ctf.note_read t.id;
-    x
+    Ok x
   | Broken ex ->
     Ctf.note_read t.id;
-    raise ex
+    Error ex
   | Unresolved q ->
     Ctf.note_try_read t.id;
-    Switch.await ?sw q t.id
+    Switch.await q t.id
 
-let await_result ?sw t =
-  match await ?sw t with
-  | x ->
-    Option.iter Switch.check sw;
-    Ok x
-  | exception ex ->
-    Option.iter Switch.check sw;
-    Error ex
+let await t =
+  match await_result t with
+  | Ok x -> x
+  | Error ex -> raise ex
 
 let fulfill t v =
   match t.state with

--- a/lib_eio/semaphore.ml
+++ b/lib_eio/semaphore.ml
@@ -27,14 +27,14 @@ let release t =
     | `Queue_empty ->
       t.state <- Free 1
 
-let rec acquire ?sw t =
+let rec acquire t =
   match t.state with
   | Waiting q ->
     Ctf.note_try_read t.id;
-    Switch.await ?sw q t.id
+    Switch.await q t.id |> Switch.or_raise
   | Free 0 ->
     t.state <- Waiting (Waiters.create ());
-    acquire ?sw t
+    acquire t
   | Free n ->
     Ctf.note_read t.id;
     t.state <- Free (pred n)

--- a/lib_eio/suspend.ml
+++ b/lib_eio/suspend.ml
@@ -2,5 +2,7 @@ open EffectHandlers
 
 type 'a enqueue = ('a, exn) result -> unit
 type _ eff += Suspend : (Ctf.id -> 'a enqueue -> unit) -> 'a eff
+type _ eff += Suspend_unchecked : (Ctf.id -> 'a enqueue -> unit) -> 'a eff
 
 let enter fn = perform (Suspend fn)
+let enter_unchecked fn = perform (Suspend_unchecked fn)

--- a/lib_eio/switch.ml
+++ b/lib_eio/switch.ml
@@ -1,101 +1,36 @@
-open EffectHandlers
-
-exception Multiple_exceptions of exn list
-
-exception Cancelled of exn
-
-type hook = unit -> unit                (* A function to remove the hook *)
-
-let () =
-  Printexc.register_printer @@ function
-  | Multiple_exceptions exns -> Some ("Multiple exceptions:\n" ^ String.concat "\nand\n" (List.map Printexc.to_string exns))
-  | Cancelled ex -> Some ("Cancelled: " ^ Printexc.to_string ex)
-  | _ -> None
-
-type state =
-  | On of (exn -> unit) Lwt_dllist.t
-  | Off of exn * Printexc.raw_backtrace
-  | Finished
-
 type t = {
   id : Ctf.id;
-  mutable state : state;
   mutable fibres : int;
   mutable extra_exceptions : exn list;
   on_release : (unit -> unit) Lwt_dllist.t;
   waiter : unit Waiters.t;              (* The main [top]/[sub] function may wait here for fibres to finish. *)
+  cancel : Cancel.t;
 }
 
-(* A dummy switch for bootstrapping *)
-let boot_switch = {
-  id = Ctf.mint_id ();
-  state = Finished;
-  fibres = 0;
-  extra_exceptions = [];
-  on_release = Lwt_dllist.create ();
-  waiter = Waiters.create ();
-}
-
-type _ eff += Set_switch : t -> t eff
-
-let with_switch t fn =
-  let old = perform (Set_switch t) in
-  Fun.protect fn
-    ~finally:(fun () -> ignore (perform (Set_switch old)))
-
-let null_hook = ignore
-
-let remove_hook h = h ()
+let is_finished t = Cancel.is_finished t.cancel
 
 let check t =
-  match t.state with
-  | On _ -> ()
-  | Off (ex, _) -> raise (Cancelled ex)
-  | Finished -> invalid_arg "Switch finished!"
+  if is_finished t then invalid_arg "Switch finished!";
+  Cancel.check t.cancel
 
 let get_error t =
-  match t.state with
-  | On _ -> None
-  | Off (ex, _) -> Some (Cancelled ex)
-  | Finished -> Some (Invalid_argument "Switch finished!")
-
-let is_finished t =
-  match t.state with
-  | Finished -> true
-  | On _ | Off _ -> false
+  Cancel.get_error t.cancel
 
 let rec turn_off t ex =
-  match t.state with
+  match t.cancel.state with
   | Finished -> invalid_arg "Switch finished!"
-  | Off (orig, _) when orig == ex || List.memq ex t.extra_exceptions -> ()
-  | Off _ ->
+  | Cancelling (orig, _) when orig == ex || List.memq ex t.extra_exceptions -> ()
+  | Cancelling _ ->
     begin match ex with
-      | Cancelled _ -> ()       (* The original exception will be reported elsewhere *)
-      | Multiple_exceptions exns -> List.iter (turn_off t) exns
+      | Cancel.Cancelled _ -> ()       (* The original exception will be reported elsewhere *)
+      | Multiple_exn.T exns -> List.iter (turn_off t) exns
       | _ -> t.extra_exceptions <- ex :: t.extra_exceptions
     end
-  | On q ->
+  | On _ ->
     Ctf.note_resolved t.id ~ex:(Some ex);
-    t.state <- Off (ex, Printexc.get_raw_backtrace ());
-    let rec aux () =
-      match Lwt_dllist.take_opt_r q with
-      | None -> ()
-      | Some f ->
-        begin
-          try f ex 
-          with ex2 -> turn_off t ex2
-        end;
-        aux ()
-    in
-    aux ()
+    Cancel.cancel t.cancel ex
 
-let add_cancel_hook t hook =
-  match t.state with
-  | Finished -> invalid_arg "Switch finished!"
-  | Off (ex, _) -> hook ex; ignore
-  | On q ->
-    let node = Lwt_dllist.add_r hook q in
-    (fun () -> Lwt_dllist.remove node)
+let add_cancel_hook t hook = Cancel.add_hook t.cancel hook
 
 let add_cancel_hook_opt t hook =
   match t with
@@ -112,29 +47,32 @@ let with_op t fn =
           Waiters.wake_all t.waiter (Ok ())
       )
 
-let await_internal ?sw waiters id tid enqueue =
+let await_internal waiters id (ctx:Suspend.context) enqueue =
   let cleanup_hooks = Queue.create () in
   let when_resolved r =
     Queue.iter Waiters.remove_waiter cleanup_hooks;
-    Ctf.note_read ~reader:id tid;
+    Ctf.note_read ~reader:id ctx.tid;
     enqueue r
   in
   let cancel ex = when_resolved (Error ex) in
-  sw |> Option.iter (fun sw ->
-      let cancel_waiter = add_cancel_hook sw cancel in
-      Queue.add cancel_waiter cleanup_hooks;
-    );
-  let resolved_waiter = Waiters.add_waiter waiters when_resolved in
+  let cancel_waiter = Cancel.add_hook ctx.cancel cancel in
+  Queue.add cancel_waiter cleanup_hooks;
+  let resolved_waiter = Waiters.add_waiter waiters (fun x -> when_resolved (Ok x)) in
   Queue.add resolved_waiter cleanup_hooks
 
-let await ?sw waiters id =
-  Suspend.enter_unchecked (await_internal ?sw waiters id)
+(* Returns a result if the wait succeeds, or raises if cancelled. *)
+let await waiters id =
+  Suspend.enter (await_internal waiters id)
+
+let or_raise = function
+  | Ok x -> x
+  | Error ex -> raise ex
 
 let rec await_idle t =
   (* Wait for fibres to finish: *)
   while t.fibres > 0 do
     Ctf.note_try_read t.id;
-    await t.waiter t.id
+    await t.waiter t.id |> or_raise;
   done;
   (* Call on_release handlers: *)
   let queue = Lwt_dllist.create () in
@@ -152,103 +90,64 @@ let rec await_idle t =
   in
   release ()
 
+let await_idle t = Cancel.protect (fun _ -> await_idle t)
+
 let raise_with_extras t ex bt =
   match t.extra_exceptions with
   | [] -> Printexc.raise_with_backtrace ex bt
-  | exns -> Printexc.raise_with_backtrace (Multiple_exceptions (ex :: List.rev exns)) bt
+  | exns -> Printexc.raise_with_backtrace (Multiple_exn.T (ex :: List.rev exns)) bt
 
-let top fn =
+let run fn =
   let id = Ctf.mint_id () in
   Ctf.note_created id Ctf.Switch;
-  let q = Lwt_dllist.create () in
+  Cancel.sub @@ fun cancel ->
   let t = {
     id;
-    state = On q;
     fibres = 0;
     extra_exceptions = [];
     waiter = Waiters.create ();
     on_release = Lwt_dllist.create ();
+    cancel;
   } in
-  with_switch t @@ fun () ->
   match fn t with
   | v ->
     await_idle t;
-    begin match t.state with
+    begin match t.cancel.state with
       | Finished -> assert false
       | On _ ->
-        (* Success. Just mark the switch as unusable now. *)
-        t.state <- Finished;
+        (* Success. *)
         Ctf.note_read t.id;
         v
-      | Off (ex, bt) ->
+      | Cancelling (ex, bt) ->
         (* Function succeeded, but got failure waiting for fibres to finish. *)
-        t.state <- Finished;
         Ctf.note_read t.id;
         raise_with_extras t ex bt
     end
   | exception ex ->
     (* Main function failed.
        Turn the switch off to cancel any running fibres, if it's not off already. *)
-    turn_off t ex;
+    begin
+      try turn_off t ex
+      with Cancel.Cancel_hook_failed _ as ex ->
+        t.extra_exceptions <- ex :: t.extra_exceptions
+    end;
     await_idle t;
     Ctf.note_read t.id;
-    match t.state with
+    match t.cancel.state with
     | On _ | Finished -> assert false
-    | Off (ex, bt) ->
-      t.state <- Finished;
-      raise_with_extras t ex bt
+    | Cancelling (ex, bt) -> raise_with_extras t ex bt
 
-let on_release_cancellable t fn =
-  match t.state with
+let on_release_full t fn =
+  match t.cancel.state with
+  | On _ | Cancelling _ -> Lwt_dllist.add_r fn t.on_release
   | Finished ->
-    fn ();
-    invalid_arg "Switch finished!"
-  | On _ | Off _ ->
-    let node = Lwt_dllist.add_r fn t.on_release in
-    (fun () -> Lwt_dllist.remove node)
+    match Cancel.protect fn with
+    | () -> invalid_arg "Switch finished!"
+    | exception ex -> raise (Multiple_exn.T [ex; Invalid_argument "Switch finished!"])
 
 let on_release t fn =
-  match t.state with
-  | Finished ->
-    fn ();
-    invalid_arg "Switch finished!"
-  | On _ | Off _ ->
-    let _ : _ Lwt_dllist.node = Lwt_dllist.add_r fn t.on_release in
-    ()
+  ignore (on_release_full t fn : _ Lwt_dllist.node)
 
-let sub ?on_release:release sw ~on_error fn =
-  match sw.state with
-  | Finished ->
-    (* Can't create child switch. Run release hooks immediately. *)
-    Option.iter (fun f -> f ()) release;
-    invalid_arg "Switch finished!"
-  | Off (ex, _) ->
-    (* Can't create child switch. Run release hooks immediately. *)
-    Option.iter (fun f -> f ()) release;
-    raise (Cancelled ex)
-  | On _ ->
-    with_op sw @@ fun () ->
-    let w = ref ignore in
-    match
-      top (fun child ->
-          w := add_cancel_hook sw (turn_off child);
-          Option.iter (on_release child) release;
-          try fn child
-          with ex -> turn_off child ex; raise ex
-        )
-    with
-    | v ->
-      Waiters.remove_waiter !w;
-      v
-    | exception ex ->
-      Waiters.remove_waiter !w;
-      on_error ex
-
-let sub_opt ?on_release:release t fn =
-  match t with
-  | Some t -> sub ?on_release:release ~on_error:raise t fn
-  | None ->
-    top (fun child ->
-        Option.iter (on_release child) release;
-        fn child
-      )
+let on_release_cancellable t fn =
+  let node = on_release_full t fn in
+  (fun () -> Lwt_dllist.remove node)

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -48,8 +48,7 @@ val noop : unit -> unit
 (** {1 Time functions} *)
 
 val sleep_until : float -> unit
-(** [sleep_until time] blocks until the current time is [time].
-    @param sw Cancel the sleep if [sw] is turned off. *)
+(** [sleep_until time] blocks until the current time is [time]. *)
 
 (** {1 Memory allocation functions} *)
 

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -47,7 +47,7 @@ val noop : unit -> unit
 
 (** {1 Time functions} *)
 
-val sleep_until : ?sw:Switch.t -> float -> unit
+val sleep_until : float -> unit
 (** [sleep_until time] blocks until the current time is [time].
     @param sw Cancel the sleep if [sw] is turned off. *)
 
@@ -76,48 +76,47 @@ val openat2 :
 (** [openat2 ~sw ~flags ~perm ~resolve ~dir path] opens [dir/path].
     See {!Uring.openat2} for details. *)
 
-val read_upto : ?sw:Switch.t -> ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> int
+val read_upto : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> int
 (** [read_upto fd chunk len] reads at most [len] bytes from [fd],
     returning as soon as some data is available.
-    @param sw Abort the read if [sw] is turned off.
     @param file_offset Read from the given position in [fd] (default: 0).
     @raise End_of_file Raised if all data has already been read. *)
 
-val read_exactly : ?sw:Switch.t -> ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> unit
+val read_exactly : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> unit
 (** [read_exactly fd chunk len] reads exactly [len] bytes from [fd],
     performing multiple read operations if necessary.
     @param file_offset Read from the given position in [fd] (default: 0).
     @raise End_of_file Raised if the stream ends before [len] bytes have been read. *)
 
-val readv : ?sw:Switch.t -> ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> int
+val readv : ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> int
 (** [readv] is like {!read_upto} but can read into any cstruct(s),
     not just chunks of the pre-shared buffer.
     If multiple buffers are given, they are filled in order. *)
 
-val write : ?sw:Switch.t -> ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> unit
+val write : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> unit
 (** [write fd buf len] writes exactly [len] bytes from [buf] to [fd].
     It blocks until the OS confirms the write is done,
     and resubmits automatically if the OS doesn't write all of it at once. *)
 
-val writev : ?sw:Switch.t -> ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> unit
+val writev : ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> unit
 (** [writev] is like {!write} but can write from any cstruct(s),
     not just chunks of the pre-shared buffer.
     If multiple buffers are given, they are sent in order.
     It will make multiple OS calls if the OS doesn't write all of it at once. *)
 
-val splice : ?sw:Switch.t -> FD.t -> dst:FD.t -> len:int -> int
+val splice : FD.t -> dst:FD.t -> len:int -> int
 (** [splice src ~dst ~len] attempts to copy up to [len] bytes of data from [src] to [dst].
     @return The number of bytes copied.
     @raise End_of_file [src] is at the end of the file.
     @raise Unix.Unix_error(EINVAL, "splice", _) if splice is not supported for these FDs. *)
 
-val connect : ?sw:Switch.t -> FD.t -> Unix.sockaddr -> unit
+val connect : FD.t -> Unix.sockaddr -> unit
 (** [connect fd addr] attempts to connect socket [fd] to [addr]. *)
 
-val await_readable : ?sw:Switch.t -> FD.t -> unit
+val await_readable : FD.t -> unit
 (** [await_readable fd] blocks until [fd] is readable (or has an error). *)
 
-val await_writable : ?sw:Switch.t -> FD.t -> unit
+val await_writable : FD.t -> unit
 (** [await_writable fd] blocks until [fd] is writable (or has an error). *)
 
 val fstat : FD.t -> Unix.stats

--- a/lib_eio_linux/tests/basic_eio_linux.ml
+++ b/lib_eio_linux/tests/basic_eio_linux.ml
@@ -12,7 +12,7 @@ let setup_log level =
 let () =
   setup_log (Some Logs.Debug);
   run @@ fun _stdenv ->
-  Switch.top @@ fun sw ->
+  Switch.run @@ fun sw ->
   let fd = Unix.handle_unix_error (openfile ~sw "test.txt" Unix.[O_RDONLY]) 0 in
   let buf = alloc () in
   let _ = read_exactly fd buf 5 in

--- a/lib_eio_linux/tests/eurcp_lib.ml
+++ b/lib_eio_linux/tests/eurcp_lib.ml
@@ -14,7 +14,7 @@ let read_then_write_chunk infd outfd file_offset len =
   U.free buf
 
 let copy_file infd outfd insize block_size =
-  Switch.top @@ fun sw ->
+  Switch.run @@ fun sw ->
   let rec copy_block file_offset =
     let remaining = Int63.(sub insize file_offset) in
     if remaining <> Int63.zero then (
@@ -27,7 +27,7 @@ let copy_file infd outfd insize block_size =
 
 let run_cp block_size queue_depth infile outfile () =
   U.run ~queue_depth ~block_size @@ fun _stdenv ->
-  Switch.top @@ fun sw ->
+  Switch.run @@ fun sw ->
   let open Unix in
   let infd = Eio_linux.openfile ~sw infile [O_RDONLY] 0 in
   let outfd = Eio_linux.openfile ~sw outfile [O_WRONLY; O_CREAT; O_TRUNC] 0o644 in

--- a/lib_eio_linux/tests/test.ml
+++ b/lib_eio_linux/tests/test.ml
@@ -90,14 +90,14 @@ let test_iovec () =
   let rec recv = function
     | [] -> ()
     | cs ->
-      let got = Eio_linux.readv ~sw from_pipe cs in
+      let got = Eio_linux.readv from_pipe cs in
       recv (Cstruct.shiftv cs got)
   in
   Fibre.both ~sw
     (fun () -> recv [Cstruct.sub message 5 3; Cstruct.sub message 15 3])
     (fun () ->
        let b = Cstruct.of_string "barfoo" in
-       Eio_linux.writev ~sw to_pipe [Cstruct.sub b 3 3; Cstruct.sub b 0 3];
+       Eio_linux.writev to_pipe [Cstruct.sub b 3 3; Cstruct.sub b 0 3];
        Eio_linux.FD.close to_pipe
     );
   Alcotest.(check string) "Transfer correct" "Got [foo] and [bar]" (Cstruct.to_string message)

--- a/lib_eio_linux/tests/test.ml
+++ b/lib_eio_linux/tests/test.ml
@@ -17,7 +17,7 @@ let read_one_byte ~sw r =
 
 let test_poll_add () =
   Eio_linux.run @@ fun _stdenv ->
-  Switch.top @@ fun sw ->
+  Switch.run @@ fun sw ->
   let r, w = Eio_linux.pipe sw in
   let thread = read_one_byte ~sw r in
   Fibre.yield ();
@@ -30,7 +30,7 @@ let test_poll_add () =
 
 let test_poll_add_busy () =
   Eio_linux.run ~queue_depth:1 @@ fun _stdenv ->
-  Switch.top @@ fun sw ->
+  Switch.run @@ fun sw ->
   let r, w = Eio_linux.pipe sw in
   let a = read_one_byte ~sw r in
   let b = read_one_byte ~sw r in
@@ -46,11 +46,11 @@ let test_poll_add_busy () =
 (* Write a string to a pipe and read it out again. *)
 let test_copy () =
   Eio_linux.run ~queue_depth:2 @@ fun _stdenv ->
-  Switch.top @@ fun sw ->
+  Switch.run @@ fun sw ->
   let msg = "Hello!" in
   let from_pipe, to_pipe = Eio_linux.pipe sw in
   let buffer = Buffer.create 20 in
-  Fibre.both ~sw
+  Fibre.both
     (fun () -> Eio.Flow.copy from_pipe (Eio.Flow.buffer_sink buffer))
     (fun () ->
        Eio.Flow.copy (Eio.Flow.string_source msg) to_pipe;
@@ -63,13 +63,13 @@ let test_copy () =
 (* Write a string via 2 pipes. The copy from the 1st to 2nd pipe will be optimised and so tests a different code-path. *)
 let test_direct_copy () =
   Eio_linux.run ~queue_depth:4 @@ fun _stdenv ->
-  Switch.top @@ fun sw ->
+  Switch.run @@ fun sw ->
   let msg = "Hello!" in
   let from_pipe1, to_pipe1 = Eio_linux.pipe sw in
   let from_pipe2, to_pipe2 = Eio_linux.pipe sw in
   let buffer = Buffer.create 20 in
   let to_output = Eio.Flow.buffer_sink buffer in
-  Switch.top (fun sw ->
+  Switch.run (fun sw ->
       Fibre.fork_ignore ~sw (fun () -> Ctf.label "copy1"; Eio.Flow.copy from_pipe1 to_pipe2; Eio.Flow.close to_pipe2);
       Fibre.fork_ignore ~sw (fun () -> Ctf.label "copy2"; Eio.Flow.copy from_pipe2 to_output);
       Eio.Flow.copy (Eio.Flow.string_source msg) to_pipe1;
@@ -82,7 +82,7 @@ let test_direct_copy () =
 (* Read and write using IO vectors rather than the fixed buffers. *)
 let test_iovec () =
   Eio_linux.run ~queue_depth:4 @@ fun _stdenv ->
-  Switch.top @@ fun sw ->
+  Switch.run @@ fun sw ->
   let from_pipe, to_pipe = Eio_linux.pipe sw in
   let from_pipe = Eio_linux.Objects.get_fd from_pipe in
   let to_pipe = Eio_linux.Objects.get_fd to_pipe in
@@ -93,7 +93,7 @@ let test_iovec () =
       let got = Eio_linux.readv from_pipe cs in
       recv (Cstruct.shiftv cs got)
   in
-  Fibre.both ~sw
+  Fibre.both
     (fun () -> recv [Cstruct.sub message 5 3; Cstruct.sub message 15 3])
     (fun () ->
        let b = Cstruct.of_string "barfoo" in

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -23,17 +23,15 @@ exception Luv_error of Luv.Error.t
 val or_raise : 'a or_error -> 'a
 (** [or_error (Error e)] raises [Luv_error e]. *)
 
-val await : (('a -> unit) -> unit) -> 'a
+val await : (Eunix.Suspended.state -> ('a -> unit) -> unit) -> 'a
 (** [await fn] converts a function using a luv-style callback to one using effects.
-    Use it as e.g. [await (Luv.File.realpath path)]. *)
+    Use it as e.g. [await (fun fibre -> Luv.File.realpath path)].
+    Use [fibre] to implement cancellation. *)
 
 (** {1 Time functions} *)
 
-val sleep_until : ?sw:Switch.t -> float -> unit
-(** [sleep_until time] blocks until the current time is [time].
-    @param sw Cancel the sleep if [sw] is turned off. *)
-
-val yield : ?sw:Switch.t -> unit -> unit
+val sleep_until : float -> unit
+(** [sleep_until time] blocks until the current time is [time]. *)
 
 (** {1 Low-level wrappers for Luv functions} *)
 
@@ -63,16 +61,16 @@ module File : sig
     string -> Luv.File.Open_flag.t list -> t or_error
   (** Wraps {!Luv.File.open_} *)
 
-  val read : ?sw:Switch.t -> t -> Luv.Buffer.t list -> Unsigned.Size_t.t or_error
+  val read : t -> Luv.Buffer.t list -> Unsigned.Size_t.t or_error
   (** Wraps {!Luv.File.read} *)
 
-  val write : ?sw:Switch.t -> t -> Luv.Buffer.t list -> unit
+  val write : t -> Luv.Buffer.t list -> unit
   (** [write t bufs] writes all the data in [bufs] (which may take several calls to {!Luv.File.write}). *)
 
-  val realpath : ?sw:Switch.t -> string -> string or_error
+  val realpath : string -> string or_error
   (** Wraps {!Luv.File.realpath} *)
 
-  val mkdir : ?sw:Switch.t -> mode:Luv.File.Mode.t list -> string -> unit or_error
+  val mkdir : mode:Luv.File.Mode.t list -> string -> unit or_error
   (** Wraps {!Luv.File.mkdir} *)
 end
 

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -23,7 +23,7 @@ exception Luv_error of Luv.Error.t
 val or_raise : 'a or_error -> 'a
 (** [or_error (Error e)] raises [Luv_error e]. *)
 
-val await : (Eunix.Suspended.state -> ('a -> unit) -> unit) -> 'a
+val await : (Eio.Private.context -> ('a -> unit) -> unit) -> 'a
 (** [await fn] converts a function using a luv-style callback to one using effects.
     Use it as e.g. [await (fun fibre -> Luv.File.realpath path)].
     Use [fibre] to implement cancellation. *)

--- a/lib_eio_luv/tests/files.md
+++ b/lib_eio_luv/tests/files.md
@@ -32,7 +32,7 @@ Hello, world!
 
 ```ocaml
 let main _stdenv =
-  Switch.top @@ fun sw ->
+  Switch.run @@ fun sw ->
   let fd = Eio_luv.File.open_ ~sw "/dev/zero" [] |> Eio_luv.or_raise in
   let buf = Luv.Buffer.create 4 in
   read_exactly fd buf;

--- a/lib_eio_luv/tests/files.md
+++ b/lib_eio_luv/tests/files.md
@@ -6,12 +6,12 @@
 ```
 
 ```ocaml
-let rec read_exactly ~sw fd buf =
+let rec read_exactly fd buf =
   let size = Luv.Buffer.size buf in
   if size > 0 then (
-    let got = Eio_luv.File.read ~sw fd [buf] |> Eio_luv.or_raise |> Unsigned.Size_t.to_int in
+    let got = Eio_luv.File.read fd [buf] |> Eio_luv.or_raise |> Unsigned.Size_t.to_int in
     let next = Luv.Buffer.sub buf ~offset:got ~length:(size - got) in
-    read_exactly ~sw fd next
+    read_exactly fd next
   )
 
 let () =
@@ -35,7 +35,7 @@ let main _stdenv =
   Switch.top @@ fun sw ->
   let fd = Eio_luv.File.open_ ~sw "/dev/zero" [] |> Eio_luv.or_raise in
   let buf = Luv.Buffer.create 4 in
-  read_exactly ~sw fd buf;
+  read_exactly fd buf;
   traceln "Read %S" (Luv.Buffer.to_string buf);
   Eio_luv.File.close fd
 ```

--- a/lib_eunix/suspended.ml
+++ b/lib_eunix/suspended.ml
@@ -1,12 +1,7 @@
 open EffectHandlers.Deep
 
-type state = {
-  tid : Ctf.id;
-  mutable switch : Eio.Std.Switch.t;
-}
-
 type 'a t = {
-  fibre : state;
+  fibre : Eio.Private.context;
   k : ('a, [`Exit_scheduler]) continuation;
 }
 

--- a/lib_eunix/suspended.ml
+++ b/lib_eunix/suspended.ml
@@ -1,14 +1,19 @@
 open EffectHandlers.Deep
 
-type 'a t = {
+type state = {
   tid : Ctf.id;
+  mutable switch : Eio.Std.Switch.t;
+}
+
+type 'a t = {
+  fibre : state;
   k : ('a, [`Exit_scheduler]) continuation;
 }
 
 let continue t v =
-  Ctf.note_switch t.tid;
+  Ctf.note_switch t.fibre.tid;
   continue t.k v
 
 let discontinue t ex =
-  Ctf.note_switch t.tid;
+  Ctf.note_switch t.fibre.tid;
   discontinue t.k ex

--- a/lib_eunix/zzz.ml
+++ b/lib_eunix/zzz.ml
@@ -1,7 +1,5 @@
 (** Keep track of scheduled alarms. *)
 
-open Eio.Std
-
 module Key = struct
   type t = Optint.Int63.t
   let compare = Optint.Int63.compare
@@ -11,7 +9,7 @@ module Job = struct
   type t = {
     time : float;
     thread : unit Suspended.t;
-    cancel_hook : Switch.hook ref;
+    cancel_hook : Eio.Hook.t ref;
   }
 
   let compare a b = Float.compare a.time b.time
@@ -39,7 +37,7 @@ let remove t id =
 let pop t ~now =
   match Q.min t.sleep_queue with
   | Some (_, { Job.time; thread; cancel_hook }) when time <= now ->
-    Switch.remove_hook !cancel_hook;
+    Eio.Hook.remove !cancel_hook;
     t.sleep_queue <- Option.get (Q.rest t.sleep_queue);
     `Due thread
   | Some (_, { Job.time; _ }) -> `Wait_until time

--- a/lib_eunix/zzz.mli
+++ b/lib_eunix/zzz.mli
@@ -1,5 +1,3 @@
-open Eio.Std
-
 module Key : sig
   type t
 end
@@ -10,7 +8,7 @@ type t
 val create : unit -> t
 (** [create ()] is a fresh empty queue. *)
 
-val add : cancel_hook:Switch.hook ref -> t -> float -> unit Suspended.t -> Key.t
+val add : cancel_hook:Eio.Hook.t ref -> t -> float -> unit Suspended.t -> Key.t
 (** [add ~cancel_hook t time thread] adds a new event, due at [time], and returns its ID.
     [cancel_hook] will be released when the event is later returned by {!pop}. *)
 

--- a/tests/test_domains.md
+++ b/tests/test_domains.md
@@ -38,10 +38,9 @@ Here, we use a mutex to check that the parent domain really did run while waitin
 
 ```ocaml
 # run @@ fun mgr ->
-  Switch.top @@ fun sw ->
   let mutex = Stdlib.Mutex.create () in
   Mutex.lock mutex;
-  Fibre.both ~sw
+  Fibre.both
     (fun () ->
       traceln "Spawning new domain...";
       let response = Eio.Domain_manager.run_compute_unsafe mgr (fun () ->

--- a/tests/test_fs.md
+++ b/tests/test_fs.md
@@ -22,22 +22,22 @@ let run (fn : sw:Switch.t -> Eio.Stdenv.t -> unit) =
   Switch.top @@ fun sw ->
   fn ~sw env
 
-let read_all ?sw flow =
+let read_all flow =
   let b = Buffer.create 100 in
-  Eio.Flow.copy ?sw flow (Eio.Flow.buffer_sink b);
+  Eio.Flow.copy flow (Eio.Flow.buffer_sink b);
   Buffer.contents b
 
-let write_file ?sw ~create ?append dir path content =
-  Eio.Dir.with_open_out ?sw ~create ?append dir path @@ fun flow ->
+let write_file ~create ?append dir path content =
+  Eio.Dir.with_open_out ~create ?append dir path @@ fun flow ->
   Eio.Flow.copy_string content flow
 
-let try_write_file ~sw ~create ?append dir path content =
-  match write_file ~sw ~create ?append dir path content with
+let try_write_file ~create ?append dir path content =
+  match write_file ~create ?append dir path content with
   | () -> traceln "write %S -> ok" path
   | exception ex -> traceln "write %S -> %a" path Fmt.exn ex
 
-let read_file ?sw dir path =
-  Eio.Dir.with_open_in ?sw dir path read_all
+let read_file dir path =
+  Eio.Dir.with_open_in dir path read_all
 
 let try_mkdir dir path =
   match Eio.Dir.mkdir dir path ~perm:0o700 with
@@ -55,8 +55,8 @@ Creating a file and reading it back:
 ```ocaml
 # run @@ fun ~sw env ->
   let cwd = Eio.Stdenv.cwd env in
-  write_file ~sw ~create:(`Exclusive 0o666) cwd "test-file" "my-data";
-  traceln "Got %S" @@ read_file ~sw cwd "test-file";;
+  write_file ~create:(`Exclusive 0o666) cwd "test-file" "my-data";
+  traceln "Got %S" @@ read_file cwd "test-file";;
 +Got "my-data"
 - : unit = ()
 ```
@@ -74,7 +74,7 @@ Trying to use cwd to access a file outside of that subtree fails:
 ```ocaml
 # run @@ fun ~sw env ->
   let cwd = Eio.Stdenv.cwd env in
-  write_file ~sw ~create:(`Exclusive 0o666) cwd "../test-file" "my-data";
+  write_file ~create:(`Exclusive 0o666) cwd "../test-file" "my-data";
   failwith "Should have failed";;
 Exception: Eio.Dir.Permission_denied ("../test-file", _)
 ```
@@ -83,7 +83,7 @@ Trying to use cwd to access an absolute path fails:
 ```ocaml
 # run @@ fun ~sw env ->
   let cwd = Eio.Stdenv.cwd env in
-  write_file ~sw ~create:(`Exclusive 0o666) cwd "/tmp/test-file" "my-data";
+  write_file ~create:(`Exclusive 0o666) cwd "/tmp/test-file" "my-data";
   failwith "Should have failed";;
 Exception: Eio.Dir.Permission_denied ("/tmp/test-file", _)
 ```
@@ -94,8 +94,8 @@ Exclusive create fails if already exists:
 ```ocaml
 # run @@ fun ~sw env ->
   let cwd = Eio.Stdenv.cwd env in
-  write_file ~sw ~create:(`Exclusive 0o666) cwd "test-file" "first-write";
-  write_file ~sw ~create:(`Exclusive 0o666) cwd "test-file" "first-write";
+  write_file ~create:(`Exclusive 0o666) cwd "test-file" "first-write";
+  write_file ~create:(`Exclusive 0o666) cwd "test-file" "first-write";
   failwith "Should have failed";;
 Exception: Eio.Dir.Already_exists ("test-file", _)
 ```
@@ -104,9 +104,9 @@ If-missing create succeeds if already exists:
 ```ocaml
 # run @@ fun ~sw env ->
   let cwd = Eio.Stdenv.cwd env in
-  write_file ~sw ~create:(`If_missing 0o666) cwd "test-file" "1st-write-original";
-  write_file ~sw ~create:(`If_missing 0o666) cwd "test-file" "2nd-write";
-  traceln "Got %S" @@ read_file ~sw cwd "test-file";;
+  write_file ~create:(`If_missing 0o666) cwd "test-file" "1st-write-original";
+  write_file ~create:(`If_missing 0o666) cwd "test-file" "2nd-write";
+  traceln "Got %S" @@ read_file cwd "test-file";;
 +Got "2nd-write-original"
 - : unit = ()
 ```
@@ -115,9 +115,9 @@ Truncate create succeeds if already exists, and truncates:
 ```ocaml
 # run @@ fun ~sw env ->
   let cwd = Eio.Stdenv.cwd env in
-  write_file ~sw ~create:(`Or_truncate 0o666) cwd "test-file" "1st-write-original";
-  write_file ~sw ~create:(`Or_truncate 0o666) cwd "test-file" "2nd-write";
-  traceln "Got %S" @@ read_file ~sw cwd "test-file";;
+  write_file ~create:(`Or_truncate 0o666) cwd "test-file" "1st-write-original";
+  write_file ~create:(`Or_truncate 0o666) cwd "test-file" "2nd-write";
+  traceln "Got %S" @@ read_file cwd "test-file";;
 +Got "2nd-write"
 - : unit = ()
 # Unix.unlink "test-file";;
@@ -128,8 +128,8 @@ Error if no create and doesn't exist:
 ```ocaml
 # run @@ fun ~sw env ->
   let cwd = Eio.Stdenv.cwd env in
-  write_file ~sw ~create:`Never cwd "test-file" "1st-write-original";
-  traceln "Got %S" @@ read_file ~sw cwd "test-file";;
+  write_file ~create:`Never cwd "test-file" "1st-write-original";
+  traceln "Got %S" @@ read_file cwd "test-file";;
 Exception: Eio.Dir.Not_found ("test-file", _)
 ```
 
@@ -137,9 +137,9 @@ Appending to an existing file:
 ```ocaml
 # run @@ fun ~sw env ->
   let cwd = Eio.Stdenv.cwd env in
-  write_file ~sw ~create:(`Or_truncate 0o666) cwd "test-file" "1st-write-original";
-  write_file ~sw ~create:`Never ~append:true cwd "test-file" "2nd-write";
-  traceln "Got %S" @@ read_file ~sw cwd "test-file";;
+  write_file ~create:(`Or_truncate 0o666) cwd "test-file" "1st-write-original";
+  write_file ~create:`Never ~append:true cwd "test-file" "2nd-write";
+  traceln "Got %S" @@ read_file cwd "test-file";;
 +Got "1st-write-original2nd-write"
 - : unit = ()
 # Unix.unlink "test-file";;
@@ -153,7 +153,7 @@ Appending to an existing file:
   let cwd = Eio.Stdenv.cwd env in
   try_mkdir cwd "subdir";
   try_mkdir cwd "subdir/nested";
-  write_file ~sw ~create:(`Exclusive 0o600) cwd "subdir/nested/test-file" "data";
+  write_file ~create:(`Exclusive 0o600) cwd "subdir/nested/test-file" "data";
   ();;
 +mkdir "subdir" -> ok
 +mkdir "subdir/nested" -> ok
@@ -196,9 +196,9 @@ Create a sandbox, write a file with it, then read it from outside:
   let cwd = Eio.Stdenv.cwd env in
   try_mkdir cwd "sandbox";
   let subdir = Eio.Dir.open_dir ~sw cwd "sandbox" in
-  write_file ~sw ~create:(`Exclusive 0o600) subdir "test-file" "data";
+  write_file ~create:(`Exclusive 0o600) subdir "test-file" "data";
   try_mkdir subdir "../new-sandbox";
-  traceln "Got %S" @@ read_file ~sw cwd "sandbox/test-file";;
+  traceln "Got %S" @@ read_file cwd "sandbox/test-file";;
 +mkdir "sandbox" -> ok
 +mkdir "../new-sandbox" -> Eio.Dir.Permission_denied ("../new-sandbox", _)
 +Got "data"
@@ -217,9 +217,9 @@ Using `cwd` we can't access the parent, but using `fs` we can:
   chdir "fs-test";
   Fun.protect ~finally:(fun () -> chdir "..") (fun () ->
     try_mkdir cwd "../outside-cwd";
-    try_write_file ~sw ~create:(`Exclusive 0o600) cwd "../test-file" "data";
+    try_write_file ~create:(`Exclusive 0o600) cwd "../test-file" "data";
     try_mkdir fs "../outside-cwd";
-    try_write_file ~sw ~create:(`Exclusive 0o600) fs "../test-file" "data";
+    try_write_file ~create:(`Exclusive 0o600) fs "../test-file" "data";
   );
   Unix.unlink "test-file";
   Unix.rmdir "outside-cwd";;

--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -14,9 +14,9 @@ let run (fn : net:Eio.Net.t -> Switch.t -> unit) =
 
 let addr = `Tcp (Unix.inet_addr_loopback, 8081)
 
-let read_all ?sw flow =
+let read_all flow =
   let b = Buffer.create 100 in
-  Eio.Flow.copy ?sw flow (Eio.Flow.buffer_sink b);
+  Eio.Flow.copy flow (Eio.Flow.buffer_sink b);
   Buffer.contents b
 
 exception Graceful_shutdown
@@ -32,7 +32,7 @@ let run_client ~sw ~net ~addr =
   let flow = Eio.Net.connect ~sw net addr in
   Eio.Flow.copy_string "Hello from client" flow;
   Eio.Flow.shutdown flow `Send;
-  let msg = read_all ~sw flow in
+  let msg = read_all flow in
   traceln "Client received: %S" msg
 ```
 
@@ -44,7 +44,7 @@ let run_server ~sw socket =
     Eio.Net.accept_sub socket ~sw (fun ~sw flow _addr ->
       traceln "Server accepted connection from client";
       Fun.protect (fun () ->
-        let msg = read_all ~sw flow in
+        let msg = read_all flow in
         traceln "Server received: %S" msg
       ) ~finally:(fun () -> Eio.Flow.copy_string "Bye" flow)
     )
@@ -61,7 +61,7 @@ let test_address addr ~net sw =
     (fun () ->
       run_client ~sw ~net ~addr;
       traceln "Client finished - cancelling server";
-      Switch.turn_off sw Graceful_shutdown
+      raise Graceful_shutdown
     )
 ```
 
@@ -106,24 +106,29 @@ Cancelling the read:
 
 ```ocaml
 # run @@ fun ~net sw ->
-  Switch.top @@ fun read_switch ->
+  let shutdown, set_shutdown = Promise.create () in
   let server = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:5 addr in
   Fibre.both ~sw
     (fun () ->
-      Eio.Net.accept_sub server ~sw (fun ~sw flow _addr ->
-        try
-          let msg = read_all ~sw:read_switch flow in
-          traceln "Server received: %S" msg
-        with Switch.Cancelled Graceful_shutdown ->
-          Eio.Flow.copy_string "Request cancelled" flow
-      ) ~on_error:raise
+        Eio.Net.accept_sub server ~sw (fun ~sw flow _addr ->
+          try
+            Fibre.both ~sw
+              (fun () -> raise (Promise.await shutdown))
+              (fun () ->
+                let msg = read_all flow in
+                traceln "Server received: %S" msg
+              )
+          with Graceful_shutdown ->
+            Switch.top @@ fun _sw ->
+            Eio.Flow.copy_string "Request cancelled" flow;
+        ) ~on_error:raise
     )
     (fun () ->
       traceln "Connecting to server...";
       let flow = Eio.Net.connect ~sw net addr in
       traceln "Connection opened - cancelling server's read";
       Fibre.yield ();
-      Switch.turn_off read_switch Graceful_shutdown;
+      Promise.fulfill set_shutdown Graceful_shutdown;
       let msg = read_all flow in
       traceln "Client received: %S" msg
     );;

--- a/tests/test_switch.md
+++ b/tests/test_switch.md
@@ -42,8 +42,8 @@ Exception: Failure "Cancel".
 ```ocaml
 # run (fun sw ->
     Fibre.both ~sw
-      (fun () -> for i = 1 to 2 do traceln "i = %d" i; Fibre.yield ~sw () done)
-      (fun () -> for j = 1 to 2 do traceln "j = %d" j; Fibre.yield ~sw () done)
+      (fun () -> for i = 1 to 2 do traceln "i = %d" i; Fibre.yield () done)
+      (fun () -> for j = 1 to 2 do traceln "j = %d" j; Fibre.yield () done)
   );;
 +i = 1
 +j = 1
@@ -57,7 +57,7 @@ Exception: Failure "Cancel".
 ```ocaml
 # run (fun sw ->
       Fibre.both ~sw
-        (fun () -> for i = 1 to 5 do traceln "i = %d" i; Fibre.yield ~sw () done)
+        (fun () -> for i = 1 to 5 do traceln "i = %d" i; Fibre.yield () done)
         (fun () -> failwith "Failed")
     );;
 +i = 1
@@ -69,8 +69,8 @@ Exception: Failure "Failed".
 ```ocaml
 # run (fun sw ->
       Fibre.both ~sw
-        (fun () -> Fibre.yield ~sw (); failwith "Failed")
-        (fun () -> for i = 1 to 5 do traceln "i = %d" i; Fibre.yield ~sw () done)
+        (fun () -> Fibre.yield (); failwith "Failed")
+        (fun () -> for i = 1 to 5 do traceln "i = %d" i; Fibre.yield () done)
     );;
 +i = 1
 Exception: Failure "Failed".
@@ -239,7 +239,7 @@ A child can fail independently of the parent:
       Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child 2"; Promise.await ~sw p2);
       Promise.break r1 (Failure "Child error");
       Promise.fulfill r2 ();
-      Fibre.yield ~sw ();
+      Fibre.yield ();
       traceln "Parent fibre is still running"
     );;
 +Child 1
@@ -262,7 +262,7 @@ A child can be cancelled independently of the parent:
           Promise.await ~sw p
         );
       Switch.turn_off (Option.get !child) (Failure "Cancel child");
-      Fibre.yield ~sw ();
+      Fibre.yield ();
       traceln "Parent fibre is still running"
     );;
 +Child 1
@@ -279,7 +279,7 @@ A child error handle raises:
       let on_error = raise in
       Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child"; Promise.await ~sw p);
       Promise.break r (Failure "Child error escapes");
-      Fibre.yield ~sw ();
+      Fibre.yield ();
       traceln "Not reached"
     );;
 +Child

--- a/tests/test_switch.md
+++ b/tests/test_switch.md
@@ -9,7 +9,7 @@ open Eio.Std
 
 let run (fn : Switch.t -> unit) =
   Eio_main.run @@ fun _e ->
-  Switch.top fn
+  Switch.run fn
 ```
 
 # Test cases
@@ -40,8 +40,8 @@ Exception: Failure "Cancel".
 `Fibre.both`, both fibres pass:
 
 ```ocaml
-# run (fun sw ->
-    Fibre.both ~sw
+# run (fun _sw ->
+    Fibre.both
       (fun () -> for i = 1 to 2 do traceln "i = %d" i; Fibre.yield () done)
       (fun () -> for j = 1 to 2 do traceln "j = %d" j; Fibre.yield () done)
   );;
@@ -56,7 +56,7 @@ Exception: Failure "Cancel".
 
 ```ocaml
 # run (fun sw ->
-      Fibre.both ~sw
+      Fibre.both
         (fun () -> for i = 1 to 5 do traceln "i = %d" i; Fibre.yield () done)
         (fun () -> failwith "Failed")
     );;
@@ -68,7 +68,7 @@ Exception: Failure "Failed".
 
 ```ocaml
 # run (fun sw ->
-      Fibre.both ~sw
+      Fibre.both
         (fun () -> Fibre.yield (); failwith "Failed")
         (fun () -> for i = 1 to 5 do traceln "i = %d" i; Fibre.yield () done)
     );;
@@ -80,7 +80,7 @@ Exception: Failure "Failed".
 
 ```ocaml
 # run (fun sw ->
-      Fibre.both ~sw (fun () -> failwith "Failed") ignore;
+      Fibre.both (fun () -> failwith "Failed") ignore;
       traceln "Not reached"
     );;
 Exception: Failure "Failed".
@@ -90,7 +90,7 @@ Exception: Failure "Failed".
 
 ```ocaml
 # run (fun sw ->
-      Fibre.both ~sw ignore (fun () -> failwith "Failed");
+      Fibre.both ignore (fun () -> failwith "Failed");
       traceln "not reached"
     );;
 Exception: Failure "Failed".
@@ -100,7 +100,7 @@ Exception: Failure "Failed".
 
 ```ocaml
 # run (fun sw ->
-      Fibre.both ~sw
+      Fibre.both
         (fun () -> failwith "Failed 1")
         (fun () -> failwith "Failed 2")
     );;
@@ -141,12 +141,12 @@ Turning off a switch runs the cancel callbacks, unless they've been removed by t
       let h1 = Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 1") in
       let h2 = Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 2") in
       let h3 = Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 3") in
-      Switch.remove_hook h2;
+      Eio.Hook.remove h2;
       Switch.turn_off sw (Failure "Cancelled");
       let h4 = Switch.add_cancel_hook sw (fun _ -> traceln "Cancel 4") in
-      Switch.remove_hook h1;
-      Switch.remove_hook h3;
-      Switch.remove_hook h4
+      Eio.Hook.remove h1;
+      Eio.Hook.remove h3;
+      Eio.Hook.remove h4
     );;
 +Cancel 3
 +Cancel 1
@@ -154,15 +154,31 @@ Turning off a switch runs the cancel callbacks, unless they've been removed by t
 Exception: Failure "Cancelled".
 ```
 
-Wait for either a promise or a switch; switch cancelled first:
+Cancellation callbacks do not run on success, but release ones do:
+
+```ocaml
+# run @@ fun sw ->
+  Switch.add_cancel_hook sw (fun _ -> traceln "Cance hook") |> ignore;
+  Switch.on_release sw (fun _ -> traceln "Release hook");;
++Release hook
+- : unit = ()
+```
+
+Wait for either a promise or a cancellation; cancellation first:
 ```ocaml
 # run (fun sw ->
       let p, r = Promise.create () in
-      Fibre.fork_ignore ~sw (fun () -> traceln "Waiting"; Promise.await ~sw p; traceln "Resolved");
-      Switch.turn_off sw (Failure "Cancelled");
-      Promise.fulfill r ()
+      Fibre.fork_ignore ~sw (fun () ->
+        Fibre.both
+          (fun () -> traceln "Waiting"; Promise.await p; traceln "Resolved")
+          (fun () -> failwith "Cancelled")
+      );
+      Fibre.yield ();
+      Promise.fulfill r ();
+      traceln "Main thread done";
     );;
 +Waiting
++Main thread done
 Exception: Failure "Cancelled".
 ```
 
@@ -171,7 +187,7 @@ Wait for either a promise or a switch; promise resolves first:
 ```ocaml
 # run (fun sw ->
       let p, r = Promise.create () in
-      Fibre.fork_ignore ~sw (fun () -> traceln "Waiting"; Promise.await ~sw p; traceln "Resolved");
+      Fibre.fork_ignore ~sw (fun () -> traceln "Waiting"; Promise.await p; traceln "Resolved");
       Promise.fulfill r ();
       Fibre.yield ();
       traceln "Now cancelling...";
@@ -188,7 +204,7 @@ Wait for either a promise or a switch; switch cancelled first. Result version.
 ```ocaml
 # run (fun sw ->
       let p, r = Promise.create () in
-      Fibre.fork_ignore ~sw (fun () -> traceln "Waiting"; ignore (Promise.await_result ~sw p); traceln "Resolved");
+      Fibre.fork_ignore ~sw (fun () -> traceln "Waiting"; ignore (Promise.await_result p); traceln "Resolved");
       Switch.turn_off sw (Failure "Cancelled");
       Promise.fulfill r ()
     );;
@@ -201,13 +217,14 @@ Wait for either a promise or a switch; promise resolves first but switch off wit
 ```ocaml
 # run (fun sw ->
       let p, r = Promise.create () in
-      Fibre.fork_ignore ~sw (fun () -> traceln "Waiting"; ignore (Promise.await_result ~sw p); traceln "Resolved");
+      Fibre.fork_ignore ~sw (fun () -> traceln "Waiting"; ignore (Promise.await_result p); traceln "Resolved");
       Promise.fulfill r ();
       traceln "Now cancelling...";
       Switch.turn_off sw (Failure "Cancelled")
     );;
 +Waiting
 +Now cancelling...
++Resolved
 Exception: Failure "Cancelled".
 ```
 
@@ -217,14 +234,14 @@ Child switches are cancelled when the parent is cancelled:
 # run (fun sw ->
       let p, _ = Promise.create () in
       let on_error ex = traceln "child: %s" (Printexc.to_string ex) in
-      Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child 1"; Promise.await ~sw p);
-      Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child 2"; Promise.await ~sw p);
+      Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child 1"; Promise.await p);
+      Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child 2"; Promise.await p);
       Switch.turn_off sw (Failure "Cancel parent")
     );;
 +Child 1
 +Child 2
-+child: Failure("Cancel parent")
-+child: Failure("Cancel parent")
++child: Cancelled: Failure("Cancel parent")
++child: Cancelled: Failure("Cancel parent")
 Exception: Failure "Cancel parent".
 ```
 
@@ -235,8 +252,8 @@ A child can fail independently of the parent:
       let p1, r1 = Promise.create () in
       let p2, r2 = Promise.create () in
       let on_error ex = traceln "child: %s" (Printexc.to_string ex) in
-      Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child 1"; Promise.await ~sw p1);
-      Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child 2"; Promise.await ~sw p2);
+      Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child 1"; Promise.await p1);
+      Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child 2"; Promise.await p2);
       Promise.break r1 (Failure "Child error");
       Promise.fulfill r2 ();
       Fibre.yield ();
@@ -271,13 +288,13 @@ A child can be cancelled independently of the parent:
 - : unit = ()
 ```
 
-A child error handle raises:
+A child error handler raises:
 
 ```ocaml
 # run (fun sw ->
       let p, r = Promise.create () in
       let on_error = raise in
-      Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child"; Promise.await ~sw p);
+      Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child"; Promise.await p);
       Promise.break r (Failure "Child error escapes");
       Fibre.yield ();
       traceln "Not reached"
@@ -290,12 +307,16 @@ A child error handler deals with the exception:
 
 ```ocaml
 # run (fun sw ->
-      let print ex = traceln "%s" (Printexc.to_string ex); 0 in
-      let x = Switch.sub sw ~on_error:print (fun _sw -> failwith "Child error") in
-      traceln "x = %d" x
+      let p, r = Promise.create () in
+      let on_error = traceln "caught: %a" Fmt.exn in
+      Fibre.fork_sub_ignore ~sw ~on_error (fun sw -> traceln "Child"; Promise.await p);
+      Promise.break r (Failure "Child error is caught");
+      Fibre.yield ();
+      traceln "Still running"
     );;
-+Failure("Child error")
-+x = 0
++Child
++caught: Failure("Child error is caught")
++Still running
 - : unit = ()
 ```
 
@@ -313,12 +334,16 @@ Failure
 
 # Release handlers
 
+```ocaml
+let release label = Fibre.yield (); traceln "release %s" label
+```
+
 Release on success:
 
 ```ocaml
 # run (fun sw ->
-    Switch.on_release sw (fun () -> traceln "release 1");
-    Switch.on_release sw (fun () -> traceln "release 2");
+    Switch.on_release sw (fun () -> release "1");
+    Switch.on_release sw (fun () -> release "2");
   );;
 +release 2
 +release 1
@@ -329,8 +354,8 @@ Release on error:
 
 ```ocaml
 # run (fun sw ->
-    Switch.on_release sw (fun () -> traceln "release 1");
-    Switch.on_release sw (fun () -> traceln "release 2");
+    Switch.on_release sw (fun () -> release "1");
+    Switch.on_release sw (fun () -> release "2");
     failwith "Test error"
   );;
 +release 2
@@ -342,9 +367,9 @@ A release operation itself fails:
 
 ```ocaml
 # run (fun sw ->
-    Switch.on_release sw (fun () -> traceln "release 1"; failwith "failure 1");
-    Switch.on_release sw (fun () -> traceln "release 2");
-    Switch.on_release sw (fun () -> traceln "release 3"; failwith "failure 3");
+    Switch.on_release sw (fun () -> release "1"; failwith "failure 1");
+    Switch.on_release sw (fun () -> release "2");
+    Switch.on_release sw (fun () -> release "3"; failwith "failure 3");
   );;
 +release 3
 +release 2
@@ -353,6 +378,21 @@ Exception: Multiple exceptions:
 Failure("failure 3")
 and
 Failure("failure 1")
+```
+
+Attaching a release handler to a finished switch from a cancelled context:
+
+```ocaml
+# run @@ fun sw ->
+  let sub = Switch.run Fun.id in        (* A finished switch *)
+  Switch.turn_off sw (Failure "Parent cancelled too!");
+  Switch.on_release sub (fun () -> release "1");;
++release 1
+Exception:
+Multiple exceptions:
+Failure("Parent cancelled too!")
+and
+Invalid_argument("Switch finished!")
 ```
 
 Using switch from inside release handler:
@@ -389,9 +429,9 @@ Using switch from inside release handler:
 
 ```ocaml
 let fork_sub_ignore_resource sw =
-  traceln "Allocate resource";
+  traceln "allocate resource";
   Fibre.fork_sub_ignore ~sw ~on_error:raise
-    ~on_release:(fun () -> traceln "Free resource")
+    ~on_release:(fun () -> release "resource")
     (fun _sw -> traceln "Child fibre running")
 ```
 
@@ -401,9 +441,9 @@ We release when `fork_sub_ignore` returns:
 # run (fun sw ->
     fork_sub_ignore_resource sw
   );;
-+Allocate resource
++allocate resource
 +Child fibre running
-+Free resource
++release resource
 - : unit = ()
 ```
 
@@ -414,8 +454,8 @@ We release when `fork_sub_ignore` fails due to parent switch being already off:
     Switch.turn_off sw (Failure "Switch already off");
     fork_sub_ignore_resource sw
   );;
-+Allocate resource
-+Free resource
++allocate resource
++release resource
 Exception: Failure "Switch already off".
 ```
 
@@ -423,12 +463,11 @@ We release when `fork_sub_ignore` fails due to parent switch being invalid:
 
 ```ocaml
 # run (fun sw ->
-    let copy = ref sw in
-    Switch.sub sw ~on_error:raise (fun sub -> copy := sub);
-    fork_sub_ignore_resource !copy
+    let sub = Switch.run Fun.id in
+    fork_sub_ignore_resource sub
   );;
-+Allocate resource
-+Free resource
++allocate resource
++release resource
 Exception: Invalid_argument "Switch finished!".
 ```
 
@@ -444,4 +483,24 @@ We release when `fork_sub_ignore`'s switch is turned off while running:
 +Allocate resource
 +Free resource
 Exception: Failure "Simulated error".
+```
+
+# Error reporting
+
+All cancel hooks run, even if some fail, and all errors are reported:
+
+```ocaml
+# run (fun sw ->
+    Switch.add_cancel_hook sw (fun _ -> failwith "cancel1 failed") |> ignore;
+    Switch.add_cancel_hook sw (fun _ -> failwith "cancel2 failed") |> ignore;
+    raise Exit
+  );;
+Exception:
+Multiple exceptions:
+Stdlib.Exit
+and
+During cancellation:
+Failure("cancel2 failed")
+and
+Failure("cancel1 failed")
 ```

--- a/tests/test_sync.md
+++ b/tests/test_sync.md
@@ -21,7 +21,7 @@ Create a promise, fork a thread waiting for it, then fulfull it:
 ```ocaml
 # let () =
     Eio_main.run @@ fun _stdenv ->
-    Switch.top @@ fun sw ->
+    Switch.run @@ fun sw ->
     let p, r = Promise.create () in
     traceln "Initial state: %a" (pp_promise Fmt.string) p;
     let thread = Fibre.fork ~sw ~exn_turn_off:false (fun () -> Promise.await p) in
@@ -42,7 +42,7 @@ Create a promise, fork a thread waiting for it, then break it:
 ```ocaml
 # let () =
     Eio_main.run @@ fun _stdenv ->
-    Switch.top @@ fun sw ->
+    Switch.run @@ fun sw ->
     let p, r = Promise.create () in
     traceln "Initial state: %a" (pp_promise Fmt.string) p;
     let thread = Fibre.fork ~sw ~exn_turn_off:false (fun () -> Promise.await p) in
@@ -66,13 +66,13 @@ Some simple tests of `fork_ignore`:
 # let () =
     Eio_main.run @@ fun _stdenv ->
     let i = ref 0 in
-    Switch.top (fun sw ->
+    Switch.run (fun sw ->
         Fibre.fork_ignore ~sw (fun () -> incr i);
       );
     traceln "Forked code ran; i is now %d" !i;
     let p1, r1 = Promise.create () in
     try
-      Switch.top (fun sw ->
+      Switch.run (fun sw ->
           Fibre.fork_ignore ~sw (fun () -> Promise.await p1; incr i; raise Exit);
           traceln "Forked code waiting; i is still %d" !i;
           Promise.fulfill r1 ()
@@ -90,7 +90,7 @@ Basic semaphore tests:
 # let () =
     let module Semaphore = Eio.Semaphore in
     Eio_main.run @@ fun _stdenv ->
-    Switch.top @@ fun sw ->
+    Switch.run @@ fun sw ->
     let running = ref 0 in
     let sem = Semaphore.make 2 in
     let fork = Fibre.fork ~sw ~exn_turn_off:false in
@@ -126,7 +126,7 @@ Releasing a semaphore when no-one is waiting for it:
 # let () =
     let module Semaphore = Eio.Semaphore in
     Eio_main.run @@ fun _stdenv ->
-    Switch.top @@ fun sw ->
+    Switch.run @@ fun sw ->
     let sem = Semaphore.make 0 in
     Semaphore.release sem;        (* Release with free-counter *)
     traceln "Initial config: %d" (Semaphore.get_value sem);

--- a/tests/test_time.md
+++ b/tests/test_time.md
@@ -30,9 +30,8 @@ Check sleep works with a switch:
 
 ```ocaml
 # run @@ fun ~clock ->
-  Switch.top @@ fun sw ->
   let t0 = Unix.gettimeofday () in
-  Eio.Time.sleep ~sw clock 0.01;
+  Eio.Time.sleep clock 0.01;
   let t1 = Unix.gettimeofday () in
   assert (t1 -. t0 >= 0.01);;
 - : unit = ()
@@ -44,8 +43,8 @@ Cancelling sleep:
 # run @@ fun ~clock ->
   Switch.top @@ fun sw ->
   Fibre.both ~sw
-    (fun () -> Eio.Time.sleep ~sw clock 1200.; assert false)
-    (fun () -> Switch.turn_off sw (Failure "Simulated cancel"));;
+    (fun () -> Eio.Time.sleep clock 1200.; assert false)
+    (fun () -> failwith "Simulated cancel");;
 Exception: Failure "Simulated cancel".
 ```
 
@@ -55,7 +54,7 @@ Switch is already off:
 # run @@ fun ~clock ->
   Switch.top @@ fun sw ->
   Switch.turn_off sw (Failure "Simulated failure");
-  Eio.Time.sleep ~sw clock 1200.0;
+  Eio.Time.sleep clock 1200.0;
   assert false;;
 Exception: Failure "Simulated failure".
 ```
@@ -66,7 +65,7 @@ Scheduling a timer that's already due:
 # run @@ fun ~clock ->
   Switch.top @@ fun sw ->
   Fibre.both ~sw
-    (fun () -> traceln "First fibre runs"; Eio.Time.sleep ~sw clock (-1.0); traceln "Sleep done")
+    (fun () -> traceln "First fibre runs"; Eio.Time.sleep clock (-1.0); traceln "Sleep done")
     (fun () -> traceln "Second fibre runs");;
 +First fibre runs
 +Second fibre runs
@@ -81,13 +80,13 @@ Check ordering works:
   Switch.top @@ fun sw ->
   Fibre.both ~sw
     (fun () ->
-      Eio.Time.sleep ~sw clock 1200.0;
+      Eio.Time.sleep clock 1200.0;
       assert false
     )
     (fun () ->
       Eio.Time.sleep clock 0.1;
       traceln "Short timer finished";
-      Switch.turn_off sw (Failure "Simulated cancel")
+      failwith "Simulated cancel"
     );;
 +Short timer finished
 Exception: Failure "Simulated cancel".

--- a/tests/test_time.md
+++ b/tests/test_time.md
@@ -41,8 +41,7 @@ Cancelling sleep:
 
 ```ocaml
 # run @@ fun ~clock ->
-  Switch.top @@ fun sw ->
-  Fibre.both ~sw
+  Fibre.both
     (fun () -> Eio.Time.sleep clock 1200.; assert false)
     (fun () -> failwith "Simulated cancel");;
 Exception: Failure "Simulated cancel".
@@ -52,7 +51,7 @@ Switch is already off:
 
 ```ocaml
 # run @@ fun ~clock ->
-  Switch.top @@ fun sw ->
+  Switch.run @@ fun sw ->
   Switch.turn_off sw (Failure "Simulated failure");
   Eio.Time.sleep clock 1200.0;
   assert false;;
@@ -63,8 +62,8 @@ Scheduling a timer that's already due:
 
 ```ocaml
 # run @@ fun ~clock ->
-  Switch.top @@ fun sw ->
-  Fibre.both ~sw
+  Switch.run @@ fun sw ->
+  Fibre.both
     (fun () -> traceln "First fibre runs"; Eio.Time.sleep clock (-1.0); traceln "Sleep done")
     (fun () -> traceln "Second fibre runs");;
 +First fibre runs
@@ -77,8 +76,8 @@ Check ordering works:
 
 ```ocaml
 # run @@ fun ~clock ->
-  Switch.top @@ fun sw ->
-  Fibre.both ~sw
+  Switch.run @@ fun sw ->
+  Fibre.both
     (fun () ->
       Eio.Time.sleep clock 1200.0;
       assert false


### PR DESCRIPTION
Instead of requiring every cancellable operation to pass a `~sw` argument, give each fibre a default switch and use that. It's too easy to forget to make something cancellable and clutters up the code.

This should enable further API improvements, but the change is big enough that it's probably worth reviewing on its own.