### PR TITLE
Create fibre context before forking

### DIFF
--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -298,5 +298,4 @@ module Private = struct
       | Get_context = Cancel.Get_context
       | Trace = Std.Trace
   end
-  let boot_cancel = Cancel.boot
 end


### PR DESCRIPTION
This moves some more logic out of the individual backends and reduces the number of contexts we need to create. It should also allow more flexibility in scheduling things, since it allows a fibre to be created without being started immediately.