### PR TITLE
Track whether cancellation came from parent context

### DIFF
--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -163,7 +163,7 @@ module Std : sig
         This is a convenience function for running {!Switch.run} inside a {!fork_ignore}.
         @param on_release If given, this function is called when the new fibre ends.
                           If the fibre cannot be created (e.g. because [sw] is already off), it runs immediately.
-        @param on_error This is called if the fibre raises an exception.
+        @param on_error This is called if the fibre raises an exception (other than {!Cancel.Cancelled}).
                         If it raises in turn, the parent switch is turned off. *)
 
     val fork : sw:Switch.t -> exn_turn_off:bool -> (unit -> 'a) -> 'a Promise.t

--- a/lib_eio/switch.ml
+++ b/lib_eio/switch.ml
@@ -31,11 +31,7 @@ let rec turn_off t ex =
     Cancel.cancel t.cancel ex
 
 let add_cancel_hook t hook = Cancel.add_hook t.cancel hook
-
-let add_cancel_hook_opt t hook =
-  match t with
-  | Some t -> add_cancel_hook t hook
-  | None -> ignore
+let add_cancel_hook_unwrapped t hook = Cancel.add_hook_unwrapped t.cancel hook
 
 let with_op t fn =
   check t;

--- a/tests/test_fibre.md
+++ b/tests/test_fibre.md
@@ -142,3 +142,25 @@ Cancelled from parent while already cancelling:
 +Cancelling parent
 Exception: Failure "Parent cancel".
 ```
+
+Cancelling in a sub-switch. We see the exception as `Cancelled Exit` when we're being asked to cancel,
+but just as plain `Exit` after we leave the context in which the cancellation started:
+
+```ocaml
+# run @@ fun () ->
+  let p, r = Promise.create () in
+  Fibre.both
+    (fun () ->
+      try
+        Switch.run (fun _ ->
+          try Promise.await p
+          with ex -> traceln "Nested exception: %a" Fmt.exn ex; raise ex
+        )
+      with ex -> traceln "Parent exception: %a" Fmt.exn ex; raise ex
+    )
+    (fun () -> raise Exit);
+  failwith "not-reached";;
++Nested exception: Cancelled: Stdlib.Exit
++Parent exception: Cancelled: Stdlib.Exit
+Exception: Stdlib.Exit.
+```

--- a/tests/test_stream.md
+++ b/tests/test_stream.md
@@ -217,7 +217,7 @@ Trying to use a stream with a cancelled context:
 +Cancelled: Cancel
 +Reading from stream
 +Cancelled: Cancel
-Exception: Cancelled: Cancel
+Exception: Cancel.
 ```
 
 Readers queue up:

--- a/tests/test_switch.md
+++ b/tests/test_switch.md
@@ -228,7 +228,7 @@ Wait for either a promise or a switch; promise resolves first but switch off wit
 Exception: Failure "Cancelled".
 ```
 
-Child switches are cancelled when the parent is cancelled:
+Child switches are cancelled when the parent is cancelled, but `on_error` isn't notified:
 
 ```ocaml
 # run (fun sw ->
@@ -240,8 +240,6 @@ Child switches are cancelled when the parent is cancelled:
     );;
 +Child 1
 +Child 2
-+child: Cancelled: Failure("Cancel parent")
-+child: Cancelled: Failure("Cancel parent")
 Exception: Failure "Cancel parent".
 ```
 


### PR DESCRIPTION
If we're cancelling because the parent context asked us to cancel then we need to raise a Cancelled exception on exit to propagate the cancellation upwards. But if cancelled from inside, then we just raise the original exception.