### PR TITLE
Don't lose exceptions when cancelled

### DIFF
--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -66,7 +66,7 @@ module FD = struct
     let res = perform (Close fd) in
     Log.debug (fun l -> l "close: woken up");
     if res < 0 then
-      raise (Unix.Unix_error (Uring.error_of_errno res, "close", ""))
+      raise (Unix.Unix_error (Uring.error_of_errno res, "close", string_of_int (Obj.magic fd : int)))
 
   let ensure_closed t =
     if is_open t then close t

--- a/tests/test_switch.md
+++ b/tests/test_switch.md
@@ -399,3 +399,19 @@ Failure("cancel2 failed")
 and
 Failure("cancel1 failed")
 ```
+
+# Errors during cleanup are reported during cancellation
+
+```ocaml
+# run (fun sw ->
+    Fibre.fork ~sw (fun () ->
+      Switch.run @@ fun sw ->
+      try Fibre.await_cancel () with _ -> failwith "cleanup failed");
+    Fibre.fork ~sw (fun () -> failwith "simulated error")
+  );;
+Exception:
+Multiple exceptions:
+Failure("simulated error")
+and
+Failure("cleanup failed")
+```


### PR DESCRIPTION
Before, if a fibre failed when its parent context was cancelled then we just reported the parent's cancellation exception. But that could hide other errors, in particular errors during cleanup.

Now, cancellation contexts track whether they were cancelled by their parents.