### PR TITLE
Depend on base-domains

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@
  (description "An eio implementation for Unix-compatible systems.")
  (depends
   (optint (>= 0.1.0))
-  (ocaml-variants (= "4.12.0+domains"))
+  base-domains
   (ctf (= :version))
   (eio (= :version))
   (alcotest (and (>= 1.4.0) :with-test))
@@ -35,7 +35,7 @@
  (description "An eio implementation for Linux using io-uring.")
  (depends
   (alcotest (and (>= 1.4.0) :with-test))
-  (ocaml-variants (= "4.12.0+domains"))
+  base-domains
   (ctf (= :version))
   (eio (= :version))
   (eunix (= :version))
@@ -49,7 +49,7 @@
  (synopsis "Eio implementation using luv (libuv)")
  (description "An eio implementation for most platforms, using luv.")
  (depends
-  (ocaml-variants (= "4.12.0+domains"))
+  base-domains
   (ctf (= :version))
   (eio (= :version))
   (eunix (= :version))

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
   "alcotest" {>= "1.4.0" & with-test}
-  "ocaml-variants" {= "4.12.0+domains"}
+  "base-domains"
   "ctf" {= version}
   "eio" {= version}
   "eunix" {= version}

--- a/eio_luv.opam
+++ b/eio_luv.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml-variants" {= "4.12.0+domains"}
+  "base-domains"
   "ctf" {= version}
   "eio" {= version}
   "eunix" {= version}

--- a/eunix.opam
+++ b/eunix.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
   "optint" {>= "0.1.0"}
-  "ocaml-variants" {= "4.12.0+domains"}
+  "base-domains"
   "ctf" {= version}
   "eio" {= version}
   "alcotest" {>= "1.4.0" & with-test}


### PR DESCRIPTION
opam-repository now provides a special package to mark support for domains, avoiding the need to hard-code a dependency on ocaml.4.12.0+domains.