### PR TITLE
Make Waiters.wake_one safe with cancellation

### DIFF
--- a/lib_eio/waiters.mli
+++ b/lib_eio/waiters.mli
@@ -5,16 +5,6 @@ type 'a t
 
 val create : unit -> 'a t
 
-val add_waiter : 'a t -> ('a -> unit) -> Hook.t
-(** [add_waiter t fn] adds [fn] to the queue of functions to call when the wait is over.
-    It returns a hook which can be used to remove [fn] from the queue to cancel the wait.
-    Note: Removing the hook is not thread-safe, even if the call to [add_waiter] itself
-    is protected by a mutex, so use {!add_waiter_protected} if [t] can be shared between domains. *)
-
-val add_waiter_protected : mutex:Mutex.t -> 'a t -> ('a -> unit) -> Hook.t
-(** [add_waiter_protected ~mutex t fn] is like {!add_waiter}, but will take [mutex] when removing the hook.
-    The caller must also have [mutex] locked when calling this. *)
-
 val wake_all : 'a t -> 'a -> unit
 (** [wake_all t] calls (and removes) all the functions waiting on [t].
     If [t] is shared between domains, the caller must hold the mutex while calling this. *)

--- a/stress/dune
+++ b/stress/dune
@@ -1,0 +1,3 @@
+(executables
+  (names stress_semaphore)
+  (libraries eio_main))

--- a/stress/stress_semaphore.ml
+++ b/stress/stress_semaphore.ml
@@ -1,0 +1,38 @@
+open Eio.Std
+
+(* Three domains fighting over 2 semaphore tokens,
+   with domains cancelling if they don't get served quickly. *)
+
+let n_domains = 3
+let n_tokens = 2
+let n_iters = 100_000
+
+let main ~domain_mgr =
+  let sem = Eio.Semaphore.make n_tokens in
+  Switch.run (fun sw ->
+      for _ = 1 to n_domains do
+        Fibre.fork_ignore ~sw (fun () ->
+            Eio.Domain_manager.run domain_mgr (fun () ->
+                let i = ref 0 in
+                while !i < n_iters do
+                  let got = ref false in
+                  Fibre.first
+                    (fun () -> Eio.Semaphore.acquire sem; got := true)
+                    (fun () -> Fibre.yield ());
+                  if !got then (
+                    incr i;
+                    Eio.Semaphore.release sem;
+                  ) else (
+                    (* traceln "yield" *)
+                  )
+                done
+              )
+          )
+      done;
+    );
+  assert (Eio.Semaphore.get_value sem = n_tokens);
+  print_endline "OK"
+
+let () =
+  Eio_main.run @@ fun env ->
+  main ~domain_mgr:(Eio.Stdenv.domain_mgr env)


### PR DESCRIPTION
Before, if we cancelled a waiter just as `wake_one` was being called (which can happen when using multiple domains) then we could end up not waking anything.