### PR TITLE
Make cancellation thread-safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,9 @@ bench:
 	dune exec -- ./bench/bench_promise.exe
 	dune exec -- ./bench/bench_stream.exe
 	dune exec -- ./bench/bench_semaphore.exe
+	dune exec -- ./bench/bench_cancel.exe
 	dune exec -- ./lib_eio_linux/tests/bench_noop.exe
+
+test_luv:
+	rm -rf _build
+	EIO_BACKEND=luv dune runtest

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,4 @@ bench:
 	dune exec -- ./bench/bench_promise.exe
 	dune exec -- ./bench/bench_stream.exe
 	dune exec -- ./bench/bench_semaphore.exe
+	dune exec -- ./lib_eio_linux/tests/bench_noop.exe

--- a/bench/bench_cancel.ml
+++ b/bench/bench_cancel.ml
@@ -1,0 +1,63 @@
+open Eio.Std
+
+(* The main domain spawns two other domains, connected to each by a stream.
+   It keeps reading from whichever stream is ready first, cancelling the other read.
+   This tests the time needed to set up and tear down cancellation contexts and
+   tests that cancellation can happen in parallel with success. *)
+
+let n_iters = 100_000
+
+let run_sender ~exit stream =
+  Fibre.first
+    (fun () ->
+       for i = 1 to n_iters do
+         Eio.Stream.add stream i
+       done;
+    )
+    (fun () -> Promise.await exit)
+
+let run_bench ?domain_mgr ~clock () =
+  let stream1 = Eio.Stream.create 1 in
+  let stream2 = Eio.Stream.create 1 in
+  (* todo: implement cross-domain cancellation to get rid of this hack *)
+  let exit, set_exit = Promise.create () in
+  let run_sender stream () =
+    match domain_mgr with
+    | Some dm -> Eio.Domain_manager.run dm (fun () -> run_sender ~exit stream)
+    | None -> run_sender ~exit stream
+  in
+  Gc.full_major ();
+  let _minor0, prom0, _major0 = Gc.counters () in
+  let t0 = Eio.Time.now clock in
+  Switch.run (fun sw ->
+      try
+        Fibre.fork_ignore ~sw (run_sender stream1);
+        Fibre.fork_ignore ~sw (run_sender stream2);
+        for _ = 1 to n_iters do
+          ignore @@
+          Fibre.first
+            (fun () -> Eio.Stream.take stream1)
+            (fun () -> Eio.Stream.take stream2)
+        done;
+        Promise.fulfill set_exit ()
+      with ex ->
+        Promise.break set_exit ex;
+        raise ex
+    );
+  let t1 = Eio.Time.now clock in
+  let time_total = t1 -. t0 in
+  let time_per_iter = time_total /. float n_iters in
+  let _minor1, prom1, _major1 = Gc.counters () in
+  let prom = prom1 -. prom0 in
+  Printf.printf "%11b, %7.2f, %13.4f\n%!" (domain_mgr <> None) (1e9 *. time_per_iter) (prom /. float n_iters)
+
+let main ~domain_mgr ~clock =
+  Printf.printf "use_domains,  ns/iter, promoted/iter\n%!";
+  run_bench ~clock ();
+  run_bench ~domain_mgr ~clock ()
+
+let () =
+  Eio_main.run @@ fun env ->
+  main
+    ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+    ~clock:(Eio.Stdenv.clock env)

--- a/bench/dune
+++ b/bench/dune
@@ -1,4 +1,3 @@
 (executables
-  (names bench bench_stream bench_promise bench_semaphore bench_yield)
-  (enabled_if (= %{system} "linux"))
+  (names bench_stream bench_promise bench_semaphore bench_yield)
   (libraries eio_main))

--- a/bench/dune
+++ b/bench/dune
@@ -1,3 +1,3 @@
 (executables
-  (names bench_stream bench_promise bench_semaphore bench_yield)
+  (names bench_stream bench_promise bench_semaphore bench_yield bench_cancel)
   (libraries eio_main))

--- a/lib_eio/cancel.ml
+++ b/lib_eio/cancel.ml
@@ -11,20 +11,31 @@ let () =
   | _ -> None
 
 type state =
