### PR TITLE
Add take_all

### DIFF
--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -303,12 +303,22 @@ module Stream : sig
   (** [take t] takes the next item from the head of [t].
       If no items are available, it waits until one becomes available. *)
 
+  val take_all : 'a t -> 'a list
+  (** [take_all t] returns all items in [t] as a list. {b Note} this is a destructive operation,
+      i.e items are removed from [t]. *)
+
   val take_nonblocking : 'a t -> 'a option
   (** [take_nonblocking t] is like [Some (take t)] except that
       it returns [None] if the stream is empty rather than waiting.
       Note that if another domain may add to the stream then a [None]
       result may already be out-of-date by the time this returns. *)
-end  
+
+  val length : 'a t -> int
+  (** [length t] returns the number of items currently in [t]. *)
+
+  val is_empty : 'a t -> bool
+  (** [is_empty t] is [length t = 0]. *)
+end
 
 (** Cancelling other fibres when an exception occurs. *)
 module Cancel : sig
@@ -734,7 +744,7 @@ module Private : sig
     type 'a enqueue = ('a, exn) result -> unit
     (** A function provided by the scheduler to reschedule a previously-suspended thread. *)
 
-    type _ eff += 
+    type _ eff +=
       | Suspend : (Fibre_context.t -> 'a enqueue -> unit) -> 'a eff
       (** [Suspend fn] is performed when a fibre must be suspended
           (e.g. because it called {!Promise.await} on an unresolved promise).

--- a/lib_eio/stream.ml
+++ b/lib_eio/stream.ml
@@ -92,6 +92,17 @@ let take t =
     Mutex.unlock t.mutex;
     v
 
+let take_all t =
+  let [@tailrec_mod_constr] rec loop () =
+    match Queue.take_opt t.items with
+    | Some x -> x :: loop ()
+    | None -> []
+  in
+  Mutex.lock t.mutex;
+  let s = loop () in
+  Mutex.unlock t.mutex;
+  s
+
 let take_nonblocking t =
   Mutex.lock t.mutex;
   match Queue.take_opt t.items with
@@ -118,3 +129,12 @@ let take_nonblocking t =
     end;
     Mutex.unlock t.mutex;
     Some v
+
+let length t =
+  Mutex.lock t.mutex;
+  let len = Queue.length t.items in
+  Mutex.unlock t.mutex;
+  len
+
+let is_empty t = (length t = 0)
+


### PR DESCRIPTION
Draft: This build on top of pr #141 and adds `to_seq` function to convert Stream items to `Seq.t`.

Perhaps this should `to_list` instead and return a list?
