### PR TITLE
Add eio.unix module for Unix integration

### DIFF
--- a/lib_eio/unix/dune
+++ b/lib_eio/unix/dune
@@ -1,0 +1,4 @@
+(library
+ (name eio_unix)
+ (public_name eio.unix)
+ (libraries eio unix))

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -1,0 +1,10 @@
+open EffectHandlers
+
+module Effects = struct
+  type _ eff += 
+    | Await_readable : Unix.file_descr -> unit eff
+    | Await_writable : Unix.file_descr -> unit eff
+end
+
+let await_readable fd = perform (Effects.Await_readable fd)
+let await_writable fd = perform (Effects.Await_writable fd)

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -1,0 +1,15 @@
+(** Extension of {!Eio} for integration with OCaml's [Unix] module. *)
+
+val await_readable : Unix.file_descr -> unit
+(** [await_readable fd] blocks until [fd] is readable (or has an error). *)
+
+val await_writable : Unix.file_descr -> unit
+(** [await_writable fd] blocks until [fd] is writable (or has an error). *)
+
+module Effects : sig
+  open EffectHandlers
+
+  type _ eff += 
+    | Await_readable : Unix.file_descr -> unit eff
+    | Await_writable : Unix.file_descr -> unit eff
+end

--- a/lib_eio_linux/dune
+++ b/lib_eio_linux/dune
@@ -5,4 +5,4 @@
  (foreign_stubs
   (language c)
   (names eio_stubs))
- (libraries eio eio.utils unix uring logs fmt bigstringaf ctf))
+ (libraries eio eio.utils eio.unix uring logs fmt bigstringaf ctf))

--- a/lib_eio_luv/dune
+++ b/lib_eio_luv/dune
@@ -1,4 +1,4 @@
 (library
  (name eio_luv)
  (public_name eio_luv)
- (libraries eio luv eio.utils unix logs fmt bigstringaf ctf))
+ (libraries eio.unix luv eio.utils logs fmt bigstringaf ctf))

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -76,18 +76,6 @@ module File : sig
 
 end
 
-module Poll : sig
-
-  val poll_readable : Unix.file_descr -> unit
-  (** Wraps {!Luv.Poll.start}. [poll fd] polls the file descriptor [fd]
-      until it is readable, and stops polling once it is ready. *)
-
-  val poll_writable : Unix.file_descr -> unit
-  (** Wraps {!Luv.Poll.start}. [poll fd] polls the file descriptor [fd]
-      until it is writable, and stops polling once it is ready. *)
-
-end
-
 module Handle : sig
   type 'a t
 


### PR DESCRIPTION
For now, this provides `await_readable` and `await_writable`. This allows `Lwt_eio` to work with either backend.

Closes #127.

/cc @Sudha247