### PR TITLE
Improve cancellation

### DIFF
--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -235,7 +235,7 @@ module Stream = struct
     let r = enter (fun t k ->
         Fibre_context.set_cancel_fn k.fibre (fun ex ->
             Luv.Stream.read_stop (Handle.get "read_into:cancel" sock) |> or_raise;
-            enqueue_failed_thread t k (Eio.Cancel.Cancelled ex)
+            enqueue_failed_thread t k ex
           );
         Luv.Stream.read_start (Handle.get "read_start" sock) ~allocate:(fun _ -> buf) (fun r ->
             Luv.Stream.read_stop (Handle.get "read_stop" sock) |> or_raise;


### PR DESCRIPTION
Documented how cancellation is supposed to work.

 Added `Fibre.check ()`, to check whether the current context has been cancelled.

In eio_luv, don't wrap an extra Cancelled around cancelled exceptions.

Don't create a `Multiple_exn.T` of a cancellation and something else. Just ignore the cancellation in that case and report the interesting exception. Whoever sent the cancellation is responsible for reporting that problem.

Mark all nested contexts as cancelled before running any functions. If a function fails (shouldn't happen now), still run those from other contexts.