### PR TITLE
Fix minor documentation errors

### DIFF
--- a/doc/rationale.md
+++ b/doc/rationale.md
@@ -99,7 +99,7 @@ For example:
 - Some flows are backed by a Unix file descriptor which we may want to extract.
 
 The OCaml standard library provides separate `close_in` and `close_out` functions, but cannot handle two-way flows.
-Eio instead provides a single `Flow.close` what works with all flows that can be closed.
+Eio instead provides a single `Flow.close` that works with all flows that can be closed.
 
 Users of Eio can choose how specific to make their code.
 For example, calling `Eio_main.run` will get you a basic Unix-like environment,

--- a/lib_ctf/unix/ctf_unix.mli
+++ b/lib_ctf/unix/ctf_unix.mli
@@ -6,4 +6,4 @@ val mmap_buffer : size:int -> string -> Ctf.log_buffer
 
 val with_tracing : ?size:int -> string -> (unit -> 'a) -> 'a
 (** [with_tracing path fn] is a convenience function that uses {!mmap_buffer} to create a log buffer,
-    calls {!Control.start} to start recording, runs [fn], and then stops recording. *)
+    calls {!Ctf.Control.start} to start recording, runs [fn], and then stops recording. *)

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -23,7 +23,7 @@ module FD : sig
   type t
 
   val is_open : t -> bool
-  (** [is_open t] is [true] if {!close t} hasn't been called yet. *)
+  (** [is_open t] is [true] if {!close} hasn't been called yet. *)
 
   val close : t -> unit
   (** [close t] closes [t].

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -40,7 +40,7 @@ module File : sig
   type t
 
   val is_open : t -> bool
-  (** [is_open t] is [true] if {!close t} hasn't been called yet. *)
+  (** [is_open t] is [true] if {!close} hasn't been called yet. *)
 
   val close : t -> unit
   (** [close t] closes [t].
@@ -80,7 +80,7 @@ module Handle : sig
   type 'a t
 
   val is_open : 'a t -> bool
-  (** [is_open t] is [true] if {!close t} hasn't been called yet. *)
+  (** [is_open t] is [true] if {!close} hasn't been called yet. *)
 
   val close : 'a t -> unit
   (** [close t] closes [t].


### PR DESCRIPTION
The list of remaining errors from `dune build @doc` is disappointingly long:

```
File "eio__Effect.cmt":
Warning: Couldn't find the following modules:
  Stdlib
File "../../lib_ctf/.ctf.objs/byte/ctf.odoc":
Warning: Couldn't find the following modules:
  Stdlib
File "../../lib_eio/unix/.eio_unix.objs/byte/eio_unix.odoc":
Warning: Couldn't find the following modules:
  Unix
File "../../lib_eio/utils/.eio_utils.objs/byte/eio_utils.odoc":
Warning: Couldn't find the following modules:
  Stdlib Stdlib__effectHandlers
File "../../lib_eio/.eio.objs/byte/eio.odoc":
Warning: Couldn't find the following modules:
  Cstruct Fmt Stdlib Stdlib__effectHandlers Unix
File "lib_eio/eio.mli", line 752, characters 14-27:
Warning: Failed to resolve reference unresolvedroot(Fibre).fork Couldn't find "Fibre"
File "lib_eio/eio.mli", line 746, characters 34-50:
Warning: Failed to resolve reference unresolvedroot(Promise).await Couldn't find "Promise"
File "lib_eio/eio.mli", line 522, characters 12-35:
Warning: Failed to resolve reference unresolvedroot(Fibre).fork_on_accept Couldn't find "Fibre"
File "lib_eio/eio.mli", line 352, characters 10-24:
Warning: Failed to resolve reference unresolvedroot(Switch).fail Couldn't find "Switch"
File "lib_eio/eio.mli", line 342, characters 26-43:
Warning: Failed to resolve reference unresolvedroot(Fibre).check() Couldn't find "Fibre"
File "lib_eio/eio.mli", line 335, characters 23-37:
Warning: Failed to resolve reference unresolvedroot(Fibre).check Couldn't find "Fibre"
File "lib_eio/eio.mli", line 334, characters 29-43:
Warning: Failed to resolve reference unresolvedroot(Fibre).yield Couldn't find "Fibre"
File "lib_eio/eio.mli", line 322, characters 12-21:
Warning: Failed to resolve reference unresolvedroot(Switch) Couldn't find "Switch"
File "lib_eio/eio.mli", line 373, characters 43-63:
Warning: Failed to resolve reference unresolvedroot(Switch).on_release Couldn't find "Switch"
Warning, resolved hidden path: Eio__Effect.eff
File "../../lib_eio_linux/.eio_linux.objs/byte/eio_linux.odoc":
Warning: Couldn't find the following modules:
  Cstruct Optint Unix Uring
File "lib_eio_linux/eio_linux.mli", line 137, characters 9-25:
Warning: Failed to resolve reference unresolvedroot(Unix).shutdown Couldn't find "Unix"
File "lib_eio_linux/eio_linux.mli", line 125, characters 9-22:
Warning: Failed to resolve reference unresolvedroot(Unix).fstat Couldn't find "Unix"
File "lib_eio_linux/eio_linux.mli", line 79, characters 8-24:
Warning: Failed to resolve reference unresolvedroot(Uring).openat2 Couldn't find "Uring"
File "lib_eio_linux/eio_linux.mli", line 68, characters 9-26:
Warning: Failed to resolve reference unresolvedroot(Unix).open_file Couldn't find "Unix"
File "../../lib_eio_luv/.eio_luv.objs/byte/eio_luv.odoc":
Warning: Couldn't find the following modules:
  Luv Stdlib Unsigned
File "lib_eio_luv/eio_luv.mli", line 75, characters 12-29:
Warning: Failed to resolve reference unresolvedroot(Luv).File.mkdir Couldn't find "Luv"
File "lib_eio_luv/eio_luv.mli", line 72, characters 12-32:
Warning: Failed to resolve reference unresolvedroot(Luv).File.realpath Couldn't find "Luv"
File "lib_eio_luv/eio_luv.mli", line 69, characters 84-101:
Warning: Failed to resolve reference unresolvedroot(Luv).File.write Couldn't find "Luv"
File "lib_eio_luv/eio_luv.mli", line 66, characters 12-28:
Warning: Failed to resolve reference unresolvedroot(Luv).File.read Couldn't find "Luv"
File "lib_eio_luv/eio_luv.mli", line 63, characters 12-29:
Warning: Failed to resolve reference unresolvedroot(Luv).File.open_ Couldn't find "Luv"
```

From https://github.com/ocaml/odoc/issues/794#issuecomment-988046473 I understand that most of these errors are expected, as you can't refer to a library installed as an opam package at the moment, so e.g. referring to `Stdlib` doesn't work.

`unresolvedroot(Fibre).fork Couldn't find "Fibre"` and similar seem to be odoc ignoring the `open Std` for some reason.

The `Couldn't find "closet"` error also confused me for a while! It was from the reference `{!close t}`.

/cc @jonludlam
