### PR TITLE
Allow to set SO_REUSEPORT option

### DIFF
--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -154,11 +154,11 @@ module Net = struct
   let accept_sub ~sw (t : #listening_socket) = t#accept_sub ~sw
 
   class virtual t = object
-    method virtual listen : reuse_addr:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> listening_socket
+    method virtual listen : reuse_addr:bool -> reuse_port:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> listening_socket
     method virtual connect : sw:Switch.t -> Sockaddr.t -> <Flow.two_way; Flow.close>
   end
 
-  let listen ?(reuse_addr=false) ~backlog ~sw (t:#t) = t#listen ~reuse_addr ~backlog ~sw
+  let listen ?(reuse_addr=false) ?(reuse_port=false) ~backlog ~sw (t:#t) = t#listen ~reuse_addr ~reuse_port ~backlog ~sw
   let connect ~sw (t:#t) = t#connect ~sw
 end
 

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -437,17 +437,18 @@ module Net : sig
       [flow] will be closed automatically when the sub-switch is finished, if not already closed by then. *)
 
   class virtual t : object
-    method virtual listen : reuse_addr:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> listening_socket
+    method virtual listen : reuse_addr:bool -> reuse_port:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> listening_socket
     method virtual connect : sw:Switch.t -> Sockaddr.t -> <Flow.two_way; Flow.close>
   end
 
-  val listen : ?reuse_addr:bool -> backlog:int -> sw:Switch.t -> #t -> Sockaddr.t -> listening_socket
+  val listen : ?reuse_addr:bool -> ?reuse_port:bool -> backlog:int -> sw:Switch.t -> #t -> Sockaddr.t -> listening_socket
   (** [listen ~sw ~backlog t addr] is a new listening socket bound to local address [addr].
       The new socket will be closed when [sw] finishes, unless closed manually first.
       For (non-abstract) Unix domain sockets, the path will be removed afterwards.
       @param backlog The number of pending connections that can be queued up (see listen(2)).
       @param reuse_addr Set the [Unix.SO_REUSEADDR] socket option.
-                        For Unix paths, also remove any stale left-over socket. *)
+                        For Unix paths, also remove any stale left-over socket.
+      @param reuse_port Set the [Unix.SO_REUSEPORT] socket option. *)
 
   val connect : sw:Switch.t -> #t -> Sockaddr.t -> <Flow.two_way; Flow.close>
   (** [connect ~sw t addr] is a new socket connected to remote address [addr].


### PR DESCRIPTION
This PR adds the option of setting SO_REUSEPORT socket option in linux_uring backend.

For libuv/luv backend, it seems it is not easy to set it as yet. This is related to another outstanding issue related to SO_REUSEADDR option in libuv backend. Perhaps once luv releases luv-unix, we can revisit this issue again. For now in-order to ensure the repo builds
I have followed a similar approach as SO_REUSEADDR, i.e. dummy function `luv_reuse_port` analogous to `luv_resuse_addr`.

SO_REUSEPORT can be used to build scalable, high performance network servers in linux version 3.9 and over. This is so because reuseport is used to enable socket sharding on multiple threads or child processes. Listening sockets with SO_REUSEPORT enabled are further
load balanced by the kernel; so we get a performant load balancer for free.

References:
https://www.nginx.com/blog/socket-sharding-nginx-release-1-9-1/
https://stackoverflow.com/questions/14388706/how-do-so-reuseaddr-and-so-reuseport-differ

SO_RESUSEADDR/SO_RESUSEPORT luv issue:
https://github.com/aantron/luv/issues/120 
