### PR TITLE
Restore domains test

### DIFF
--- a/tests/test_domains.md
+++ b/tests/test_domains.md
@@ -25,13 +25,12 @@ Spawning a second domain:
 ```
 
 The domain raises an exception:
-XXX: disabled due to https://github.com/ocaml-multicore/ocaml-multicore/issues/770
 
-        ```ocaml
-        # run @@ fun mgr ->
-          Eio.Domain_manager.run mgr (fun () -> failwith "Exception from new domain");;
-        Exception: Failure "Exception from new domain".
-        ```
+```ocaml
+# run @@ fun mgr ->
+  Eio.Domain_manager.run mgr (fun () -> failwith "Exception from new domain");;
+Exception: Failure "Exception from new domain".
+```
 
 We can still run other fibres in the main domain while waiting.
 Here, we use a mutex to check that the parent domain really did run while waiting for the child domain.


### PR DESCRIPTION
The fix to ocaml-multicore has been back-ported to 4.12+domains and is now being used by CI.