-  | On of (exn -> unit) Lwt_dllist.t
+  | On
   | Cancelling of exn * Printexc.raw_backtrace
   | Finished
 
+(* There is a tree of cancellation contexts for each domain.
+   A fibre is always in exactly one context, but can move to a new child and back (see [sub]).
+   While a fibre is performing a cancellable operation, it sets a cancel function.
+   When a context is cancelled, we attempt to call and remove each fibre's cancellation function, if any.
+   Cancelling always happens from the fibre's own domain, but the cancellation function may be removed
+   from another domain as soon as an operation is known to have succeeded.
+   An operation may either finish normally or be cancelled;
+   whoever manages to clear the cancellation function is responsible for resuming the continuation.
+   If cancelled, this is done by calling the cancellation function. *)
 type t = {
   mutable state : state;
   parent : t;
   children : t Lwt_dllist.t;
+  fibres : fibre_context Lwt_dllist.t;
   protected : bool;
 }
-
-type fibre_context = {
+and fibre_context = {
   tid : Ctf.id;
-  mutable cancel : t;
+  mutable cancel_context : t;
+  mutable cancel_node : fibre_context Lwt_dllist.node option; (* Our entry in [cancel_context.fibres] *)
+  cancel_fn : (exn -> unit) option Atomic.t;
 }
 
 (* A dummy value for bootstrapping *)
@@ -32,6 +43,7 @@ let rec boot = {
   state = Finished;
   parent = boot;
   children = Lwt_dllist.create ();
+  fibres = Lwt_dllist.create ();
   protected = false;
 }
 
@@ -39,66 +51,74 @@ type _ eff += Get_context : fibre_context eff
 
 let cancelled t =
   match t.state with
-  | On _ -> false
+  | On -> false
   | Cancelling _ -> true
   | Finished -> invalid_arg "Cancellation context finished!"
 
 let check t =
   match t.state with
-  | On _ -> ()
+  | On -> ()
   | Cancelling (ex, _) -> raise (Cancelled ex)
   | Finished -> invalid_arg "Cancellation context finished!"
 
 let get_error t =
   match t.state with
-  | On _ -> None
+  | On -> None
   | Cancelling (ex, _) -> Some (Cancelled ex)
   | Finished -> Some (Invalid_argument "Cancellation context finished!")
 
 let is_finished t =
   match t.state with
   | Finished -> true
-  | On _ | Cancelling _ -> false
+  | On | Cancelling _ -> false
+
+let move_fibre_to t fibre =
+  let new_node = Lwt_dllist.add_r fibre t.fibres in     (* Add to new context *)
+  fibre.cancel_context <- t;
+  Option.iter Lwt_dllist.remove fibre.cancel_node;      (* Remove from old context *)
+  fibre.cancel_node <- Some new_node
 
 (* Runs [fn] with a fresh cancellation context. *)
-let with_cc ~ctx ~parent ~protected fn =
-  let q = Lwt_dllist.create () in
+let with_cc ~ctx:fibre ~parent ~protected fn =
   let children = Lwt_dllist.create () in
-  let t = { state = On q; parent; children; protected } in
+  let fibres = Lwt_dllist.create () in
+  let t = { state = On; parent; children; protected; fibres } in
   let node = Lwt_dllist.add_r t parent.children in
-  ctx.cancel <- t;
+  move_fibre_to t fibre;
+  let cleanup () =
+    move_fibre_to parent fibre;
+    t.state <- Finished;
+    Lwt_dllist.remove node
+  in
   match fn t with
-  | x            -> ctx.cancel <- t.parent; t.state <- Finished; Lwt_dllist.remove node; x
-  | exception ex -> ctx.cancel <- t.parent; t.state <- Finished; Lwt_dllist.remove node; raise ex
+  | x            -> cleanup (); x
+  | exception ex -> cleanup (); raise ex
 
 let protect fn =
   let ctx = perform Get_context in
-  with_cc ~ctx ~parent:ctx.cancel ~protected:true @@ fun t ->
+  with_cc ~ctx ~parent:ctx.cancel_context ~protected:true @@ fun t ->
   let x = fn () in
   check t;
   x
-
-let add_hook t hook =
-  match t.state with
-  | Finished -> invalid_arg "Cancellation context finished!"
-  | Cancelling (ex, _) -> protect (fun () -> hook (Cancelled ex)); Hook.null
-  | On q -> Hook.Node (Lwt_dllist.add_r hook q)
 
 let rec cancel t ex =
   match t.state with
   | Finished -> invalid_arg "Cancellation context finished!"
   | Cancelling _ -> ()
-  | On q ->
+  | On ->
     let bt = Printexc.get_raw_backtrace () in
     t.state <- Cancelling (ex, bt);
     let cex = Cancelled ex in
     let rec aux () =
-      match Lwt_dllist.take_opt_r q with
+      match Lwt_dllist.take_opt_r t.fibres with
       | None -> Lwt_dllist.fold_r (cancel_child ex) t.children []
-      | Some f ->
-        match f cex with
-        | () -> aux ()
-        | exception ex2 -> ex2 :: aux ()
+      | Some fibre ->
+        match Atomic.exchange fibre.cancel_fn None with
+        | None -> aux ()        (* The operation succeeded and so can't be cancelled now *)
+        | Some cancel_fn ->
+          match cancel_fn cex with
+          | () -> aux ()
+          | exception ex2 -> ex2 :: aux ()
     in
     match protect aux with
     | [] -> ()
@@ -111,7 +131,7 @@ and cancel_child ex t acc =
 
 let sub fn =
   let ctx = perform Get_context in
-  with_cc ~ctx ~parent:ctx.cancel ~protected:false @@ fun t ->
+  with_cc ~ctx ~parent:ctx.cancel_context ~protected:false @@ fun t ->
   let x =
     match fn t with
     | x ->
@@ -122,7 +142,7 @@ let sub fn =
       raise ex
   in
   match t.state with
-  | On _ -> x
+  | On -> x
   | Cancelling (ex, bt) -> Printexc.raise_with_backtrace ex bt
   | Finished -> invalid_arg "Cancellation context finished!"
 
@@ -130,6 +150,30 @@ let sub fn =
    (instead, return the parent context on exit so the caller can check that) *)
 let sub_unchecked fn =
   let ctx = perform Get_context in
-  with_cc ~ctx ~parent:ctx.cancel ~protected:false @@ fun t ->
+  with_cc ~ctx ~parent:ctx.cancel_context ~protected:false @@ fun t ->
   fn t;
   t.parent
+
+module Fibre_context = struct
+  type t = fibre_context
+
+  let tid t = t.tid
+  let cancellation_context t = t.cancel_context
+
+  let get_error t = get_error t.cancel_context
+
+  let set_cancel_fn t fn =
+    (* if Atomic.exchange t.cancel_fn (Some fn) <> None then failwith "Fibre already has a cancel function!" *)
+    Atomic.set t.cancel_fn (Some fn)
+
+  let clear_cancel_fn t =
+    Atomic.exchange t.cancel_fn None <> None
+
+  let make ~tid ~cc =
+    let t = { tid; cancel_context = cc; cancel_node = None; cancel_fn = Atomic.make None } in
+    t.cancel_node <- Some (Lwt_dllist.add_r t cc.fibres);
+    t
+
+  let destroy t =
+    Option.iter Lwt_dllist.remove t.cancel_node
+end

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -259,10 +259,7 @@ module Stdenv = struct
 end
 
 module Private = struct
-  type context = Cancel.fibre_context = {
-    tid : Ctf.id;
-    mutable cancel : Cancel.t;
-  }
+  module Fibre_context = Cancel.Fibre_context
 
   module Effects = struct
     type 'a enqueue = 'a Suspend.enqueue

--- a/lib_eio/suspend.ml
+++ b/lib_eio/suspend.ml
@@ -7,6 +7,6 @@ let enter_unchecked fn = perform (Suspend fn)
 
 let enter fn =
   enter_unchecked @@ fun fibre enqueue ->
-  match Cancel.get_error fibre.cancel with
+  match Cancel.Fibre_context.get_error fibre with
   | None -> fn fibre enqueue
   | Some ex -> enqueue (Error ex)

--- a/lib_eio_linux/tests/bench_noop.ml
+++ b/lib_eio_linux/tests/bench_noop.ml
@@ -28,5 +28,5 @@ let main ~clock =
     )
 
 let () =
