### PR TITLE
Simplify and improve error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,9 @@ leading to clearer code and avoiding resource leaks.
 For example, `fork` creates a new fibre that continues running after `fork` returns,
 so it needs to take a switch argument.
 
-Every switch also creates a new cancellation context,
-and you can turn off the switch to cancel all fibres within it.
+Every switch also creates a new cancellation context.
+You can use `Switch.fail` to mark the switch as failed and cancel all fibres within it.
+The exception (or exceptions) passed to `fail` will be raised by `run` when the fibres have exited.
 
 You can also use `Fibre.fork_sub` to create a child sub-switch.
 Turning off the parent switch will also turn off the child switch, but turning off the child doesn't disable the parent.

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -16,7 +16,7 @@ end
 
 module Semaphore = Semaphore
 module Stream = Stream
-module Multiple_exn = Multiple_exn
+module Exn = Exn
 
 open Std
 

--- a/lib_eio/exn.ml
+++ b/lib_eio/exn.ml
@@ -1,0 +1,23 @@
+type with_bt = exn * Printexc.raw_backtrace
+
+exception Multiple of exn list  (* Note: the last exception in list is the first one reported *)
+
+exception Cancelled of exn
+
+exception Cancel_hook_failed of exn list
+
+let () =
+  Printexc.register_printer @@ function
+  | Multiple exns -> Some ("Multiple exceptions:\n" ^ String.concat "\nand\n" (List.rev_map Printexc.to_string exns))
+  | Cancel_hook_failed exns -> Some ("During cancellation:\n" ^ String.concat "\nand\n" (List.map Printexc.to_string exns))
+  | Cancelled ex -> Some ("Cancelled: " ^ Printexc.to_string ex)
+  | _ -> None
+
+let combine e1 e2 =
+  if fst e1 == fst e2 then e1
+  else match e1, e2 with
+    | (Cancelled _, _), e
+    | e, (Cancelled _, _) -> e  (* Don't need to report a cancelled exception if we have something better *)
+    | (Multiple exs, _), _ when List.memq (fst e2) exs -> e1   (* Avoid duplicates *)
+    | (Multiple exs, bt1), (e2, _) -> Multiple (e2 :: exs), bt1
+    | (e1, bt1), (e2, _) -> Multiple [e2; e1], bt1

--- a/lib_eio/multiple_exn.ml
+++ b/lib_eio/multiple_exn.ml
@@ -1,6 +1,0 @@
-exception T of exn list
-
-let () =
-  Printexc.register_printer @@ function
-  | T exns -> Some ("Multiple exceptions:\n" ^ String.concat "\nand\n" (List.map Printexc.to_string exns))
-  | _ -> None

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -66,7 +66,7 @@ module FD = struct
     let res = perform (Close fd) in
     Log.debug (fun l -> l "close: woken up");
     if res < 0 then
-      raise (Unix.Unix_error (Uring.error_of_errno res, "close", ""))
+      raise (Unix.Unix_error (Uring.error_of_errno res, "close", string_of_int (Obj.magic fd : int)))
 
   let ensure_closed t =
     if is_open t then close t

--- a/tests/test_domains.md
+++ b/tests/test_domains.md
@@ -83,7 +83,7 @@ Spawning when already cancelled - no new domain is started:
 ```ocaml
 # run @@ fun mgr ->
   Switch.run @@ fun sw ->
-  Switch.turn_off sw (Failure "Simulated error");
+  Switch.fail sw (Failure "Simulated error");
   Eio.Domain_manager.run mgr (fun () -> traceln "Domain spawned - shouldn't happen!");;
 Exception: Failure "Simulated error".
 ```

--- a/tests/test_fibre.md
+++ b/tests/test_fibre.md
@@ -239,7 +239,7 @@ Exception: Failure "simulated error".
          traceln "Forked child";
          Fibre.await_cancel ()
       ) in
-      Switch.turn_off sw Exit;
+      Switch.fail sw Exit;
       Promise.await child
     );
   "not reached";;
@@ -375,7 +375,7 @@ Turning off the child switch in the accept function. We treat this as the handle
 
 ```ocaml
 # run @@ fun () ->
-  Switch.run @@ test_fork_on_accept ~in_accept:(fun sw -> Switch.turn_off sw (Failure "Accept turn-off"));;
+  Switch.run @@ test_fork_on_accept ~in_accept:(fun sw -> Switch.fail sw (Failure "Accept turn-off"));;
 +Got connection
 +Releasing connection
 +on_handler_error: Failure("Accept turn-off")
@@ -431,7 +431,7 @@ until the connection is released.
   let bg_switch = Option.get !bg_switch in
   test_fork_on_accept bg_switch
     ~in_accept:(fun _  ->
-       Switch.turn_off bg_switch (Failure "Background switch turned off");
+       Switch.fail bg_switch (Failure "Background switch turned off");
        Fibre.yield ()
     );;
 +Got connection

--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -142,7 +142,7 @@ Calling accept when the switch is already off:
 ```ocaml
 # run @@ fun ~net sw ->
   let server = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:5 addr in
-  Switch.turn_off sw (Failure "Simulated error");
+  Switch.fail sw (Failure "Simulated error");
   Eio.Net.accept_sub server ~sw (fun ~sw:_ _flow _addr -> assert false)
     ~on_error:raise;;
 Exception: Failure "Simulated error".

--- a/tests/test_stream.md
+++ b/tests/test_stream.md
@@ -231,7 +231,7 @@ Trying to use a stream with a cancelled context:
 +Reading from stream
 +Got 1 from stream
 +Added 1 to stream
-Exception: Cancel.
+- : unit = ()
 ```
 
 Readers queue up:

--- a/tests/test_time.md
+++ b/tests/test_time.md
@@ -52,7 +52,7 @@ Switch is already off:
 ```ocaml
 # run @@ fun ~clock ->
   Switch.run @@ fun sw ->
-  Switch.turn_off sw (Failure "Simulated failure");
+  Switch.fail sw (Failure "Simulated failure");
   Eio.Time.sleep clock 1200.0;
   assert false;;
 Exception: Failure "Simulated failure".


### PR DESCRIPTION
Cancellation contexts are now only about making things stop promptly, not about reporting errors. That's now handled entirely by the switches.

This fixes a problem where an error raised while cancelling an operation would be lost.