### PR TITLE
Add Fibre.first

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is an unreleased repository, as it's very much a work-in-progress.
 * [Fibres](#fibres)
 * [Tracing](#tracing)
 * [Cancellation](#cancellation)
+* [Racing](#racing)
 * [Switches](#switches)
 * [Design Note: Results vs Exceptions](#design-note-results-vs-exceptions)
 * [Performance](#performance)
@@ -232,6 +233,28 @@ You should assume that any operation that can switch fibres can also raise a `Ca
 
 If you want to make an operation non-cancellable, wrap it with `Cancel.protect`
 (this creates a new context that isn't cancelled with its parent).
+
+## Racing
+
+`Fibre.first` returns the result of the first fibre to finish, cancelling the other one:
+
+```ocaml
+# Eio_main.run @@ fun _env ->
+  let x =
+    Fibre.first
+      (fun () ->
+        traceln "first fibre delayed...";
+        Fibre.yield ();
+        traceln "delay over";
+        "a"
+      )
+      (fun () -> "b")
+  in
+  traceln "x = %S" x;;
++first fibre delayed...
++x = "b"
+- : unit = ()
+```
 
 ## Switches
 

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -144,6 +144,12 @@ module Std : sig
         (it will then re-raise the original exception).
         @raise Multiple_exn.T if both fibres raise exceptions (excluding {!Cancel.Cancelled}). *)
 
+    val first : (unit -> 'a) -> (unit -> 'a) -> 'a
+    (** [first f g] runs [f ()] and [g ()] concurrently.
+        They run in a new cancellation sub-context, and when one finishes the other is cancelled.
+        If one raises, the other is cancelled and the exception is reported.
+        @raise Multiple_exn.T if both fibres raise exceptions (excluding {!Cancel.Cancelled} when cancelled). *)
+
     val fork_ignore : sw:Switch.t -> (unit -> unit) -> unit
     (** [fork_ignore ~sw fn] runs [fn ()] in a new fibre, but does not wait for it to complete.
         The new fibre is attached to [sw] (which can't finish until the fibre ends).

--- a/tests/test_fibre.md
+++ b/tests/test_fibre.md
@@ -1,0 +1,144 @@
+# Setting up the environment
+
+```ocaml
+# #require "eio_main";;
+```
+
+```ocaml
+open Eio.Std
+
+let run fn =
+  Eio_main.run @@ fun _ ->
+  traceln "%s" (fn ())
+```
+
+# Fibre.first
+
+First finishes, second is cancelled:
+
+```ocaml
+# run @@ fun () ->
+  let p, r = Promise.create () in
+  Fibre.first
+    (fun () -> "a")
+    (fun () -> Promise.await p);;
++a
+- : unit = ()
+```
+
+Second finishes, first is cancelled:
+
+```ocaml
+# run @@ fun () ->
+  let p, r = Promise.create () in
+  Fibre.first
+    (fun () -> Promise.await p)
+    (fun () -> "b");;
++b
+- : unit = ()
+```
+
+If both succeed, we pick the first one:
+
+```ocaml
+# run @@ fun () ->
+  Fibre.first
+    (fun () -> "a")
+    (fun () -> "b");;
++a
+- : unit = ()
+```
+
+One crashes - report it:
+
+```ocaml
+# run @@ fun () ->
+  Fibre.first
+    (fun () -> "a")
+    (fun () -> failwith "b crashed");;
+Exception: Failure "b crashed".
+```
+
+```ocaml
+# run @@ fun () ->
+  Fibre.first
+    (fun () -> failwith "a crashed")
+    (fun () -> "b");;
+Exception: Failure "a crashed".
+```
+
+Both crash - report both:
+
+```ocaml
+# run @@ fun () ->
+  Fibre.first
+    (fun () -> failwith "a crashed")
+    (fun () -> failwith "b crashed");;
+Exception: Multiple exceptions:
+Failure("a crashed")
+and
+Failure("b crashed")
+```
+
+Cancelled before it can crash:
+
+```ocaml
+# run @@ fun () ->
+  Fibre.first
+    (fun () -> "a")
+    (fun () -> Fibre.yield (); failwith "b crashed");;
++a
+- : unit = ()
+```
+
+One claims to be cancelled (for some reason other than the other fibre finishing):
+
+```ocaml
+# run @@ fun () ->
+  Fibre.first
+    (fun () -> raise (Eio.Cancel.Cancelled (Failure "cancel-a")))
+    (fun () -> "b");;
+Exception: Cancelled: Failure("cancel-a")
+```
+
+```ocaml
+# run @@ fun () ->
+  Fibre.first
+    (fun () -> Fibre.yield (); "a")
+    (fun () -> raise (Eio.Cancel.Cancelled (Failure "cancel-b")));;
+Exception: Cancelled: Failure("cancel-b")
+```
+
+Cancelled from parent:
+
+```ocaml
+# run @@ fun () ->
+  let p, r = Promise.create () in
+  Fibre.both
+    (fun () ->
+      failwith @@ Fibre.first
+        (fun () -> Promise.await p)
+        (fun () -> Promise.await p)
+    )
+    (fun () -> failwith "Parent cancel");
+  "not-reached";;
+Exception: Failure "Parent cancel".
+```
+
+Cancelled from parent while already cancelling:
+
+```ocaml
+# run @@ fun () ->
+  Fibre.both
+    (fun () ->
+      let _ = Fibre.first
+        (fun () -> "a")
+        (fun () -> Fibre.yield (); failwith "cancel-b")
+      in
+      traceln "Parent cancel failed"
+    )
+    (fun () -> traceln "Cancelling parent"; failwith "Parent cancel");
+  "not-reached";;
++Cancelling parent
+Exception: Failure "Parent cancel".
+```


### PR DESCRIPTION
Runs two threads and returns the result from the first to finish, cancelling the other thread (like `Lwt.pick`).