### PR TITLE
Use a lock-free run queue for luv backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all:
 	dune build @runtest @all
 
 bench:
+	dune exec -- ./bench/bench_yield.exe
 	dune exec -- ./bench/bench_promise.exe
 	dune exec -- ./bench/bench_stream.exe
 	dune exec -- ./bench/bench_semaphore.exe

--- a/bench/bench_stream.ml
+++ b/bench/bench_stream.ml
@@ -38,7 +38,7 @@ let main ~domain_mgr ~clock =
   [false, 10_000_000;
    true,   1_000_000]
   |> List.iter (fun (use_domains, n_iters) ->
-      [1; 10; 100; 1000] |> List.iter (fun capacity ->
+      [0; 1; 10; 100; 1000] |> List.iter (fun capacity ->
           run_bench ~domain_mgr ~clock ~use_domains ~n_iters ~capacity
         )
     )

--- a/bench/bench_yield.ml
+++ b/bench/bench_yield.ml
@@ -13,7 +13,7 @@ let main ~clock =
           for _ = 1 to n_fibres do
             Fibre.fork_ignore ~sw (fun () ->
                 for _ = 1 to n_iters do
-                  Eio_linux.noop ()
+                  Fibre.yield ()
                 done
               )
           done
@@ -24,7 +24,9 @@ let main ~clock =
       let time_per_iter = time_total /. float n_total in
       let _minor1, prom1, _major1 = Gc.counters () in
       let prom = prom1 -. prom0 in
-      Printf.printf "%5d, %.2f, %7.4f\n%!" n_fibres (1e9 *. time_per_iter) (prom /. float n_total)
+      Printf.printf "%8d, % 7.2f, % 13.4f\n%!" n_fibres (1e9 *. time_per_iter) (prom /. float n_total)
+      (* traceln "%d fibres did %d noops in %.2f seconds : %.2f ns/iter"
+           n_fibres n_iters time_total (1e9 *. time_per_iter) *)
     )
 
 let () =

--- a/bench/bench_yield.ml
+++ b/bench/bench_yield.ml
@@ -25,8 +25,6 @@ let main ~clock =
       let _minor1, prom1, _major1 = Gc.counters () in
       let prom = prom1 -. prom0 in
       Printf.printf "%8d, % 7.2f, % 13.4f\n%!" n_fibres (1e9 *. time_per_iter) (prom /. float n_total)
-      (* traceln "%d fibres did %d noops in %.2f seconds : %.2f ns/iter"
-           n_fibres n_iters time_total (1e9 *. time_per_iter) *)
     )
 
 let () =

--- a/bench/dune
+++ b/bench/dune
@@ -1,4 +1,4 @@
 (executables
-  (names bench bench_stream bench_promise bench_semaphore)
+  (names bench bench_stream bench_promise bench_semaphore bench_yield)
   (enabled_if (= %{system} "linux"))
   (libraries eio_main))

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -677,6 +677,7 @@ let run main =
       Luv.Loop.stop loop
     );
   ignore (Luv.Loop.run ~loop () : bool);
