### PR TITLE
Improve scheduling of forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,10 +267,10 @@ For example:
 ```ocaml
 # Eio_main.run @@ fun _env ->
   Switch.run (fun sw ->
-    Fibre.fork_ignore ~sw
+    Fibre.fork ~sw
       (fun () -> for i = 1 to 3 do traceln "i = %d" i; Fibre.yield () done);
     traceln "First thread forked";
-    Fibre.fork_ignore ~sw
+    Fibre.fork ~sw
       (fun () -> for j = 1 to 3 do traceln "j = %d" j; Fibre.yield () done);
     traceln "Second thread forked; top-level code is finished"
   );
@@ -299,13 +299,13 @@ and any files it opened have been closed.
 So, a `Switch.run` puts a bound on the lifetime of things created within it,
 leading to clearer code and avoiding resource leaks.
 
-For example, `fork_ignore` creates a new fibre that continues running after `fork_ignore` returns,
+For example, `fork` creates a new fibre that continues running after `fork` returns,
 so it needs to take a switch argument.
 
 Every switch also creates a new cancellation context,
 and you can turn off the switch to cancel all fibres within it.
 
-You can also use `Fibre.fork_sub_ignore` to create a child sub-switch.
+You can also use `Fibre.fork_sub` to create a child sub-switch.
 Turning off the parent switch will also turn off the child switch, but turning off the child doesn't disable the parent.
 
 For example, a web-server might use one switch for the whole server and then create one sub-switch for each incoming connection.
@@ -783,7 +783,7 @@ Each item in the stream is a request payload and a resolver for the reply promis
   Switch.run @@ fun sw ->
   let stream = Eio.Stream.create 100 in
   let spawn_worker name =
-    Fibre.fork_ignore ~sw (fun () ->
+    Fibre.fork ~sw (fun () ->
        Eio.Domain_manager.run domain_mgr (fun () -> run_worker name stream)
     )
   in
@@ -791,7 +791,7 @@ Each item in the stream is a request payload and a resolver for the reply promis
   spawn_worker "B";
   Switch.run (fun sw ->
      for i = 1 to 3 do
-       Fibre.fork_ignore ~sw (fun () ->
+       Fibre.fork ~sw (fun () ->
          traceln "Client %d submitting job..." i;
          traceln "Client %d got %s" i (submit stream i)
        )

--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ For example:
 +i = 1
 +First thread forked
 +j = 1
-+i = 2
 +Second thread forked; top-level code is finished
++i = 2
 +j = 2
 +i = 3
 +j = 3
@@ -759,6 +759,7 @@ Client fibres submit items to a stream and workers process the items:
 
 ```ocaml
 let handle_job request =
+  Fibre.yield ();       (* (simulated work) *)
   Printf.sprintf "Processed:%d" request
 
 let run_worker id stream =
@@ -794,17 +795,18 @@ Each item in the stream is a request payload and a resolver for the reply promis
        Fibre.fork ~sw (fun () ->
          traceln "Client %d submitting job..." i;
          traceln "Client %d got %s" i (submit stream i)
-       )
+       );
+       Fibre.yield ()
      done;
   );
   raise Exit;;
 +Worker A ready
-+Client 1 submitting job...
 +Worker B ready
-+Client 2 submitting job...
++Client 1 submitting job...
 +Worker A processing request 1
-+Client 3 submitting job...
++Client 2 submitting job...
 +Worker B processing request 2
++Client 3 submitting job...
 +Client 1 got Processed:1
 +Worker A processing request 3
 +Client 2 got Processed:2

