### PR TITLE
Keep an explicit tree of cancellation contexts

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -3,9 +3,11 @@ open Eio.Std
 let n_fibres = [1; 2; 3; 4; 5; 10; 20; 30; 40; 50; 100; 500; 1000; 10000]
 
 let main ~clock =
-  traceln "n_fibers, ns/iter";
+  Printf.printf "n_fibers, ns/iter, promoted/iter\n%!";
   n_fibres |> List.iter (fun n_fibres ->
       let n_iters = 1000000 / n_fibres in
+      Gc.full_major ();
+      let _minor0, prom0, _major0 = Gc.counters () in
       let t0 = Eio.Time.now clock in
       Switch.run (fun sw ->
           for _ = 1 to n_fibres do
@@ -20,7 +22,9 @@ let main ~clock =
       let time_total = t1 -. t0 in
       let n_total = n_fibres * n_iters in
       let time_per_iter = time_total /. float n_total in
-      traceln "%d, %.2f" n_fibres (1e9 *. time_per_iter)
+      let _minor1, prom1, _major1 = Gc.counters () in
+      let prom = prom1 -. prom0 in
+      Printf.printf "%5d, %.2f, %7.4f\n%!" n_fibres (1e9 *. time_per_iter) (prom /. float n_total)
       (* traceln "%d fibres did %d noops in %.2f seconds : %.2f ns/iter"
            n_fibres n_iters time_total (1e9 *. time_per_iter) *)
     )

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -257,7 +257,7 @@ module Stdenv = struct
 end
 
 module Private = struct
-  type context = Suspend.context = {
+  type context = Cancel.fibre_context = {
     tid : Ctf.id;
     mutable cancel : Cancel.t;
   }
@@ -268,8 +268,8 @@ module Private = struct
       | Suspend = Suspend.Suspend
       | Fork = Fibre.Fork
       | Fork_ignore = Fibre.Fork_ignore
+      | Get_context = Cancel.Get_context
       | Trace = Std.Trace
-      | Set_cancel = Cancel.Set_cancel
   end
   let boot_cancel = Cancel.boot
 end

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -613,7 +613,7 @@ module Private : sig
           passing it the suspended fibre's context and a function to resume it.
           [fn] should arrange for [enqueue] to be called once the thread is ready to run again. *)
 
-      | Fork : (unit -> 'a) -> 'a Promise.t eff
+      | Fork : (context -> 'a) -> 'a Promise.t eff
       (** See {!Fibre.fork} *)
 
       | Fork_ignore : (context -> unit) -> unit eff

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -283,9 +283,6 @@ module Cancel : sig
       This can be used to clean up resources on cancellation.
       However, it is usually better to use {!Switch.on_release} (which calls this for you). *)
 
-  val protect_full : (t -> 'a) -> 'a
-  (** [protect_full fn] is like {!protect}, but also gives access to the new context. *)
-
   val check : t -> unit
   (** [check t] checks that [t] hasn't been cancelled.
       @raise Cancelled If the context has been cancelled. *)
@@ -619,7 +616,7 @@ module Private : sig
       | Fork : (unit -> 'a) -> 'a Promise.t eff
       (** See {!Fibre.fork} *)
 
-      | Fork_ignore : (unit -> unit) -> unit eff
+      | Fork_ignore : (context -> unit) -> unit eff
       (** See {!Fibre.fork_ignore} *)
 
       | Trace : (?__POS__:(string * int * int * int) -> ('a, Format.formatter, unit, unit) format4 -> 'a) eff
@@ -628,8 +625,7 @@ module Private : sig
           If the system is not ready to receive the trace output,
           the whole domain must block until it is. *)
 
-      | Set_cancel : Cancel.t -> Cancel.t eff
-      (** [Set_cancel c] sets the running fibre's cancel context to [c] and returns the previous context. *)
+      | Get_context : context eff
   end
 
   val boot_cancel : Cancel.t

--- a/lib_eio/suspend.ml
+++ b/lib_eio/suspend.ml
@@ -1,12 +1,7 @@
 open EffectHandlers
 
-type context = {
-  tid : Ctf.id;
-  mutable cancel : Cancel.t;
-}
-
 type 'a enqueue = ('a, exn) result -> unit
-type _ eff += Suspend : (context -> 'a enqueue -> unit) -> 'a eff
+type _ eff += Suspend : (Cancel.fibre_context -> 'a enqueue -> unit) -> 'a eff
 
 let enter_unchecked fn = perform (Suspend fn)
 

--- a/lib_eio/switch.ml
+++ b/lib_eio/switch.ml
@@ -31,7 +31,6 @@ let rec turn_off t ex =
     Cancel.cancel t.cancel ex
 
 let add_cancel_hook t hook = Cancel.add_hook t.cancel hook
-let add_cancel_hook_unwrapped t hook = Cancel.add_hook_unwrapped t.cancel hook
 
 let with_op t fn =
   check t;
@@ -43,7 +42,7 @@ let with_op t fn =
           Waiters.wake_all t.waiter (Ok ())
       )
 
-let await_internal waiters id (ctx:Suspend.context) enqueue =
+let await_internal waiters id (ctx:Cancel.fibre_context) enqueue =
   let cleanup_hooks = Queue.create () in
   let when_resolved r =
     Queue.iter Waiters.remove_waiter cleanup_hooks;

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -990,8 +990,8 @@ let run ?(queue_depth=64) ?(block_size=4096) main =
               fork
                 ~tid:id
                 ~cancel:fibre.cancel
-                (fun _fibre ->
-                   match f () with
+                (fun new_fibre ->
+                   match f new_fibre with
                    | x -> Promise.fulfill resolver x
                    | exception ex ->
                      Log.debug (fun f -> f "Forked fibre failed: %a" Fmt.exn ex);

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -607,8 +607,8 @@ let run main =
             fork
               ~tid:id
               ~cancel:fibre.cancel
-              (fun _new_fibre ->
-                 match f () with
+              (fun new_fibre ->
+                 match f new_fibre with
                  | x -> Promise.fulfill resolver x
                  | exception ex ->
                    Log.debug (fun f -> f "Forked fibre failed: %a" Fmt.exn ex);


### PR DESCRIPTION
This is slightly more efficient, and might also be useful to allow dumping out the tree for debugging.

The benchmark output only changes slightly. Before:

        n_fibers, ns/iter, promoted/iter
            1, 524.20,  0.0016
            2, 394.78,  0.0040
            3, 343.78,  0.0048
            4, 315.77,  0.0072
            5, 300.92,  0.0090
           10, 273.20,  0.0179
           20, 265.16,  0.0357
           30, 261.86,  0.0532
           40, 259.82,  0.0712
           50, 263.72,  0.0887
          100, 371.08, 12.9941
          500, 414.16, 13.0958
         1000, 415.46, 13.1503
        10000, 648.22, 14.0348
After:

    n_fibers, ns/iter, promoted/iter
        1, 523.13,  0.0015
        2, 378.86,  0.0039
        3, 341.11,  0.0066
        4, 318.76,  0.0070
        5, 301.93,  0.0088
       10, 274.63,  0.0176
       20, 262.06,  0.0352
       30, 260.06,  0.0523
       40, 257.90,  0.0702
       50, 257.43,  0.0873
      100, 375.31, 12.9928
      500, 389.29, 13.0256
     1000, 406.85, 13.1256
    10000, 582.68, 13.7761

It should also make it easier to try other approaches. e.g. registering a set of fibres with a cancellation context and calling `fibre.on_cancel` or similar, instead of registering each operation with the context individually.