### PR TITLE
Fix Buf_read.take_all

### DIFF
--- a/lib_eio/buf_read.ml
+++ b/lib_eio/buf_read.ml
@@ -128,9 +128,13 @@ let string s t =
   )
 
 let take_all t =
-  let data = Cstruct.to_string (peek t) in
-  consume t t.len;
-  data
+  try
+    while true do ensure t (t.len + 1) done;
+    assert false
+  with End_of_file ->
+    let data = Cstruct.to_string (peek t) in
+    consume t t.len;
+    data
 
 let count_while p t =
   let rec aux i =

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -530,7 +530,8 @@ module Buf_read : sig
 
   val take_all : string parser
   (** [take_all] takes all remaining data until end-of-file.
-      Returns [""] if already at end-of-file. *)
+      Returns [""] if already at end-of-file.
+      @raise Buffer_limit_exceeded if the remaining data exceeds the buffer limit *)
 
   val take_while : (char -> bool) -> string parser
   (** [take_while p] finds the first byte for which [p] is false

--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -319,3 +319,31 @@ val i : R.t = <abstr>
 +mock_flow returning Eof
 - : string = "de"
 ```
+
+## Take all
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:100;;
+val i : R.t = <abstr>
+# next := ["20 text/gemini\r\n"; "# Introduction\n"; "# Conclusion\n"]; R.line i;;
++mock_flow returning 16 bytes
+- : string = "20 text/gemini"
+# R.take_all i;;
++mock_flow returning 15 bytes
++mock_flow returning 13 bytes
++mock_flow returning Eof
+- : string = "# Introduction\n# Conclusion\n"
+```
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:10;;
+val i : R.t = <abstr>
+# next := ["abc"; "def"; "ghi"; "jkl"]; R.take_all i;;
++mock_flow returning 3 bytes
++mock_flow returning 3 bytes
++mock_flow returning 3 bytes
++mock_flow returning 1 bytes
+Exception: Eio__Buf_read.Buffer_limit_exceeded.
+# R.take 3 i;;
+- : string = "abc"
+```


### PR DESCRIPTION
It was supposed to take everything in the stream, not just everything currently in the buffer!