### PR TITLE
Allow reading absolute paths with `Stdenv.fs`

### DIFF
--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -903,7 +903,7 @@ module Objects = struct
           ~access:`R
           ~flags:Uring.Open_flags.cloexec
           ~perm:0
-          ~resolve:Uring.Resolve.beneath
+          ~resolve:resolve_flags
       in
       (flow fd :> <Eio.Flow.source; Eio.Flow.close>)
 

--- a/tests/test_fs.md
+++ b/tests/test_fs.md
@@ -232,3 +232,19 @@ Using `cwd` we can't access the parent, but using `fs` we can:
 +chdir ".."
 - : unit = ()
 ```
+
+Can use `fs` to access absolute paths:
+
+```ocaml
+# run @@ fun env ->
+  let cwd = Eio.Stdenv.cwd env in
+  let fs = Eio.Stdenv.fs env in
+  let b = Buffer.create 10 in
+  Eio.Dir.with_open_in fs Filename.null (fun flow -> Eio.Flow.copy flow (Eio.Flow.buffer_sink b));
+  traceln "Read %S and got %S" Filename.null (Buffer.contents b);
+  traceln "Trying with cwd instead fails:";
+  Eio.Dir.with_open_in cwd Filename.null (fun flow -> Eio.Flow.copy flow (Eio.Flow.buffer_sink b));;;
++Read "/dev/null" and got ""
++Trying with cwd instead fails:
+Exception: Eio.Dir.Permission_denied ("/dev/null", _)
+```


### PR DESCRIPTION
`open_in` was missing the fix that was already applied to `open_out` and `open_dir`.