### PR TITLE
Split out Ctf_unix module

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,10 @@ The library can write traces in CTF format, showing when threads (fibres) are cr
 We can run the previous code with tracing enabled (writing to a new `trace.ctf` file) like this:
 
 ```ocaml
+# #require "ctf.unix";;
 # let () =
-    let buffer = Ctf.Unix.mmap_buffer ~size:0x100000 "trace.ctf" in
-    let trace_config = Ctf.Control.make buffer in
-    Ctf.Control.start trace_config;
-    Eio_main.run main;
-    Ctf.Control.stop trace_config;;
+    Ctf_unix.with_tracing "trace.ctf" @@ fun () ->
+    Eio_main.run main;;
 +x = 1
 +y = 1
 +x = 2

--- a/lib_ctf/ctf.mli
+++ b/lib_ctf/ctf.mli
@@ -87,16 +87,12 @@ val note_signal : ?src:id -> id -> unit
 
 type log_buffer = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
-module Unix : sig
-  val mmap_buffer : size:int -> string -> log_buffer
-  (** [mmap_buffer ~size path] initialises file [path] as an empty buffer for tracing. *)
-end
-
 module Control : sig
   type t
 
-  val make : log_buffer -> t
-  (** [make b] is a trace buffer that record events in [b]. *)
+  val make : timestamper:(log_buffer -> int -> unit) -> log_buffer -> t
+  (** [make ~timestamper b] is a trace buffer that record events in [b].
+      In most cases, the {!Ctf_unix} module provides a simpler interface. *)
 
   val start : t -> unit
   (** [start t] begins recording events in [t]. *)
@@ -104,4 +100,3 @@ module Control : sig
   val stop : t -> unit
   (** [stop t] stops recording to [t] (which must be the current trace buffer). *)
 end
-

--- a/lib_ctf/dune
+++ b/lib_ctf/dune
@@ -2,4 +2,4 @@
   (name ctf)
   (public_name ctf)
   (preprocess (pps ppx_cstruct))
-  (libraries cstruct ocplib-endian.bigstring mtime mtime.clock.os))
+  (libraries cstruct ocplib-endian.bigstring mtime))

--- a/lib_ctf/unix/ctf_unix.ml
+++ b/lib_ctf/unix/ctf_unix.ml
@@ -1,0 +1,19 @@
+open Bigarray
+
+let timestamper log_buffer ofs =
+  let ns = Mtime.to_uint64_ns @@ Mtime_clock.now () in
+  EndianBigstring.LittleEndian.set_int64 log_buffer ofs ns
+
+let mmap_buffer ~size path =
+  let fd = Unix.(openfile path [O_RDWR; O_CREAT; O_TRUNC] 0o644) in
+  Unix.set_close_on_exec fd;
+  Unix.ftruncate fd size;
+  let ba = array1_of_genarray (Unix.map_file fd char c_layout true [| size |]) in
+  Unix.close fd;
+  ba
+
+let with_tracing ?(size=0x100000) path fn =
+  let buffer = mmap_buffer ~size path in
+  let trace_config = Ctf.Control.make ~timestamper buffer in
+  Ctf.Control.start trace_config;
+  Fun.protect fn ~finally:(fun () -> Ctf.Control.stop trace_config)

--- a/lib_ctf/unix/ctf_unix.mli
+++ b/lib_ctf/unix/ctf_unix.mli
@@ -1,0 +1,9 @@
+val timestamper : Ctf.log_buffer -> int -> unit
+(** Uses [Mtime_clock] to write timestamps. *)
+
+val mmap_buffer : size:int -> string -> Ctf.log_buffer
+(** [mmap_buffer ~size path] initialises file [path] as an empty buffer for tracing. *)
+
+val with_tracing : ?size:int -> string -> (unit -> 'a) -> 'a
+(** [with_tracing path fn] is a convenience function that uses {!mmap_buffer} to create a log buffer,
+    calls {!Control.start} to start recording, runs [fn], and then stops recording. *)

--- a/lib_ctf/unix/dune
+++ b/lib_ctf/unix/dune
@@ -1,0 +1,4 @@
+(library
+  (name ctf_unix)
+  (public_name ctf.unix)
+  (libraries ctf unix mtime.clock.os))

--- a/tests/test_domains.md
+++ b/tests/test_domains.md
@@ -25,12 +25,13 @@ Spawning a second domain:
 ```
 
 The domain raises an exception:
+XXX: disabled due to https://github.com/ocaml-multicore/ocaml-multicore/issues/770
 
-```ocaml
-# run @@ fun mgr ->
-  Eio.Domain_manager.run mgr (fun () -> failwith "Exception from new domain");;
-Exception: Failure "Exception from new domain".
-```
+        ```ocaml
+        # run @@ fun mgr ->
+          Eio.Domain_manager.run mgr (fun () -> failwith "Exception from new domain");;
+        Exception: Failure "Exception from new domain".
+        ```
 
 We can still run other fibres in the main domain while waiting.
 Here, we use a mutex to check that the parent domain really did run while waiting for the child domain.


### PR DESCRIPTION
This helps avoid Eio getting a dependency on Unix. Also, added `Ctf_unix.with_tracing` as a convenience function.