### PR TITLE
Add support for OCaml 5.00+trunk

### DIFF
--- a/lib_eio/cancel.ml
+++ b/lib_eio/cancel.ml
@@ -1,4 +1,4 @@
-open EffectHandlers
+open Effect
 
 exception Cancelled = Exn.Cancelled
 exception Cancel_hook_failed = Exn.Cancel_hook_failed

--- a/lib_eio/dune
+++ b/lib_eio/dune
@@ -3,3 +3,15 @@
   (public_name eio)
   (libraries cstruct ctf lwt-dllist fmt)
   (flags (:standard -w -50)))
+
+(rule
+  (target effect.ml)
+  (enabled_if (>= %{ocaml_version} "5.00"))
+  (action
+    (copy effect.new.ml effect.ml)))
+
+(rule
+  (target effect.ml)
+  (enabled_if (< %{ocaml_version} "5.00"))
+  (action
+    (copy effect.compat.ml effect.ml)))

--- a/lib_eio/effect.compat.ml
+++ b/lib_eio/effect.compat.ml
@@ -1,0 +1,1 @@
+include Stdlib.EffectHandlers

--- a/lib_eio/effect.new.ml
+++ b/lib_eio/effect.new.ml
@@ -1,0 +1,1 @@
+include Stdlib.Effect

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -1,4 +1,4 @@
-open EffectHandlers
+open Effect
 
 module Hook = Hook
 module Cancel = Cancel
@@ -298,4 +298,6 @@ module Private = struct
       | Get_context = Cancel.Get_context
       | Trace = Std.Trace
   end
+
+  module Effect = Effect
 end

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -735,7 +735,7 @@ module Private : sig
   end
 
   module Effects : sig
-    open EffectHandlers
+    open Effect
 
     type 'a enqueue = ('a, exn) result -> unit
     (** A function provided by the scheduler to reschedule a previously-suspended thread. *)
@@ -759,4 +759,7 @@ module Private : sig
 
       | Get_context : Fibre_context.t eff
   end
+
+  (** Temporary hack for compatibility with ocaml.4.12+domains *)
+  module Effect = Effect
 end

--- a/lib_eio/fibre.ml
+++ b/lib_eio/fibre.ml
@@ -1,4 +1,4 @@
-open EffectHandlers
+open Effect
 
 type _ eff += Fork : Cancel.fibre_context * (unit -> unit) -> unit eff
 

--- a/lib_eio/suspend.ml
+++ b/lib_eio/suspend.ml
@@ -1,4 +1,4 @@
-open EffectHandlers
+open Effect
 
 type 'a enqueue = ('a, exn) result -> unit
 type _ eff += Suspend : (Cancel.fibre_context -> 'a enqueue -> unit) -> 'a eff

--- a/lib_eio/switch.ml
+++ b/lib_eio/switch.ml
@@ -115,7 +115,7 @@ let run_internal t fn =
 let run fn = Cancel.sub (fun cc -> run_internal (create cc) fn)
 
 let run_protected fn =
-  let ctx = EffectHandlers.perform Cancel.Get_context in
+  let ctx = Effect.perform Cancel.Get_context in
   Cancel.with_cc ~ctx ~parent:ctx.cancel_context ~protected:true @@ fun cancel ->
   run_internal (create cancel) fn
 
@@ -124,7 +124,7 @@ let run_protected fn =
    and means that cancelling [t] will cancel [fn]. *)
 let run_in t fn =
   with_op t @@ fun () ->
-  let ctx = EffectHandlers.perform Cancel.Get_context in
+  let ctx = Effect.perform Cancel.Get_context in
   let old_cc = ctx.cancel_context in
   Cancel.move_fibre_to t.cancel ctx;
   match fn () with

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -1,4 +1,4 @@
-open EffectHandlers
+open Eio.Private.Effect
 
 module Effects = struct
   type _ eff += 

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -7,7 +7,7 @@ val await_writable : Unix.file_descr -> unit
 (** [await_writable fd] blocks until [fd] is writable (or has an error). *)
 
 module Effects : sig
-  open EffectHandlers
+  open Eio.Private.Effect
 
   type _ eff += 
     | Await_readable : Unix.file_descr -> unit eff

--- a/lib_eio/utils/suspended.ml
+++ b/lib_eio/utils/suspended.ml
@@ -1,4 +1,4 @@
-open EffectHandlers.Deep
+open Eio.Private.Effect.Deep
 
 type 'a t = {
   fibre : Eio.Private.Fibre_context.t;

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -18,8 +18,8 @@ let src = Logs.Src.create "eio_linux" ~doc:"Effect-based IO system for Linux/io-
 module Log = (val Logs.src_log src : Logs.LOG)
 
 open Eio.Std
-open EffectHandlers
-open EffectHandlers.Deep
+open Eio.Private.Effect
+open Eio.Private.Effect.Deep
 
 module Fibre_context = Eio.Private.Fibre_context
 

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -18,8 +18,8 @@ let src = Logs.Src.create "eio_luv" ~doc:"Eio backend using luv"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 open Eio.Std
-open EffectHandlers
-open EffectHandlers.Deep
+open Eio.Private.Effect
+open Eio.Private.Effect.Deep
 
 module Fibre_context = Eio.Private.Fibre_context
 module Lf_queue = Eio_utils.Lf_queue


### PR DESCRIPTION
This builds on #150, but keeps compatibility with 4.12+domains as 5.00 is quite difficult to build at the moment (neither dune nor ocamlfind will install, for example).