### PR TITLE
Add Switch.dump and Cancel.dump for debugging

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,6 +14,7 @@
   (ctf (= :version))
   (cstruct (>= 6.0.1))
   lwt-dllist
+  (fmt (>= 0.8.9))
   (alcotest (and (>= 1.4.0) :with-test))))
 (package
  (name eunix)

--- a/eio.opam
+++ b/eio.opam
@@ -12,6 +12,7 @@ depends: [
   "ctf" {= version}
   "cstruct" {>= "6.0.1"}
   "lwt-dllist"
+  "fmt" {>= "0.8.9"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/lib_eio/dune
+++ b/lib_eio/dune
@@ -1,5 +1,5 @@
 (library
   (name eio)
   (public_name eio)
-  (libraries cstruct ctf lwt-dllist)
+  (libraries cstruct ctf lwt-dllist fmt)
   (flags (:standard -w -50)))

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -71,6 +71,9 @@ module Std : sig
 
     val on_release_cancellable : t -> (unit -> unit) -> Hook.t
     (** Like [on_release], but the handler can be removed later. *)
+
+    val dump : t Fmt.t
+    (** Dump out details of the switch's state for debugging. *)
   end
 
   module Promise : sig
@@ -367,6 +370,9 @@ module Cancel : sig
       All cancellation functions are run, even if some of them raise exceptions.
       If [t] is already cancelled then this does nothing.
       @raise Cancel_hook_failed if one or more hooks fail. *)
+
+  val dump : t Fmt.t
+  (** Show the cancellation sub-tree rooted at [t], for debugging. *)
 end
 
 (** {1 Cross-platform OS API} *)

--- a/lib_eio/switch.ml
+++ b/lib_eio/switch.ml
@@ -7,6 +7,12 @@ type t = {
   cancel : Cancel.t;
 }
 
+let dump f t =
+  Fmt.pf f "@[<v2>Switch %d (%d extra fibres):@,%a@]"
+    (t.id :> int)
+    t.fibres
+    Cancel.dump t.cancel
+
 let is_finished t = Cancel.is_finished t.cancel
 
 let check t =


### PR DESCRIPTION
Example output:

```
Switch 6 (1 extra fibres):
  on [4]
    cancelling(Failure("Background switch turned off")) []
      cancelling(Failure("Background switch turned off")) []
      on (protected) [7]
```

This shows switch 6 and its cancellation context tree. Fibre 4 is running directly in the switch's context (which is "on"). The context has a child (cancelling) and two grandchildren, one of which is protected from cancellation and running fibre 7.