### PR TITLE
lib_eio: add take_all function

### DIFF
--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -303,6 +303,10 @@ module Stream : sig
   (** [take t] takes the next item from the head of [t].
       If no items are available, it waits until one becomes available. *)
 
+  val take_all : 'a t -> 'a list
+  (** [take_all t] returns all items in [t] as a list. {b Note} this is a destructive operation,
+      i.e items are removed from [t]. *)
+
   val take_nonblocking : 'a t -> 'a option
   (** [take_nonblocking t] is like [Some (take t)] except that
       it returns [None] if the stream is empty rather than waiting.

--- a/lib_eio/stream.ml
+++ b/lib_eio/stream.ml
@@ -92,6 +92,17 @@ let take t =
     Mutex.unlock t.mutex;
     v
 
+let take_all t =
+  let [@tailrec_mod_constr] rec loop () =
+    match Queue.take_opt t.items with
+    | Some x -> x :: loop ()
+    | None -> []
+  in
+  Mutex.lock t.mutex;
+  let s = loop () in
+  Mutex.unlock t.mutex;
+  s
+
 let take_nonblocking t =
   Mutex.lock t.mutex;
   match Queue.take_opt t.items with


### PR DESCRIPTION
This is a rebased version of https://github.com/ocaml-multicore/eio/pull/142 with cleaner git history.
The comments/discussion on the PR is still applicable to this PR.

(cherry picked from commit 36bed7b7dad6737e6f3dbe998cd2f6db673a7fb6)