### PR TITLE
Allow `Domain_mgr.run` to be cancelled

### DIFF
--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -168,8 +168,36 @@ module Domain_manager = struct
     method virtual run_raw : 'a. (unit -> 'a) -> 'a
   end
 
-  let run (t : #t) = t#run
   let run_raw (t : #t) = t#run_raw
+
+  let run (t : #t) fn =
+    let ctx = perform Cancel.Get_context in
+    Cancel.check ctx.cancel_context;
+    let cancelled, set_cancelled = Promise.create () in
+    Cancel.Fibre_context.set_cancel_fn ctx (Promise.fulfill set_cancelled);
+    (* If the spawning fibre is cancelled, [cancelled] gets set to the exception. *)
+    match
+      t#run @@ fun () ->
+      Fibre.first
+        (fun () ->
+           match Promise.await cancelled with
+           | Cancel.Cancelled ex -> raise ex    (* To avoid [Cancelled (Cancelled ex))] *)
+           | ex -> raise ex (* Shouldn't happen *)
+        )
+        fn
+    with
+    | x ->
+      ignore (Cancel.Fibre_context.clear_cancel_fn ctx : bool);
+      x
+    | exception ex ->
+      ignore (Cancel.Fibre_context.clear_cancel_fn ctx : bool);
+      match Promise.state cancelled with
+      | `Fulfilled (Cancel.Cancelled ex2 as cex) when ex == ex2 ->
+        (* We unwrapped the exception above to avoid a double cancelled exception.
+           But this means that the top-level reported the original exception,
+           which isn't what we want. *)
+        raise cex
+      | _ -> raise ex
 end
 
 module Time = struct

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -449,15 +449,18 @@ end
 
 module Domain_manager : sig
   class virtual t : object
-    method virtual run : 'a. (unit -> 'a) -> 'a
     method virtual run_raw : 'a. (unit -> 'a) -> 'a
+
+    method virtual run : 'a. (unit -> 'a) -> 'a
+    (** Note: cancellation is handled by the {!run} wrapper function, not the object. *)
   end
 
   val run : #t -> (unit -> 'a) -> 'a
   (** [run t f] runs [f ()] in a newly-created domain and returns the result.
       Other fibres in the calling domain can run in parallel with the new domain.
       Warning: [f] must only access thread-safe values from the calling domain,
-      but this is not enforced by the type system. *)
+      but this is not enforced by the type system.
+      If the calling fibre is cancelled, this is propagated to the spawned domain. *)
 
   val run_raw : #t -> (unit -> 'a) -> 'a
   (** [run_raw t f] is like {!run}, but does not run an event loop in the new domain,

--- a/tests/test_domains.md
+++ b/tests/test_domains.md
@@ -77,3 +77,13 @@ Cancelling another domain:
 +Spawning fibre got Cancelled: Failure("Simulated error")
 Exception: Failure "Simulated error".
 ```
+
+Spawning when already cancelled - no new domain is started:
+
+```ocaml
+# run @@ fun mgr ->
+  Switch.run @@ fun sw ->
+  Switch.turn_off sw (Failure "Simulated error");
+  Eio.Domain_manager.run mgr (fun () -> traceln "Domain spawned - shouldn't happen!");;
+Exception: Failure "Simulated error".
+```

--- a/tests/test_domains.md
+++ b/tests/test_domains.md
@@ -58,3 +58,22 @@ Here, we use a mutex to check that the parent domain really did run while waitin
 +Got "Hello from new domain" from spawned domain
 - : unit = ()
 ```
+
+Cancelling another domain:
+
+```ocaml
+# run @@ fun mgr ->
+  Fibre.both
+    (fun () ->
+       try
+         Eio.Domain_manager.run mgr (fun () ->
+           try Fibre.await_cancel ()
+           with ex -> traceln "Spawned domain got %a" Fmt.exn ex; raise ex
+         )
+       with ex -> traceln "Spawning fibre got %a" Fmt.exn ex; raise ex
+    )
+    (fun () -> failwith "Simulated error");;
++Spawned domain got Cancelled: Failure("Simulated error")
++Spawning fibre got Cancelled: Failure("Simulated error")
+Exception: Failure "Simulated error".
+```


### PR DESCRIPTION
The cancel exception is injected into to the spawned domain.