-  Eio_main.run @@ fun env ->
+  Eio_linux.run @@ fun env ->
   main ~clock:(Eio.Stdenv.clock env)

--- a/lib_eio_linux/tests/dune
+++ b/lib_eio_linux/tests/dune
@@ -16,6 +16,12 @@
  (modules basic_eio_linux)
  (libraries logs.fmt fmt.tty eurcp_lib))
 
+(executables
+  (names bench_noop)
+  (enabled_if (= %{system} "linux"))
+  (modules bench_noop)
+  (libraries eio_linux))
+
 (test
  (name test)
  (package eio_linux)

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -23,10 +23,11 @@ exception Luv_error of Luv.Error.t
 val or_raise : 'a or_error -> 'a
 (** [or_error (Error e)] raises [Luv_error e]. *)
 
-val await : (Luv.Loop.t -> Eio.Private.context -> ('a -> unit) -> unit) -> 'a
-(** [await fn] converts a function using a luv-style callback to one using effects.
-    Use it as e.g. [await (fun loop fibre -> Luv.File.realpath ~loop path)].
-    Use [fibre] to implement cancellation. *)
+val await_with_cancel :
+  request:[< `File | `Addr_info | `Name_info | `Random | `Thread_pool ] Luv.Request.t ->
+  (Luv.Loop.t -> ('a -> unit) -> unit) -> 'a
+(** [await_with_cancel ~request fn] converts a function using a luv-style callback to one using effects.
+    It sets the fibre's cancel function to cancel [request], and clears it when the operation completes. *)
 
 (** {1 Time functions} *)
 

--- a/lib_eunix/suspended.ml
+++ b/lib_eunix/suspended.ml
@@ -1,14 +1,16 @@
 open EffectHandlers.Deep
 
 type 'a t = {
-  fibre : Eio.Private.context;
+  fibre : Eio.Private.Fibre_context.t;
   k : ('a, [`Exit_scheduler]) continuation;
 }
 
+let tid t = Eio.Private.Fibre_context.tid t.fibre
+
 let continue t v =
-  Ctf.note_switch t.fibre.tid;
+  Ctf.note_switch (tid t);
   continue t.k v
 
 let discontinue t ex =
-  Ctf.note_switch t.fibre.tid;
+  Ctf.note_switch (tid t);
   discontinue t.k ex

--- a/lib_eunix/zzz.mli
+++ b/lib_eunix/zzz.mli
@@ -8,13 +8,15 @@ type t
 val create : unit -> t
 (** [create ()] is a fresh empty queue. *)
 
-val add : cancel_hook:Eio.Hook.t ref -> t -> float -> unit Suspended.t -> Key.t
-(** [add ~cancel_hook t time thread] adds a new event, due at [time], and returns its ID.
-    [cancel_hook] will be released when the event is later returned by {!pop}. *)
+val add : t -> float -> unit Suspended.t -> Key.t
+(** [add t time thread] adds a new event, due at [time], and returns its ID.
+    You must use {!Eio.Private.Fibre_context.set_cancel_fn} on [thread] before
+    calling {!pop}. *)
 
 val remove : t -> Key.t -> unit
 (** [remove t key] removes an event previously added with [add]. *)
 
 val pop : t -> now:float -> [`Due of unit Suspended.t | `Wait_until of float | `Nothing]
 (** [pop ~now t] removes and returns the earliest thread due by [now].
+    It also clears the thread's cancel function.
     If no thread is due yet, it returns the time the earliest thread becomes due. *)


### PR DESCRIPTION
Previously, each cancellation context kept a list of functions to call when cancelled. When a cancellable operation starts, a function is registered which can be used to cancel it. When the operation finishes (or is cancelled) the function is removed again.

With multiple domains, an operation may succeed in one domain just as it is being cancelled in another. Since removing a node from a doubly-linked list cannot be done atomically, this would require a mutex.

Instead, a cancellation context now keeps a list of fibres. When a fibre is forked, it gets added to the list, and when it finishes it is removed. A fibre can also move to a new context (e.g. on `Cancel.sub`). This list is only accessed from the fibre's own domain.

Each fibre holds a single (atomic, optional) cancellation function. This is set when a cancellable operation starts. When the operation is cancelled or finishes, this is cleared (using `Atomic.exchange`) and the continuation is enqueued to be run.