### PR TITLE
[eio_linux] Allow running uring in polling mode

### DIFF
--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -37,5 +37,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
 pin-depends: [
-  ["uring.dev" "git+https://github.com/ocaml-multicore/ocaml-uring.git#389183cb464ffede2b3b2419885c61035e74b574"]
+  ["uring.dev" "git+https://github.com/ocaml-multicore/ocaml-uring.git#22f59b8c08753e7dbafae279ef8bde2edf0c29b5"]
 ]

--- a/eio_linux.opam.template
+++ b/eio_linux.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  ["uring.dev" "git+https://github.com/ocaml-multicore/ocaml-uring.git#389183cb464ffede2b3b2419885c61035e74b574"]
+  ["uring.dev" "git+https://github.com/ocaml-multicore/ocaml-uring.git#22f59b8c08753e7dbafae279ef8bde2edf0c29b5"]
 ]

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -164,5 +164,5 @@ val pipe : Switch.t -> Objects.source * Objects.sink
 
 (** {1 Main Loop} *)
 
-val run : ?queue_depth:int -> ?block_size:int -> (Objects.stdenv -> unit) -> unit
+val run : ?queue_depth:int -> ?block_size:int -> ?polling_timeout:int -> (Objects.stdenv -> unit) -> unit
 (** FIXME queue_depth and block_size should be in a handler and not the mainloop *)


### PR DESCRIPTION
This can be much faster, as Linux can start handling requests without waiting for us to submit them.