### PR TITLE
Remove Unix dependency from Eio

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,35 @@
+Copyright (C) 2021 Anil Madhavapeddy  
+Copyright (C) 2022 Thomas Leonard  
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+This project includes some IPv6 code by Hugo Heuzard from ocaml-ipaddr,
+which has the following license:
+
+ISC License
+
+Copyright (c) 2013-2015 David Sheets <sheets@alum.mit.edu>  
+Copyright (c) 2010-2011, 2014 Anil Madhavapeddy <anil@recoil.org>  
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ let main ~net ~addr =
 # Eio_main.run @@ fun env ->
   main
     ~net:(Eio.Stdenv.net env)
-    ~addr:(`Tcp (Unix.inet_addr_loopback, 8080));;
+    ~addr:(`Tcp (Eio.Net.Ipaddr.V4.loopback, 8080));;
 +Server ready...
 +Connecting to server...
 +Server accepted connection from client

--- a/ctf.opam
+++ b/ctf.opam
@@ -10,7 +10,6 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
   "alcotest" {>= "1.4.0" & with-test}
-  "ocplib-endian" {>= "1.1"}
   "mtime" {>= "1.2.0"}
   "cstruct" {>= "6.0.1"}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -50,7 +50,6 @@
  (description "Trace IO events.")
  (depends
   (alcotest (and (>= 1.4.0) :with-test))
-  (ocplib-endian (>= 1.1))
   (mtime (>= 1.2.0))
   (cstruct (>= 6.0.1))))
 (package

--- a/lib_ctf/ctf.mli
+++ b/lib_ctf/ctf.mli
@@ -100,3 +100,10 @@ module Control : sig
   val stop : t -> unit
   (** [stop t] stops recording to [t] (which must be the current trace buffer). *)
 end
+
+(**/**)
+
+module BS : sig
+  val set_int8 : Cstruct.buffer -> int -> int -> unit
+  val set_int64_le : Cstruct.buffer -> int -> int64 -> unit
+end

--- a/lib_ctf/dune
+++ b/lib_ctf/dune
@@ -1,4 +1,4 @@
 (library
   (name ctf)
   (public_name ctf)
-  (libraries cstruct ocplib-endian.bigstring mtime))
+  (libraries cstruct mtime))

--- a/lib_ctf/unix/ctf_unix.ml
+++ b/lib_ctf/unix/ctf_unix.ml
@@ -2,7 +2,7 @@ open Bigarray
 
 let timestamper log_buffer ofs =
   let ns = Mtime.to_uint64_ns @@ Mtime_clock.now () in
-  EndianBigstring.LittleEndian.set_int64 log_buffer ofs ns
+  Ctf.BS.set_int64_le log_buffer ofs ns
 
 let mmap_buffer ~size path =
   let fd = Unix.(openfile path [O_RDWR; O_CREAT; O_TRUNC] 0o644) in

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -127,19 +127,130 @@ end
 module Net = struct
   exception Connection_reset of exn
 
-  module Sockaddr = struct
-    type inet_addr = Unix.inet_addr
+  module Ipaddr = struct
+    type 'a t = string   (* = [Unix.inet_addr], but avoid a Unix dependency here *)
 
+    module V4 = struct
+      let any      = "\000\000\000\000"
+      let loopback = "\127\000\000\001"
+
+      let pp f t =
+        Fmt.pf f "%d.%d.%d.%d"
+          (Char.code t.[0])
+          (Char.code t.[1])
+          (Char.code t.[2])
+          (Char.code t.[3])
+    end
+
+    module V6 = struct
+      let any      = "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+      let loopback = "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\001"
+
+      let to_int16 t =
+        let get i = Char.code (t.[i]) in
+        let pair i = (get i lsl 8) lor (get (i + 1)) in
+        List.init 8 (fun i -> pair (i * 2))
+
+      (* [calc_elide elide zeros acc parts] finds the best place for the "::"
+         when printing an IPv6 address.
+         Returns [None, rev t] if there are no pairs of zeros, or
+         [Some (-n), rev t'] where [n] is the length of the longest run of zeros
+         and [t'] is [t] with all runs of zeroes replaced with [-len_run]. *)
+      let calc_elide t =
+        (* [elide] is the negative of the length of the best previous run of zeros seen.
+           [zeros] is the current run.
+           [acc] is the values seen so far, with runs of zeros replaced by a
+           negative value giving the length of the run. *)
+        let rec loop elide zeros acc = function
+        | 0 :: xs -> loop elide (zeros - 1) acc xs
+        | n :: xs when zeros = 0 -> loop elide 0 (n :: acc) xs
+        | n :: xs -> loop (min elide zeros) 0 (n :: zeros :: acc) xs
+        | [] ->
+          let elide = min elide zeros in
+          let parts = if zeros = 0 then acc else zeros :: acc in
+          ((if elide < -1 then Some elide else None), List.rev parts)
+            
+        in
+        loop 0 0 [] t
+
+      let rec cons_zeros l x =
+        if x >= 0 then l else cons_zeros (Some 0 :: l) (x + 1)
+
+      let elide l =
+        let rec aux ~elide = function
+          | [] -> []
+          | x :: xs when x >= 0 ->
+            Some x :: aux ~elide xs
+          | x :: xs when Some x = elide ->
+            None :: aux ~elide:None xs
+          | z :: xs ->
+            cons_zeros (aux ~elide xs) z
+        in
+        let elide, l = calc_elide l in
+        assert (match elide with Some x when x < -8 -> false | _ -> true);
+        aux ~elide l
+
+      (* Based on https://github.com/mirage/ocaml-ipaddr/
+         See http://tools.ietf.org/html/rfc5952 *)
+      let pp f t =
+        let comp = to_int16 t in
+        let v4 = match comp with [0; 0; 0; 0; 0; 0xffff; _; _] -> true | _ -> false in
+        let l = elide comp in
+        let rec fill = function
+          | [ Some hi; Some lo ] when v4 ->
+            Fmt.pf f "%d.%d.%d.%d"
+              (hi lsr 8) (hi land 0xff)
+              (lo lsr 8) (lo land 0xff)
+          | None :: xs ->
+            Fmt.string f "::";
+            fill xs
+          | [ Some n ] -> Fmt.pf f "%x" n
+          | Some n :: None :: xs ->
+            Fmt.pf f "%x::" n;
+            fill xs
+          | Some n :: xs ->
+            Fmt.pf f "%x:" n;
+            fill xs
+          | [] -> ()
+        in
+        fill l
+    end
+
+    type v4v6 = [`V4 | `V6] t
+
+    let classify t =
+      match String.length t with
+      | 4 -> `V4 t
+      | 16 -> `V6 t
+      | _ -> assert false
+
+    let of_raw t =
+      match String.length t with
+      | 4 | 16 -> t
+      | x -> Fmt.invalid_arg "An IP address must be either 4 or 16 bytes long (%S is %d bytes)" t x
+
+    let pp f t =
+      match classify t with
+      | `V4 t -> V4.pp f t
+      | `V6 t -> V6.pp f t
+
+    let pp_for_uri f t =
+      match classify t with
+      | `V4 t -> V4.pp f t
+      | `V6 t -> Fmt.pf f "[%a]" V6.pp t
+  end
+
+  module Sockaddr = struct
     type t = [
       | `Unix of string
-      | `Tcp of inet_addr * int
+      | `Tcp of Ipaddr.v4v6 * int
     ]
 
     let pp f = function
       | `Unix path ->
         Format.fprintf f "unix:%s" path
       | `Tcp (addr, port) ->
-        Format.fprintf f "tcp:%s:%d" (Unix.string_of_inet_addr addr) port
+        Format.fprintf f "tcp:%a:%d" Ipaddr.pp_for_uri addr port
   end
 
   class virtual listening_socket = object

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -219,6 +219,10 @@ module Time = struct
   let with_timeout_exn t d = Fibre.first (fun () -> sleep t d; raise Timeout)
 end
 
+module Unix_perm = struct
+  type t = int
+end
+
 module Dir = struct
   type path = string
 
@@ -232,7 +236,7 @@ module Dir = struct
     inherit Flow.write
   end
 
-  type create = [`Never | `If_missing of Unix.file_perm | `Or_truncate of Unix.file_perm | `Exclusive of Unix.file_perm]
+  type create = [`Never | `If_missing of Unix_perm.t | `Or_truncate of Unix_perm.t | `Exclusive of Unix_perm.t]
 
   class virtual t = object
     method virtual open_in : sw:Switch.t -> path -> <Flow.source; Flow.close>
@@ -241,7 +245,7 @@ module Dir = struct
       append:bool ->
       create:create ->
       path -> <rw; Flow.close>
-    method virtual mkdir : perm:Unix.file_perm -> path -> unit
+    method virtual mkdir : perm:Unix_perm.t -> path -> unit
     method virtual open_dir : sw:Switch.t -> path -> t_with_close
   end
   and virtual t_with_close = object

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -488,12 +488,48 @@ end
 module Net : sig
   exception Connection_reset of exn
 
-  module Sockaddr : sig
-    type inet_addr = Unix.inet_addr
+  module Ipaddr : sig
+    type 'a t = private string
+    (** The raw bytes of the IP address.
+        It is either 4 bytes long (for an IPv4 address) or
+        16 bytes long (for IPv6). *)
 
+    module V4 : sig
+      val any : [> `V4] t
+      (** A special IPv4 address, for use only with [listen], representing
+          all the Internet addresses that the host machine possesses. *)
+
+      val loopback : [> `V4] t
+      (** A special IPv4 address representing the host machine ([127.0.0.1]). *)
+    end
+
+    module V6 : sig
+      val any : [> `V6] t
+      (** A special IPv6 address, for use only with [listen], representing
+          all the Internet addresses that the host machine possesses. *)
+
+      val loopback : [> `V6] t
+      (** A special IPv6 address representing the host machine ([::1]). *)
+    end
+
+    val pp : [< `V4 | `V6] t Fmt.t
+
+    type v4v6 = [`V4 | `V6] t
+
+    val classify :
+      [< `V4 | `V6] t ->
+      [ `V4 of [> `V4] t
+      | `V6 of [> `V6] t]
+
+    val of_raw : string -> v4v6
+    (** [of_raw addr] casts [addr] to an IP address.
+        @raise Invalid_argument if it is not 4 or 16 bytes long. *)
+  end
+
+  module Sockaddr : sig
     type t = [
       | `Unix of string
-      | `Tcp of inet_addr * int
+      | `Tcp of Ipaddr.v4v6 * int
     ]
 
     val pp : Format.formatter -> t -> unit

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -586,6 +586,11 @@ module Time : sig
       raising exception [Timeout]. *)
 end
 
+module Unix_perm : sig
+  type t = int
+  (** This is the same as {!Unix.file_perm}, but avoids a dependency on [Unix]. *)
+end
+
 module Dir : sig
   type path = string
 
@@ -599,7 +604,7 @@ module Dir : sig
     inherit Flow.write
   end
 
-  type create = [`Never | `If_missing of Unix.file_perm | `Or_truncate of Unix.file_perm | `Exclusive of Unix.file_perm]
+  type create = [`Never | `If_missing of Unix_perm.t | `Or_truncate of Unix_perm.t | `Exclusive of Unix_perm.t]
   (** When to create a new file:
       If [`Never] then it's an error if the named file doesn't exist.
       If [`If_missing] then an existing file is simply opened.
@@ -615,7 +620,7 @@ module Dir : sig
       append:bool ->
       create:create ->
       path -> <rw; Flow.close>
-    method virtual mkdir : perm:Unix.file_perm -> path -> unit
+    method virtual mkdir : perm:Unix_perm.t -> path -> unit
     method virtual open_dir : sw:Switch.t -> path -> t_with_close
   end
   and virtual t_with_close : object

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -8,3 +8,8 @@ end
 
 let await_readable fd = perform (Effects.Await_readable fd)
 let await_writable fd = perform (Effects.Await_writable fd)
+
+module Ipaddr = struct
+  let to_unix : _ Eio.Net.Ipaddr.t -> Unix.inet_addr = Obj.magic
+  let of_unix : Unix.inet_addr -> _ Eio.Net.Ipaddr.t = Obj.magic
+end

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -6,6 +6,11 @@ val await_readable : Unix.file_descr -> unit
 val await_writable : Unix.file_descr -> unit
 (** [await_writable fd] blocks until [fd] is writable (or has an error). *)
 
+module Ipaddr : sig
+  val to_unix : [< `V4 | `V6] Eio.Net.Ipaddr.t -> Unix.inet_addr
+  val of_unix : Unix.inet_addr -> Eio.Net.Ipaddr.v4v6
+end
+
 module Effects : sig
   open Eio.Private.Effect
 

--- a/tests/nounix/dune
+++ b/tests/nounix/dune
@@ -1,0 +1,4 @@
+(test
+  (name nounix)
+  (forbidden_libraries unix)
+  (libraries eio))

--- a/tests/nounix/nounix.ml
+++ b/tests/nounix/nounix.ml
@@ -1,0 +1,7 @@
+(* This module also checks that Eio doesn't pull in a dependency on Unix.
+   See the [dune] file. *)
+
+let () =
+  let bs = Cstruct.create 8 in
+  Ctf.BS.set_int64_le bs.buffer 0 1234L;
+  assert (Cstruct.LE.get_uint64 bs 0 = 1234L)


### PR DESCRIPTION
This is necessary to use Eio in a unikernel or a browser (helps with #85).

- `Eio.Unix_perm.t` replaces `Unix.file_perm`.
- `Eio.Net.Ipaddr.t` replaces `Unix.inet_addr`.
- Uses `%caml_bigstring_set64` directly instead of via ocplib-endian, as that depends on `bigarray`, which depends on `unix`.

`Eio.Net.Ipaddr.t` has the same internal representation as `Unix.inet_addr` (a 4 or 16 byte string). `Eio_unix.Ipaddr` has functions to cast between them. Note however that this differs from the representation used by Mirage's [ipaddr](https://github.com/mirage/ocaml-ipaddr/).

The IPv6 pretty-printer is based on @hhugo's code from Mirage. At the moment there is no parser, but it allows importing a raw string so an external library could be used for that.

It would be nice to have an `Ipaddr` module in OCaml's standard library that everyone could use.