### PR TITLE
Clean up Waiters API

### DIFF
--- a/lib_eio/promise.ml
+++ b/lib_eio/promise.ml
@@ -24,7 +24,7 @@
 type 'a state =
   | Fulfilled of 'a
   | Broken of exn
-  | Unresolved of 'a Waiters.t * Mutex.t
+  | Unresolved of ('a, exn) result Waiters.t * Mutex.t
   (* The Unresolved state's mutex box contains:
      - Full access to the Waiters.
      - Half access to the promise's state.

--- a/lib_eio/semaphore.ml
+++ b/lib_eio/semaphore.ml
@@ -25,7 +25,7 @@ let release t =
   | Free x when x = max_int -> Mutex.unlock t.mutex; raise (Sys_error "semaphore would overflow max_int!")
   | Free x -> t.state <- Free (succ x); Mutex.unlock t.mutex
   | Waiting q ->
-    begin match Waiters.wake_one q (Ok ()) with
+    begin match Waiters.wake_one q () with
       | `Ok -> ()
       | `Queue_empty -> t.state <- Free 1
     end;
@@ -36,7 +36,7 @@ let rec acquire t =
   match t.state with
   | Waiting q ->
     Ctf.note_try_read t.id;
-    Waiters.await ~mutex:(Some t.mutex) q t.id |> Switch.or_raise
+    Waiters.await ~mutex:(Some t.mutex) q t.id
   | Free 0 ->
     t.state <- Waiting (Waiters.create ());
     Mutex.unlock t.mutex;

--- a/lib_eio/switch.ml
+++ b/lib_eio/switch.ml
@@ -37,7 +37,7 @@ let with_op t fn =
     ~finally:(fun () ->
         t.fibres <- t.fibres - 1;
         if t.fibres = 0 then
-          Waiters.wake_all t.waiter (Ok ())
+          Waiters.wake_all t.waiter ()
       )
 
 let or_raise = function
@@ -48,7 +48,7 @@ let rec await_idle t =
   (* Wait for fibres to finish: *)
   while t.fibres > 0 do
     Ctf.note_try_read t.id;
-    Waiters.await ~mutex:None t.waiter t.id |> or_raise;
+    Waiters.await ~mutex:None t.waiter t.id
   done;
   (* Call on_release handlers: *)
   let queue = Lwt_dllist.create () in

--- a/lib_eio/waiters.ml
+++ b/lib_eio/waiters.ml
@@ -1,4 +1,4 @@
-type 'a t = (('a, exn) result -> unit) Lwt_dllist.t
+type 'a t = ('a -> unit) Lwt_dllist.t
 
 let create = Lwt_dllist.create
 

--- a/lib_eio/waiters.mli
+++ b/lib_eio/waiters.mli
@@ -1,25 +1,51 @@
 type 'a t
+(* A queue of fibres waiting for something.
+   Note: an [_ t] is not thread-safe itself.
+   To use share it between domains, the user is responsible for wrapping it in a mutex. *)
 
 val create : unit -> 'a t
-val add_waiter_protected : mutex:Mutex.t -> 'a t -> (('a, exn) result -> unit) -> Hook.t
+
 val add_waiter : 'a t -> (('a, exn) result -> unit) -> Hook.t
+(** [add_waiter t fn] adds [fn] to the queue of functions to call when the wait is over.
+    It returns a hook which can be used to remove [fn] from the queue to cancel the wait.
+    Note: Removing the hook is not thread-safe, even if the call to [add_waiter] itself
+    is protected by a mutex, so use {!add_waiter_protected} if [t] can be shared between domains. *)
+
+val add_waiter_protected : mutex:Mutex.t -> 'a t -> (('a, exn) result -> unit) -> Hook.t
+(** [add_waiter_protected ~mutex t fn] is like {!add_waiter}, but will take [mutex] when removing the hook.
+    The caller must also have [mutex] locked when calling this. *)
+
 val wake_all : 'a t -> ('a, exn) result -> unit
+(** [wake_all t] calls (and removes) all the functions waiting on [t].
+    If [t] is shared between domains, the caller must hold the mutex while calling this. *)
+
 val wake_one : 'a t -> ('a, exn) result -> [`Ok | `Queue_empty]
+(** [wake_one t] is like {!wake_all}, but only calls (and removes) the first waiter in the queue.
+    If [t] is shared between domains, the caller must hold the mutex while calling this. *)
+
 val is_empty : 'a t -> bool
+(** [is_empty t] checks whether there are any functions waiting on [t].
+    If [t] is shared between domains, the caller must hold the mutex while calling this,
+    and the result is valid until the mutex is released. *)
 
 val await :
   mutex:Mutex.t option ->
   'a t -> Ctf.id -> ('a, exn) result
 (** [await ~mutex t id] suspends the current fibre and adds its continuation to [t].
     When the waiter is woken, the fibre is resumed and returns the result.
-   If [t] can be used from multiple domains,
-   [mutex] must be set to the mutex to use to unlock it.
-   [mutex] should be already held when calling this function,
-   which will unlock it before blocking. *)
+    If [t] can be used from multiple domains:
+    - [mutex] must be set to the mutex to use to unlock it.
+    - [mutex] must be already held when calling this function, which will unlock it before blocking.
+    When [await] returns, [mutex] will have been unlocked.
+    @raise Cancel.Cancelled if the fibre's context is cancelled *)
 
 val await_internal :
   mutex:Mutex.t option ->
   'a t -> Ctf.id -> Cancel.fibre_context ->
   ((('a, exn) result, exn) result -> unit) -> unit
-(** [await_internal] is like [await], but the caller has to suspend the fibre.
-    This also allows wrapping the enqueue funciton. *)
+(** [await_internal ~mutex t id ctx enqueue] is like [await], but the caller has to suspend the fibre.
+    This also allows wrapping the [enqueue] function.
+    Calls [enqueue (Error (Cancelled _))] if cancelled.
+    Note: [enqueue] is called from the triggering domain,
+          which is currently calling {!wake_one} or {!wake_all}
+          and must therefore be holding [mutex]. *)

--- a/tests/test_stream.md
+++ b/tests/test_stream.md
@@ -286,3 +286,32 @@ Writers queue up:
 +Added 3 to stream
 - : unit = ()
 ```
+
+Cancelling writing to a stream:
+
+```ocaml
+# run @@ fun () ->
+  let t = S.create 1 in
+  add t 0;
+  Switch.run @@ fun sw ->
+  try
+    Fibre.both
+      (fun () -> add t 1)
+      (fun () -> raise Cancel)
+  with Cancel ->
+    traceln "Cancelled";
+    take t;
+    add t 2;
+    take t;;
++Adding 0 to stream
++Added 0 to stream
++Adding 1 to stream
++Cancelled
++Reading from stream
++Got 0 from stream
++Adding 2 to stream
++Added 2 to stream
++Reading from stream
++Got 2 from stream
+- : unit = ()
+```


### PR DESCRIPTION
- Add documentation.
- Remove result type. Many users didn't actually need a result type!