### PR TITLE
Add Eio.Buf_read

### DIFF
--- a/lib_eio/buf_read.ml
+++ b/lib_eio/buf_read.ml
@@ -1,0 +1,179 @@
+exception Buffer_limit_exceeded
+
+type t = {
+  mutable buf : Cstruct.buffer;
+  mutable pos : int;
+  mutable len : int;
+  mutable flow : Flow.read option;      (* None if we've seen eof *)
+  max_size : int;
+}
+
+type 'a parser = t -> 'a
+
+let capacity t = Bigarray.Array1.dim t.buf
+
+let of_flow ?initial_size ~max_size flow =
+  let flow = (flow :> Flow.read) in
+  if max_size <= 0 then Fmt.invalid_arg "Max size %d should be positive!" max_size;
+  let initial_size = Option.value initial_size ~default:(min 4096 max_size) in
+  let buf = Bigarray.(Array1.create char c_layout initial_size) in
+  { buf; pos = 0; len = 0; flow = Some flow; max_size }
+
+let peek t =
+  Cstruct.of_bigarray ~off:t.pos ~len:t.len t.buf
+
+let consume t n =
+  if n < 0 || n > t.len then Fmt.invalid_arg "Can't consume %d bytes of a %d byte buffer!" n t.len;
+  t.pos <- t.pos + n;
+  t.len <- t.len - n
+
+let buffered_bytes t = t.len
+
+let eof_seen t = t.flow = None
+
+let ensure t n =
+  assert (n >= 0);
+  if t.len < n then (
+    (* We don't have enough data yet, so we'll need to do a read. *)
+    match t.flow with
+    | None -> raise End_of_file
+    | Some flow ->
+      (* If the buffer is empty, we might as well use all of it: *)
+      if t.len = 0 then t.pos <- 0;
+      let () =
+        let cap = capacity t in
+        if n > cap then (
+          (* [n] bytes won't fit. We need to resize the buffer. *)
+          if n > t.max_size then raise Buffer_limit_exceeded;
+          let new_size = max n (min t.max_size (cap * 2)) in
+          let new_buf = Bigarray.(Array1.create char c_layout new_size) in
+          Cstruct.blit
+            (peek t) 0
+            (Cstruct.of_bigarray new_buf) 0
+            t.len;
+          t.pos <- 0;
+          t.buf <- new_buf
+        ) else if t.pos + n > cap then (
+          (* [n] bytes will fit in the existing buffer, but we need to compact it first. *)
+          Cstruct.blit
+            (peek t) 0
+            (Cstruct.of_bigarray t.buf) 0
+            t.len;
+          t.pos <- 0
+        )
+      in
+      try
+        while t.len < n do
+          let free_space = Cstruct.of_bigarray t.buf ~off:(t.pos + t.len) in
+          assert (t.len + Cstruct.length free_space >= n);
+          let got = Flow.read_into flow free_space in
+          t.len <- t.len + got
+        done
+      with End_of_file ->
+        t.flow <- None;
+        raise End_of_file
+  );
+  assert (buffered_bytes t >= n)
+
+let as_flow t =
+  object (_ : Flow.read)
+    method read_methods = []
+
+    method read_into dst =
+      ensure t 1;
+      let len = min (buffered_bytes t) (Cstruct.length dst) in
+      Cstruct.blit (peek t) 0 dst 0 len;
+      consume t len;
+      len
+  end
+
+let get t i =
+  Bigarray.Array1.get t.buf (t.pos + i)
+
+let char c t =
+  ensure t 1;
+  let c2 = get t 0 in
+  if c <> c2 then Fmt.failwith "Expected %C but got %C" c c2;
+  consume t 1
+
+let any_char t =
+  ensure t 1;
+  let c = get t 0 in
+  consume t 1;
+  c
+
+let take len t =
+  ensure t len;
+  let data = Cstruct.to_string (Cstruct.of_bigarray t.buf ~off:t.pos ~len) in
+  consume t len;
+  data
+
+let string s t =
+  let rec aux i =
+    if i = String.length s then true
+    else if i < t.len then (
+      if get t i = s.[i] then aux (i + 1)
+      else false
+    ) else (
+      ensure t (t.len + 1);
+      aux i
+    )
+  in
+  if not (aux 0) then (
+    let buf = peek t in
+    let len = min (String.length s) (Cstruct.length buf) in
+    Fmt.failwith "Expected %S but got %S"
+      s
+      (Cstruct.to_string buf ~off:0 ~len)
+  )
+
+let take_all t =
+  let data = Cstruct.to_string (peek t) in
+  consume t t.len;
+  data
+
+let count_while p t =
+  let rec aux i =
+    if i < t.len then (
+      if p (get t i) then aux (i + 1)
+      else i
+    ) else (
+      ensure t (t.len + 1);
+      aux i
+    )
+  in
+  try aux 0
+  with End_of_file -> t.len
+
+let take_while p t =
+  let len = count_while p t in
+  let data = Cstruct.to_string (Cstruct.of_bigarray t.buf ~off:t.pos ~len) in
+  consume t len;
+  data
+
+let skip_while p t =
+  let len = count_while p t in
+  consume t len
+
+let line t =
+  (* Return the index of the first '\n', reading more data as needed. *)
+  let rec aux i =
+    if i = t.len then (
+      ensure t (t.len + 1);
+      aux i
+    ) else if get t i = '\n' then (
+      i
+    ) else (
+      aux (i + 1)
+    )
+  in
+  match aux 0 with
+  | exception End_of_file when t.len > 0 -> take_all t
+  | nl ->
+    let len =
+      if nl > 0 && get t (nl - 1) = '\r' then nl - 1
+      else nl
+    in
+    let line = Cstruct.to_string (Cstruct.of_bigarray t.buf ~off:t.pos ~len) in
+    consume t (nl + 1);
+    line

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -19,6 +19,7 @@ module Stream = Stream
 module Exn = Exn
 module Generic = Generic
 module Flow = Flow
+module Buf_read = Buf_read
 module Net = Net
 module Domain_manager = Domain_manager
 module Time = Time

--- a/lib_eio/flow.ml
+++ b/lib_eio/flow.ml
@@ -16,7 +16,7 @@ end
 
 let read_into (t : #read) buf =
   let got = t#read_into buf in
-  assert (got > 0);
+  assert (got > 0 && got <= Cstruct.length buf);
   got
 
 let read_methods (t : #read) = t#read_methods

--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -1,0 +1,321 @@
+```ocaml
+# #require "eio";;
+```
+```ocaml
+module R = Eio.Buf_read;;
+
+let traceln fmt = Fmt.pr ("+" ^^ fmt ^^ "@.")
+
+let peek t =
+  let s = Cstruct.to_string (R.peek t) in
+  assert (String.length s = R.buffered_bytes t);
+  s
+
+let ensure t n =
+  R.ensure t n;
+  peek t
+
+(* The next data to be returned by `mock_flow`. `[]` to raise `End_of_file`: *)
+let next = ref []
+
+let mock_flow = object (_ : #Eio.Flow.read)
+  method read_methods = []
+
+  method read_into buf =
+    match !next with
+    | [] ->
+      traceln "mock_flow returning Eof";
+      raise End_of_file
+    | x :: xs ->
+      let len = min (Cstruct.length buf) (String.length x) in
+      traceln "mock_flow returning %d bytes" len;
+      Cstruct.blit_from_string x 0 buf 0 len;
+      let x' = String.sub x len (String.length x - len) in
+      next := (if x' = "" then xs else x' :: xs);
+      len
+end
+
+let read flow n =
+  let buf = Cstruct.create n in
+  let len = Eio.Flow.read_into flow buf in
+  traceln "Read %S" (Cstruct.to_string buf ~len)
+
+let is_digit = function
+  | '0'..'9' -> true
+  | _ -> false
+```
+
+
+## A simple run-through
+
+```ocaml
+# let i = R.of_flow (Eio.Flow.string_source "Hello") ~max_size:100;;
+val i : R.t = <abstr>
+# peek i;;
+- : string = ""
+# ensure i 1;;
+- : string = "Hello"
+# R.consume i 1;;
+- : unit = ()
+# peek i;;
+- : string = "ello"
+# ensure i 4;;
+- : string = "ello"
+# ensure i 5;;
+Exception: End_of_file.
+# peek i;;
+- : string = "ello"
+# R.consume i 4;;
+- : unit = ()
+# peek i;;
+- : string = ""
+```
+
+## Minimising reads on the underlying flow
+
+```ocaml
+# let i = R.of_flow mock_flow ~initial_size:4 ~max_size:10;;
+val i : R.t = <abstr>
+```
+
+The first read fills the initial buffer:
+```ocaml
+# next := ["hello world!"]; ensure i 1;;
++mock_flow returning 4 bytes
+- : string = "hell"
+```
+
+The next read forces a resize (doubling to 8):
+```ocaml
+# ensure i 5;;
++mock_flow returning 4 bytes
+- : string = "hello wo"
+```
+
+Now the buffer is at max-size (10):
+```ocaml
+# ensure i 9;;
++mock_flow returning 2 bytes
+- : string = "hello worl"
+# ensure i 10;;
+- : string = "hello worl"
+# ensure i 11;;
+Exception: Eio__Buf_read.Buffer_limit_exceeded.
+```
+
+Sometimes, doubling isn't enough. Here we go straight to 10 bytes:
+
+```ocaml
+# let i = R.of_flow mock_flow ~initial_size:4 ~max_size:10;;
+val i : R.t = <abstr>
+# next := ["hello world!"]; ensure i 10;;
++mock_flow returning 10 bytes
+- : string = "hello worl"
+```
+
+## End-of-file
+
+After getting end-of-file, we don't use the flow any more:
+
+```ocaml
+# let i = R.of_flow mock_flow ~initial_size:4 ~max_size:10;;
+val i : R.t = <abstr>
+# next := ["hi"]; ensure i 10;;
++mock_flow returning 2 bytes
++mock_flow returning Eof
+Exception: End_of_file.
+# peek i;;
+- : string = "hi"
+# ensure i 10;;
+Exception: End_of_file.
+# R.take_all i;;
+- : string = "hi"
+# R.take_all i;;
+- : string = ""
+```
+
+## Multiple reads
+
+We might need several reads to fulfill the user's request:
+```ocaml
+# let i = R.of_flow mock_flow ~initial_size:4 ~max_size:10;;
+val i : R.t = <abstr>
+# next := ["one"; "two"; "three"]; ensure i 10;;
++mock_flow returning 3 bytes
++mock_flow returning 3 bytes
++mock_flow returning 4 bytes
+- : string = "onetwothre"
+# R.consume i 4; ensure i 7;;
++mock_flow returning 1 bytes
+- : string = "wothree"
+```
+
+## Reading lines
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:100;;
+val i : R.t = <abstr>
+# next := ["one"; "\ntwo\n"; "three\n"]; R.line i;;
++mock_flow returning 3 bytes
++mock_flow returning 5 bytes
+- : string = "one"
+# R.line i;;
+- : string = "two"
+# R.line i;;
++mock_flow returning 6 bytes
+- : string = "three"
+# R.line i;;
++mock_flow returning Eof
+Exception: End_of_file.
+```
+
+DOS lines:
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:100;;
+val i : R.t = <abstr>
+# next := ["one\r"; "\ntwo\r\n"; "three\r\n"]; R.line i;;
++mock_flow returning 4 bytes
++mock_flow returning 6 bytes
+- : string = "one"
+# R.line i;;
+- : string = "two"
+# R.line i;;
++mock_flow returning 7 bytes
+- : string = "three"
+# R.line i;;
++mock_flow returning Eof
+Exception: End_of_file.
+```
+
+Missing EOL:
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:100;;
+val i : R.t = <abstr>
+# next := ["on"; "e\ntwo"]; R.line i;;
++mock_flow returning 2 bytes
++mock_flow returning 5 bytes
+- : string = "one"
+# R.line i;;
++mock_flow returning Eof
+- : string = "two"
+```
+
+Multiple lines in one read:
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:100;;
+val i : R.t = <abstr>
+# next := ["one\ntwo\n\nthree"]; R.line i;;
++mock_flow returning 14 bytes
+- : string = "one"
+# R.line i;;
+- : string = "two"
+# R.line i;;
+- : string = ""
+# R.line i;;
++mock_flow returning Eof
+- : string = "three"
+# R.line i;;
+Exception: End_of_file.
+```
+
+## Flow interface
+
+```ocaml
+# let bflow = R.of_flow mock_flow ~max_size:100 |> R.as_flow;;
+val bflow : Eio.Flow.read = <obj>
+# next := ["foo"; "bar"]; read bflow 2;;
++mock_flow returning 3 bytes
++Read "fo"
+- : unit = ()
+# read bflow 2;;
++Read "o"
+- : unit = ()
+# read bflow 2;;
++mock_flow returning 3 bytes
++Read "ba"
+- : unit = ()
+# read bflow 2;;
++Read "r"
+- : unit = ()
+# read bflow 2;;
++mock_flow returning Eof
+Exception: End_of_file.
+```
+
+## Characters
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:100;;
+val i : R.t = <abstr>
+# next := ["ab"; "c"]; R.any_char i;;
++mock_flow returning 2 bytes
+- : char = 'a'
+# R.any_char i;;
+- : char = 'b'
+# R.any_char i;;
++mock_flow returning 1 bytes
+- : char = 'c'
+# R.any_char i;;
++mock_flow returning Eof
+Exception: End_of_file.
+```
+
+## Fixed-length strings
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:100;;
+val i : R.t = <abstr>
+# next := ["ab"; "c"]; R.take 1 i;;
++mock_flow returning 2 bytes
+- : string = "a"
+# R.take 3 i;;
++mock_flow returning 1 bytes
++mock_flow returning Eof
+Exception: End_of_file.
+# R.take 2 i;;
+- : string = "bc"
+```
+
+## Literals
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:100;;
+val i : R.t = <abstr>
+# next := ["ab"; "c"]; R.char 'A' i;;
++mock_flow returning 2 bytes
+Exception: Failure "Expected 'A' but got 'a'".
+# R.char 'a' i;;
+- : unit = ()
+# R.string "BC" i;;
+Exception: Failure "Expected \"BC\" but got \"b\"".
+# R.string "bC" i;;
++mock_flow returning 1 bytes
+Exception: Failure "Expected \"bC\" but got \"bc\"".
+# R.string "bcd" i;;
++mock_flow returning Eof
+Exception: End_of_file.
+# R.string "bcd" i;;
+Exception: End_of_file.
+# R.string "bc" i;;
+- : unit = ()
+```
+
+## Scanning
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:100;;
+val i : R.t = <abstr>
+# next := ["aa"; "a0"; "123de"]; R.skip_while ((=) 'a') i;;
++mock_flow returning 2 bytes
++mock_flow returning 2 bytes
+- : unit = ()
+# R.take_while is_digit i;;
++mock_flow returning 5 bytes
+- : string = "0123"
+# R.take_while (Fun.negate is_digit) i;;
++mock_flow returning Eof
+- : string = "de"
+```


### PR DESCRIPTION
This provides a low-level API that allows you to view the internal buffer and mark bytes as consumed, plus a higher-level API for reading characters, strings and lines of text.

Closes #131.

Other languages use similar names:

- Java: BufferedReader
- Python: BufferedReader
- Rust: BufReader
- Go: bufio.Reader
- OCaml:
  - in_channel
  - Lwt_io.(input channel)
  - Async_unix.Reader.t

I originally called it `Buf_reader`, but `Buf_read.line` makes more sense, and is consistent with `Flow.read`.

/cc @bikallem