+  Lf_queue.close st.run_q;
   Luv.Handle.close async (fun () -> Luv.Loop.close loop |> or_raise);
   match !main_status with
   | `Done -> ()

--- a/lib_eunix/lf_queue.ml
+++ b/lib_eunix/lf_queue.ml
@@ -1,0 +1,59 @@
+(* A lock-free multi-producer, single-consumer, thread-safe queue without support for cancellation.
+   This makes a good data structure for a scheduler's run queue.
+
+   See: "Implementing lock-free queues"
+   https://people.cs.pitt.edu/~jacklange/teaching/cs2510-f12/papers/implementing_lock_free.pdf
+   
+   It is simplified slightly because we don't need multiple consumers.
+   Therefore [head] is not atomic. *)
+
+type 'a node = {
+  next : 'a node option Atomic.t;
+  mutable value : 'a;
+}
+
+type 'a t = {
+  tail : 'a node Atomic.t;
+  mutable head : 'a node;
+}
+(* [head] is the last node dequeued (or a dummy node, initially).
+   [head.next] gives the real first node, if not [None].
+   [tail] is a node that was once at the tail of the queue.
+   Follow [tail.next] (if not [None]) to find the real last node. *)
+
+let push t x =
+  let node = { value = x; next = Atomic.make None } in
+  let rec aux () =
+    let p = Atomic.get t.tail in
+    (* [p] was the last item in the queue at some point.
+       While [p.next = None], it still is. *)
+    if Atomic.compare_and_set p.next None (Some node) then (
+      (* [node] has now been added to the queue (and possibly even consumed).
+         Update [tail], unless someone else already did it for us. *)
+      ignore (Atomic.compare_and_set t.tail p node : bool)
+    ) else (
+      (* Someone else added a different node first ([p.next] is not [None]).
+         Make [t.tail] more up-to-date, if it hasn't already changed, and try again. *)
+      ignore (Atomic.compare_and_set t.tail p (Option.get (Atomic.get p.next)) : bool);
+      aux ()
+    )
+  in
+  aux ()
+
+let pop t =
+  let p = t.head in
+  (* [p] is the previously-popped item. *)
+  match Atomic.get p.next with
+  | Some node ->
+    t.head <- node;
+    let v = node.value in
+    node.value <- Obj.magic ();         (* So it can be GC'd *)
+    Some v
+  | None -> None
+
+let is_empty t =
+  Atomic.get t.head.next = None
+
+let create () =
+  let dummy = { value = Obj.magic (); next = Atomic.make None } in
+  { tail = Atomic.make dummy; head = dummy }

--- a/lib_eunix/lf_queue.mli
+++ b/lib_eunix/lf_queue.mli
@@ -1,0 +1,13 @@
+(** A lock-free multi-producer, single-consumer, thread-safe queue without support for cancellation.
+    This makes a good data structure for a scheduler's run queue. *)
+
+type 'a t
+(** A queue of items of type ['a]. *)
+
+val create : unit -> 'a t
+
+val push : 'a t -> 'a -> unit
+
+val pop : 'a t -> 'a option
+
+val is_empty : 'a t -> bool

--- a/lib_eunix/lf_queue.mli
+++ b/lib_eunix/lf_queue.mli
@@ -4,10 +4,20 @@
 type 'a t
 (** A queue of items of type ['a]. *)
 
+exception Closed
+
 val create : unit -> 'a t
 
 val push : 'a t -> 'a -> unit
+(** [push t x] adds [x] to the queue.
+    @raise Closed if [t] is closed. *)
 
 val pop : 'a t -> 'a option
+(** [pop t] removes the head item from [t] and returns it.
+    Returns [None] if [t] is currently empty.
+    @raise Closed if [t] has been closed. *)
 
 val is_empty : 'a t -> bool
+
+val close : 'a t -> unit
+(** [close t] marks [t] as closed, preventing any further items from being pushed. *)

--- a/tests/test_lf_queue.md
+++ b/tests/test_lf_queue.md
@@ -1,0 +1,73 @@
+# A lock-free queue for schedulers
+
+```ocaml
+# #require "eunix";;
+```
+
+```ocaml
+module Q = Eunix.Lf_queue;;
+```
+
+## A basic run
+
+```ocaml
+# let q : int Q.t = Q.create ();;
+val q : int Q.t = <abstr>
+# Q.push q 1;;
+- : unit = ()
+# Q.push q 2;;
+- : unit = ()
+# Q.pop q;;
+- : int option = Some 1
+# Q.pop q;;
+- : int option = Some 2
+# Q.pop q;;
+- : int option = None
+# Q.pop q;;
+- : int option = None
+# Q.push q 3;;
+- : unit = ()
+# Q.pop q;;
+- : int option = Some 3
+```
+
+## Closing the queue
+
+```ocaml
+# let q : int Q.t = Q.create ();;
+val q : int Q.t = <abstr>
+# Q.push q 1;;
+- : unit = ()
+# Q.close q;;
+- : unit = ()
+# Q.push q 2;;
+Exception: Eunix.Lf_queue.Closed.
+# Q.pop q;;
+- : int option = Some 1
+# Q.pop q;;
+Exception: Eunix.Lf_queue.Closed.
+```
+
+## Closing an empty queue
+
+```ocaml
+# let q = Q.create () in Q.close q; Q.push q 1;;
+Exception: Eunix.Lf_queue.Closed.
+```
+
+## Empty?
+
+```ocaml
+# let q : int Q.t = Q.create ();;
+val q : int Q.t = <abstr>
+# Q.is_empty q;;
+- : bool = true
+# Q.push q 1; Q.is_empty q;;
+- : bool = false
+# Q.pop q;;
+- : int option = Some 1
+# Q.is_empty q;;
+- : bool = true
+# Q.close q; Q.is_empty q;;
+Exception: Eunix.Lf_queue.Closed.
+```


### PR DESCRIPTION
This avoids the need for a mutex around the queue. Disappointingly, it doesn't seem to be much of an improvement. Possibly because `Atomic.t` requires allocating an extra block vs a `mutable` field? It also required a lot of `Obj.magic` :-(

The trivial single-domain yield benchmark improved a bit. Before:
```
$ make bench EIO_BACKEND=luv
dune exec -- ./bench/bench_yield.exe
n_fibers, ns/iter, promoted/iter
       1,   95.00,        0.0026
       2,  151.19,       12.8926
       3,  151.80,       12.8930
       4,  147.99,       12.8934
       5,  148.09,       12.8938
      10,  147.75,       12.8960
      20,  149.30,       12.9003
      30,  151.43,       12.9047
      40,  153.97,       12.9088
      50,  155.53,       12.9131
     100,  158.35,       12.9344
     500,  173.89,       13.0800
    1000,  182.50,       13.1779
   10000,  168.52,       13.7133
