### PR TITLE
lib_eio_linux: raise End_of_file

### DIFF
--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -753,9 +753,11 @@ module Objects = struct
              (should be fixed in Linux 5.14) *)
           await_readable fd
         );
-        let got = read_upto fd chunk max_len in
-        Cstruct.blit chunk_cs 0 buf 0 got;
-        got
+        match read_upto fd chunk max_len with
+        | 0 -> raise End_of_file
+        | got ->
+            Cstruct.blit chunk_cs 0 buf 0 got;
+            got
 
       method read_methods = []
 


### PR DESCRIPTION
Eio_linux.read_into doesn't explicitly raise `End_of_file` exception
when read returns 0. Rather, the assertion will be hit in
Eio.Flow.read_into `assert(got > 0)`. This commit ensures that
`Eio_linux.read_into` raises `End_of_file` when read returns 0.

This commit is in similar spirit to `Eio_Luv.read_into` where it
explicitly raises `End_of_file` when read returns 0.

Signed-off-by: Bikal Lem <gbikal+git@gmail.com>