### PR TITLE
[eio_linux] Avoid copy in `read_into`

### DIFF
--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -760,18 +760,12 @@ module Objects = struct
         | _ -> None
 
       method read_into buf =
-        (* Inefficient copying fallback *)
-        with_chunk @@ fun chunk ->
-        let chunk_cs = Uring.Region.to_cstruct chunk in
-        let max_len = min (Cstruct.length buf) (Cstruct.length chunk_cs) in
         if Lazy.force is_tty then (
           (* Work-around for https://github.com/axboe/liburing/issues/354
              (should be fixed in Linux 5.14) *)
           await_readable fd
         );
-        let got = read_upto fd chunk max_len in
-        Cstruct.blit chunk_cs 0 buf 0 got;
-        got
+        readv fd [buf]
 
       method read_methods = []
 


### PR DESCRIPTION
Now that `readv` is implemented, we can read directly into the user's buffer.

Testing this by reading from `/dev/null` into a 64K buffer was about 5 times faster than the old way (which has a copy and is limited by the chunk size).