--- a/bench/bench_cancel.ml
+++ b/bench/bench_cancel.ml
@@ -25,8 +25,8 @@ let run_bench ?domain_mgr ~clock () =
   let t0 = Eio.Time.now clock in
   try
     Switch.run (fun sw ->
-        Fibre.fork_ignore ~sw (run_sender stream1);
-        Fibre.fork_ignore ~sw (run_sender stream2);
+        Fibre.fork ~sw (run_sender stream1);
+        Fibre.fork ~sw (run_sender stream2);
         for _ = 1 to n_iters do
           ignore @@
           Fibre.first

--- a/bench/bench_yield.ml
+++ b/bench/bench_yield.ml
@@ -11,7 +11,7 @@ let main ~clock =
       let t0 = Eio.Time.now clock in
       Switch.run (fun sw ->
           for _ = 1 to n_fibres do
-            Fibre.fork_ignore ~sw (fun () ->
+            Fibre.fork ~sw (fun () ->
                 for _ = 1 to n_iters do
                   Fibre.yield ()
                 done

--- a/doc/rationale.md
+++ b/doc/rationale.md
@@ -1,0 +1,22 @@
+This document collects some of the reasons behind various API choices in Eio.
+
+# Scheduling order
+
+When forking a new fibre, there are several reasonable scheduling behaviours:
+
+1. Append the new fibre to the run queue and then continue running the parent.
+2. Append the parent fibre to the run queue and start the child immediately.
+3. Append both old and new fibres to the run-queue (in some order), then schedule the next task at the queue's head.
+4. Prepend the old and new fibres to the *head* of the run-queue and resume one of them immediately.
+
+And several desirable features:
+
+- Especially for `Fibre.both`, putting both at the start or both at the end of the run-queue seems more consistent
+  that starting one before everything in the queue and the other after.
+- Adding both to the head of the queue is the most flexible, since the other behaviours can then be achieved by yielding.
+- Putting both at the head may lead to starvation of other fibres.
+- Running the child before the parent allows the child to e.g. create a switch and store it somewhere atomically.
+- Scheduling new work to run next can make better use of the cache in some cases (domainslib works this way).
+
+Therefore, `Fibre.fork f` runs `f` immediately and pushes the calling fibre to the head of the run-queue.
+After making this change, the examples in the README seemed a bit more natural too.

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -293,7 +293,7 @@ module Private = struct
     type 'a enqueue = 'a Suspend.enqueue
     type _ eff += 
       | Suspend = Suspend.Suspend
-      | Fork_ignore = Fibre.Fork_ignore
+      | Fork = Fibre.Fork
       | Get_context = Cancel.Get_context
       | Trace = Std.Trace
   end

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -293,7 +293,6 @@ module Private = struct
     type 'a enqueue = 'a Suspend.enqueue
     type _ eff += 
       | Suspend = Suspend.Suspend
-      | Fork = Fibre.Fork
       | Fork_ignore = Fibre.Fork_ignore
       | Get_context = Cancel.Get_context
       | Trace = Std.Trace

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -655,9 +655,6 @@ module Private : sig
           passing it the suspended fibre's context and a function to resume it.
           [fn] should arrange for [enqueue] to be called once the thread is ready to run again. *)
 
-      | Fork : Fibre_context.t * (unit -> 'a) -> 'a Promise.t eff
-      (** See {!Fibre.fork} *)
-
       | Fork_ignore : Fibre_context.t * (unit -> unit) -> unit eff
       (** See {!Fibre.fork_ignore} *)
 

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1052,20 +1052,6 @@ let rec run ?(queue_depth=64) ?(block_size=4096) main =
                 );
               schedule st
             )
-          | Eio.Private.Effects.Fork (new_fibre, f) -> Some (fun k -> 
-              let k = { Suspended.k; fibre } in
-              let promise, resolver = Promise.create_with_id (Fibre_context.tid new_fibre) in
-              enqueue_thread st k promise;
-              fork
-                ~new_fibre
-                (fun () ->
-                   match f () with
-                   | x -> Promise.fulfill resolver x
-                   | exception ex ->
-                     Log.debug (fun f -> f "Forked fibre failed: %a" Fmt.exn ex);
-                     Promise.break resolver ex
-                )
-            )
           | Eio.Private.Effects.Fork_ignore (new_fibre, f) -> Some (fun k -> 
               let k = { Suspended.k; fibre } in
               enqueue_thread st k ();

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -784,7 +784,7 @@ module Objects = struct
     method accept_sub ~sw ~on_error fn =
       Switch.check sw;
       let client, client_addr = accept_loose_fd fd in
-      Fibre.fork_sub_ignore ~sw ~on_error
+      Fibre.fork_sub ~sw ~on_error
         (fun sw ->
            let client_addr = match client_addr with
              | Unix.ADDR_UNIX path         -> `Unix path
@@ -1052,7 +1052,7 @@ let rec run ?(queue_depth=64) ?(block_size=4096) main =
                 );
               schedule st
             )
-          | Eio.Private.Effects.Fork_ignore (new_fibre, f) -> Some (fun k -> 
+          | Eio.Private.Effects.Fork (new_fibre, f) -> Some (fun k -> 
               let k = { Suspended.k; fibre } in
               enqueue_thread st k ();
               fork ~new_fibre (fun () ->

--- a/lib_eio_linux/tests/bench_noop.ml
+++ b/lib_eio_linux/tests/bench_noop.ml
@@ -11,7 +11,7 @@ let main ~clock =
       let t0 = Eio.Time.now clock in
       Switch.run (fun sw ->
           for _ = 1 to n_fibres do
-            Fibre.fork_ignore ~sw (fun () ->
+            Fibre.fork ~sw (fun () ->
                 for _ = 1 to n_iters do
                   Eio_linux.noop ()
                 done

--- a/lib_eio_linux/tests/eurcp_lib.ml
+++ b/lib_eio_linux/tests/eurcp_lib.ml
@@ -19,7 +19,7 @@ let copy_file infd outfd insize block_size =
     let remaining = Int63.(sub insize file_offset) in
     if remaining <> Int63.zero then (
       let len = Int63.to_int (min (Int63.of_int block_size) remaining) in
-      Fibre.fork_ignore ~sw (fun () -> read_then_write_chunk infd outfd file_offset len);
+      Fibre.fork ~sw (fun () -> read_then_write_chunk infd outfd file_offset len);
       copy_block Int63.(add file_offset (of_int len))
     )
   in

--- a/lib_eio_linux/tests/test.ml
+++ b/lib_eio_linux/tests/test.ml
@@ -6,7 +6,7 @@ let () =
   Printexc.record_backtrace true
 
 let read_one_byte ~sw r =
-  Fibre.fork ~sw (fun () ->
+  Fibre.fork_promise ~sw (fun () ->
       let r = Option.get (Eio_linux.Objects.get_fd_opt r) in
       Eio_linux.await_readable r;
       let b = Bytes.create 1 in
@@ -70,8 +70,8 @@ let test_direct_copy () =
   let buffer = Buffer.create 20 in
   let to_output = Eio.Flow.buffer_sink buffer in
   Switch.run (fun sw ->
-      Fibre.fork_ignore ~sw (fun () -> Ctf.label "copy1"; Eio.Flow.copy from_pipe1 to_pipe2; Eio.Flow.close to_pipe2);
-      Fibre.fork_ignore ~sw (fun () -> Ctf.label "copy2"; Eio.Flow.copy from_pipe2 to_output);
+      Fibre.fork ~sw (fun () -> Ctf.label "copy1"; Eio.Flow.copy from_pipe1 to_pipe2; Eio.Flow.close to_pipe2);
+      Fibre.fork ~sw (fun () -> Ctf.label "copy2"; Eio.Flow.copy from_pipe2 to_output);
       Eio.Flow.copy (Eio.Flow.string_source msg) to_pipe1;
       Eio.Flow.close to_pipe1;
     );

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -625,20 +625,6 @@ let rec run main =
             fn loop fibre (enqueue_thread st k))
         | Eio.Private.Effects.Trace ->
           Some (fun k -> continue k Eunix.Trace.default_traceln)
-        | Eio.Private.Effects.Fork (new_fibre, f) ->
-          Some (fun k -> 
-            let k = { Suspended.k; fibre } in
-            let promise, resolver = Promise.create_with_id (Fibre_context.tid new_fibre) in
-            enqueue_thread st k promise;
-            fork
-              ~new_fibre
-              (fun () ->
-                 match f () with
-                 | x -> Promise.fulfill resolver x
-                 | exception ex ->
-                   Log.debug (fun f -> f "Forked fibre failed: %a" Fmt.exn ex);
-                   Promise.break resolver ex
-              ))
         | Eio.Private.Effects.Fork_ignore (new_fibre, f) ->
           Some (fun k -> 
             let k = { Suspended.k; fibre } in

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -366,7 +366,7 @@ module Objects = struct
         Handle.close client;
         raise (Luv_error e)
       | Ok () ->
-        Fibre.fork_sub_ignore ~sw ~on_error
+        Fibre.fork_sub ~sw ~on_error
           (fun sw ->
              let client_addr = self#get_client_addr client in
              fn ~sw (socket client :> <Eio.Flow.two_way; Eio.Flow.close>) client_addr
@@ -625,7 +625,7 @@ let rec run main =
             fn loop fibre (enqueue_thread st k))
         | Eio.Private.Effects.Trace ->
           Some (fun k -> continue k Eunix.Trace.default_traceln)
-        | Eio.Private.Effects.Fork_ignore (new_fibre, f) ->
+        | Eio.Private.Effects.Fork (new_fibre, f) ->
           Some (fun k -> 
             let k = { Suspended.k; fibre } in
             enqueue_thread st k ();

--- a/lib_eunix/lf_queue.mli
+++ b/lib_eunix/lf_queue.mli
@@ -9,8 +9,14 @@ exception Closed
 val create : unit -> 'a t
 
 val push : 'a t -> 'a -> unit
-(** [push t x] adds [x] to the queue.
+(** [push t x] adds [x] to the tail of the queue.
+    This can be used safely by multiple producer domains, in parallel with the other operations.
     @raise Closed if [t] is closed. *)
+
+val push_head : 'a t -> 'a -> unit
+(** [push_head t x] inserts [x] at the head of the queue.
+    This can only be used by the consumer (if run in parallel with {!pop}, the item might be skipped).
+    @raise Closed if [t] is closed and empty. *)
 
 val pop : 'a t -> 'a option
 (** [pop t] removes the head item from [t] and returns it.

--- a/stress/stress_semaphore.ml
+++ b/stress/stress_semaphore.ml
@@ -11,7 +11,7 @@ let main ~domain_mgr =
   let sem = Eio.Semaphore.make n_tokens in
   Switch.run (fun sw ->
       for _ = 1 to n_domains do
-        Fibre.fork_ignore ~sw (fun () ->
+        Fibre.fork ~sw (fun () ->
             Eio.Domain_manager.run domain_mgr (fun () ->
                 let i = ref 0 in
                 while !i < n_iters do

--- a/tests/test_fibre.md
+++ b/tests/test_fibre.md
@@ -221,7 +221,7 @@ Exception: Failure "simulated error".
 
 # Fibre.fork
 
-`Fibre.fork ~sw` inherits the cancellation context from `sw`, not from the current fibre:
+`Fibre.fork_promise ~sw` inherits the cancellation context from `sw`, not from the current fibre:
 
 ```ocaml
 # run @@ fun () ->
@@ -235,7 +235,7 @@ Exception: Failure "simulated error".
     (fun () ->
       let sw = Option.get !switch in
       Eio.Cancel.protect @@ fun () ->
-      let child = Fibre.fork ~sw (fun () ->
+      let child = Fibre.fork_promise ~sw (fun () ->
          traceln "Forked child";
          Fibre.await_cancel ()
       ) in

--- a/tests/test_lf_queue.md
+++ b/tests/test_lf_queue.md
@@ -42,9 +42,15 @@ val q : int Q.t = <abstr>
 - : unit = ()
 # Q.push q 2;;
 Exception: Eunix.Lf_queue.Closed.
+# Q.push_head q 3;;
+- : unit = ()
+# Q.pop q;;
+- : int option = Some 3
 # Q.pop q;;
 - : int option = Some 1
 # Q.pop q;;
+Exception: Eunix.Lf_queue.Closed.
+# Q.push_head q 4;;
 Exception: Eunix.Lf_queue.Closed.
 ```
 
@@ -70,4 +76,25 @@ val q : int Q.t = <abstr>
 - : bool = true
 # Q.close q; Q.is_empty q;;
 Exception: Eunix.Lf_queue.Closed.
+```
+
+## Pushing to the head
+
+```ocaml
+# let q : int Q.t = Q.create ();;
+val q : int Q.t = <abstr>
+# Q.push_head q 3; Q.push q 4; Q.push_head q 2; Q.push q 5; Q.push_head q 1;;
+- : unit = ()
+# Q.pop q;;
+- : int option = Some 1
+# Q.pop q;;
+- : int option = Some 2
+# Q.pop q;;
+- : int option = Some 3
+# Q.pop q;;
+- : int option = Some 4
+# Q.pop q;;
+- : int option = Some 5
+# Q.pop q;;
+- : int option = None
 ```

--- a/tests/test_stream.md
+++ b/tests/test_stream.md
@@ -240,9 +240,9 @@ Readers queue up:
 # run @@ fun () ->
   let t = S.create 0 in
   Switch.run @@ fun sw ->
-  Fibre.fork_ignore ~sw (fun () -> take t; traceln "a done");
-  Fibre.fork_ignore ~sw (fun () -> take t; traceln "b done");
-  Fibre.fork_ignore ~sw (fun () -> take t; traceln "c done");
+  Fibre.fork ~sw (fun () -> take t; traceln "a done");
+  Fibre.fork ~sw (fun () -> take t; traceln "b done");
+  Fibre.fork ~sw (fun () -> take t; traceln "c done");
   add t 1;
   add t 2;
   add t 3;;
@@ -270,9 +270,9 @@ Writers queue up:
 # run @@ fun () ->
   let t = S.create 0 in
   Switch.run @@ fun sw ->
-  Fibre.fork_ignore ~sw (fun () -> add t 1);
-  Fibre.fork_ignore ~sw (fun () -> add t 2);
-  Fibre.fork_ignore ~sw (fun () -> add t 3);
+  Fibre.fork ~sw (fun () -> add t 1);
+  Fibre.fork ~sw (fun () -> add t 2);
+  Fibre.fork ~sw (fun () -> add t 3);
   take t;
   take t;
   take t;;


### PR DESCRIPTION
- Simplify the code by removing the old `Fork` effect, and implementing it instead in terms of `Fork_ignore`.
- Rename `Fork_ignore` to `Fork`, and the same for the functions. This is the most used version.
- The old `Fiber.fork` is now `Fibre.fork_promise` (and might get removed later).
- Extend the lock-free queue to allow the consuming domain to insert items at the head of the queue.
- When forking, we now schedule the caller at the head of the run-queue, ahead of other work.

Some arguments in favour of the new scheduling order:

- This is the most flexible arrangement (you can add yields gets the other combinations).
- The new order seems a bit more natural (the README examples look better).
- Might be better for the cache in some cases (domainslib works this way).
- It means that `Fibre.both f g` starts `f` and `g` in similar contexts. Previously, `f` started before any queued items, while `g` started after, which was a bit inconsistent.

This also adds some documentation about scheduling order to the ocamldoc (note that the previous documentation for `fork` was wrong) and adds a `rationale.md` file explaining the choice.