```
After:
```
$ make bench EIO_BACKEND=luv
dune exec -- ./bench/bench_yield.exe
n_fibers, ns/iter, promoted/iter
       1,   93.94,        4.9996
       2,   93.13,        5.0021
       3,   92.17,        5.0046
       4,   92.21,        5.0071
       5,   91.45,        5.0090
      10,  114.29,        5.0194
      20,   96.17,        5.0468
      30,   97.83,        5.0677
      40,   98.82,        5.0959
      50,   99.70,        5.1197
     100,  107.31,        5.2409
     500,  132.94,        6.1383
    1000,  142.85,        6.6771
   10000,  114.80,        5.9410
```

But the others mostly got slower, in both the single and two-domain cases. Before:
```
dune exec -- ./bench/bench_promise.exe
Reading a resolved promise: 4.377 ns
use_domains,   n_iters, ns/iter, promoted/iter
      false,  1000000,   960.81,       26.0082
       true,   100000, 11302.70,        9.6920
dune exec -- ./bench/bench_stream.exe
use_domains,  n_iters, capacity, ns/iter, promoted/iter
      false, 10000000,        1,  154.85,        0.0097
      false, 10000000,       10,   75.60,        0.0042
      false, 10000000,      100,   52.27,        0.0085
      false, 10000000,     1000,   48.92,        0.0703
       true,  1000000,        1, 3582.20,        0.0013
       true,  1000000,       10,  846.88,        0.0009
       true,  1000000,      100,  283.49,        0.0009
       true,  1000000,     1000,  175.36,        0.0031
dune exec -- ./bench/bench_semaphore.exe
use_domains,   n_iters,  batch, ns/iter, promoted/iter
      false,  1000000,   1,   380.42,        0.0209
      false,  1000000,  10,    90.74,        0.0030
      false,  1000000, 100,    56.17,        0.0009
       true,   100000,   1, 10852.43,        0.0077
       true,   100000,  10,  1101.14,        0.0081
       true,   100000, 100,   187.30,        0.0073
```
After:
```
dune exec -- ./bench/bench_promise.exe
Reading a resolved promise: 4.315 ns
use_domains,   n_iters, ns/iter, promoted/iter
      false,  1000000,  1019.63,       36.0230
       true,   100000, 11773.08,       11.8866
dune exec -- ./bench/bench_stream.exe
use_domains,  n_iters, capacity, ns/iter, promoted/iter
      false, 10000000,        1,  162.55,        3.3410
      false, 10000000,       10,   77.04,        0.8373
      false, 10000000,      100,   53.02,        0.1063
      false, 10000000,     1000,   49.79,        0.0811
       true,  1000000,        1, 3481.09,        1.6675
       true,  1000000,       10,  849.10,        0.4174
       true,  1000000,      100,  227.13,        0.0176
       true,  1000000,     1000,  278.07,        0.1113
dune exec -- ./bench/bench_semaphore.exe
use_domains,   n_iters,  batch, ns/iter, promoted/iter
      false,  1000000,   1,   394.85,       10.0135
      false,  1000000,  10,    92.60,        0.9950
      false,  1000000, 100,    56.56,        0.1001
       true,   100000,   1, 11095.63,        5.0057
       true,   100000,  10,  1132.34,        0.3956
       true,   100000, 100,   196.42,        0.0577
```