### PR TITLE
Benchmark various copying systems (not for merging)

### DIFF
--- a/lib_eio_linux/tests/eurcp_lib.ml
+++ b/lib_eio_linux/tests/eurcp_lib.ml
@@ -5,28 +5,59 @@ open Eio.Std
 module U = Eio_linux
 module Int63 = Optint.Int63
 
-let read_then_write_chunk infd outfd file_offset len =
-  let buf = U.alloc () in
-  Logs.debug (fun l -> l "r/w start %a (%d)" Int63.pp file_offset len);
-  U.read_exactly ~file_offset infd buf len;
-  U.write ~file_offset outfd buf len;
-  Logs.debug (fun l -> l "r/w done  %a (%d)" Int63.pp file_offset len);
-  U.free buf
+let fibres = Eio.Semaphore.make 64
 
-let copy_file infd outfd insize block_size =
+(* Fill [buf] from [infd], starting the read at [file_offset]. *)
+let rec read_exactly ~file_offset infd buf =
+  let got = U.readv ~file_offset infd [buf] in
+  if got <> Cstruct.length buf then
+    read_exactly ~file_offset:(Int63.add file_offset (Int63.of_int got)) infd (Cstruct.shift buf got)
+
+(* Various copy techniques *)
+module Copy_chunk = struct
+
+  (* Use the special fixed buffer operations for the copy (the original version) *)
+  let fixed_buffer infd outfd file_offset len =
+    let buf = U.alloc () in
+    U.read_exactly ~file_offset infd buf len;
+    U.write ~file_offset outfd buf len;
+    U.free buf
+
+  (* Allocate a fresh cstruct and use that with the plain [readv]/[writev]. *)
+  let new_cstruct infd outfd file_offset len =
+    let buf = Cstruct.create_unsafe len in
+    read_exactly ~file_offset infd buf;
+    U.writev ~file_offset outfd [buf]
+
+  (* Use the region allocator to get the buffer, but then just use it as a regular cstruct. *)
+  let chunk_as_cstruct infd outfd file_offset len =
+    let chunk = U.alloc () in
+    let buf = Uring.Region.to_cstruct chunk ~len in
+    read_exactly ~file_offset infd buf;
+    U.writev ~file_offset outfd [buf];
+    U.free chunk
+
+end
+
+let copy_file ~copy_chunk infd outfd insize block_size =
   Switch.run @@ fun sw ->
   let rec copy_block file_offset =
     let remaining = Int63.(sub insize file_offset) in
     if remaining <> Int63.zero then (
       let len = Int63.to_int (min (Int63.of_int block_size) remaining) in
-      Fibre.fork_ignore ~sw (fun () -> read_then_write_chunk infd outfd file_offset len);
+      Eio.Semaphore.acquire fibres;
+      Fibre.fork_ignore ~sw (fun () ->
+          Logs.debug (fun l -> l "r/w start %a (%d)" Int63.pp file_offset len);
+          copy_chunk infd outfd file_offset len;
+          Logs.debug (fun l -> l "r/w done  %a (%d)" Int63.pp file_offset len);
+          Eio.Semaphore.release fibres
+        );
       copy_block Int63.(add file_offset (of_int len))
     )
   in
   copy_block Int63.zero
 
-let run_cp block_size queue_depth infile outfile () =
-  U.run ~queue_depth ~block_size @@ fun _stdenv ->
+let run_cp ~copy_chunk block_size queue_depth infile outfile () =
   Switch.run @@ fun sw ->
   let open Unix in
   let infd = Eio_linux.openfile ~sw infile [O_RDONLY] 0 in
@@ -38,5 +69,22 @@ let run_cp block_size queue_depth infile outfile () =
                  Int63.pp insize
                  queue_depth
                  block_size);
-  copy_file infd outfd insize block_size;
+  copy_file ~copy_chunk infd outfd insize block_size;
   Logs.debug (fun l -> l "eurcp: done")
+
+let run_cp block_size queue_depth infile outfile () =
+  U.run ~queue_depth ~block_size @@ fun _stdenv ->
+  let test name copy_chunk =
+    Unix.system "sync" |> ignore;
+    Gc.full_major ();
+    let t0 = Unix.gettimeofday () in
+    run_cp ~copy_chunk block_size queue_depth infile outfile ();
+    let t1 = Unix.gettimeofday () in
+    Printf.printf "%16s, %.3f\n%!" name (t1 -. t0)
+  in
+  print_endline "          method, time/s";
+  for _ = 1 to 5 do
+    test "fixed-buffer" Copy_chunk.fixed_buffer;
+    test "new-cstruct" Copy_chunk.new_cstruct;
+    test "chunk-as-cstruct" Copy_chunk.chunk_as_cstruct;
+  done


### PR DESCRIPTION
Currently, we allocate 64 4KB blocks (256 KB) per-domain as a fixed buffer. However, this often fails as systems can default to a ulimit for locked memory lower than this (e.g. https://github.com/ocaml-multicore/eio/issues/80). Also, once the system is using all its blocks, attempting to allocate more will hang the requesting fibre, possibly causing deadlock.

I tried modifying @avsm's eurcp.ml benchmark to test various ways of copying the file data. I tried three methods:

1. "fixed-buffer" is the old system, where we use `io_uring`'s fixed buffer optimisation.
2. "new-cstruct" is the normal method of allocating a fresh cstruct for each chunk and using `readv` and `writev`.
3. "chunk-as-cstruct" uses the region allocator to get chunks, but then just uses `readv`/`writev`, not the fixed-buffer API.

Copying a 1GB file, I got:
```
              method, time/s
        fixed-buffer, 0.691
        fixed-buffer, 0.702
        fixed-buffer, 0.711
        fixed-buffer, 0.717
        fixed-buffer, 0.720
         new-cstruct, 0.621
         new-cstruct, 0.648
         new-cstruct, 0.681
         new-cstruct, 0.691
         new-cstruct, 0.718
    chunk-as-cstruct, 0.660
    chunk-as-cstruct, 0.673
    chunk-as-cstruct, 0.696
    chunk-as-cstruct, 0.720
    chunk-as-cstruct, 0.720
```

![cp](https://user-images.githubusercontent.com/554131/146027453-079257d2-4dd4-475e-b5bb-850951f74b48.png)

In conclusion, the fixed buffer optimisation doesn't seem to give a noticeable speed boost, at least for this case on my computer.

Note: I added a semaphore to limit the number of active fibres to 64 in all cases. The operations using the region allocator were already limited to 64 operations due to the size of the region.