### PR TITLE
Remove dependency on ppxlib

### DIFF
--- a/ctf.opam
+++ b/ctf.opam
@@ -10,7 +10,6 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
   "alcotest" {>= "1.4.0" & with-test}
-  "ppx_cstruct" {>= "6.0.1"}
   "ocplib-endian" {>= "1.1"}
   "mtime" {>= "1.2.0"}
   "cstruct" {>= "6.0.1"}

--- a/dune-project
+++ b/dune-project
@@ -50,7 +50,6 @@
  (description "Trace IO events.")
  (depends
   (alcotest (and (>= 1.4.0) :with-test))
-  (ppx_cstruct (>= 6.0.1))
   (ocplib-endian (>= 1.1))
   (mtime (>= 1.2.0))
   (cstruct (>= 6.0.1))))

--- a/lib_ctf/ctf.ml
+++ b/lib_ctf/ctf.ml
@@ -73,6 +73,7 @@ module Packet = struct
   let magic = 0xc1fc1fc1l
   let uuid = "\x05\x88\x3b\x8d\x52\x1a\x48\x7b\xb3\x97\x45\x6a\xb1\x50\x68\x0c"
 
+  (*
   [%%cstruct
   type packet_header = {
     (* Stream header, repeated for each packet *)
@@ -86,6 +87,17 @@ module Packet = struct
     content_size_high: uint16_t;
   } [@@little_endian]
   ]
+  *)
+
+  (* Auto-generated code from the above (to avoid a dependency on ppxlib) *)
+  let sizeof_packet_header = 30
+  let set_packet_header_magic v x = Cstruct.LE.set_uint32 v 0 x
+  let set_packet_header_uuid src srcoff dst = Cstruct.blit_from_string src srcoff dst 4 16
+  let set_packet_header_size v x = Cstruct.LE.set_uint32 v 20 x
+  let set_packet_header_stream_packet_count v x = Cstruct.LE.set_uint16 v 24 x
+  let set_packet_header_content_size_low v x = Cstruct.LE.set_uint16 v 26 x
+  let set_packet_header_content_size_high v x = Cstruct.LE.set_uint16 v 28 x
+  (* End auto-generated code *)
 
   type t = {
     packet_start : int;

--- a/lib_ctf/dune
+++ b/lib_ctf/dune
@@ -1,5 +1,4 @@
 (library
   (name ctf)
   (public_name ctf)
-  (preprocess (pps ppx_cstruct))
   (libraries cstruct ocplib-endian.bigstring mtime))


### PR DESCRIPTION
The only thing using this was Ctf, for the packet format, which never changes. Instead, just inline the generated code. Eventually this code will be replaced with eventring anyway.

This is also useful as a step towards OCaml 5.00, as ppxlib doesn't support that yet.