### PR TITLE
Add more functions to Buf_read

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,6 +18,8 @@
   (optint (>= 0.1.0))
   (psq (>= 0.2.0))
   (fmt (>= 0.8.9))
+  (astring (and (>= 0.8.5) :with-test))
+  (crowbar (and (>= 0.2) :with-test))
   (alcotest (and (>= 1.4.0) :with-test))))
 (package
  (name eio_linux)

--- a/eio.opam
+++ b/eio.opam
@@ -16,6 +16,8 @@ depends: [
   "optint" {>= "0.1.0"}
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}
+  "astring" {>= "0.8.5" & with-test}
+  "crowbar" {>= "0.2" & with-test}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,0 +1,4 @@
+(test
+  (package eio)
+  (libraries cstruct crowbar fmt astring eio)
+  (name test))

--- a/fuzz/test.ml
+++ b/fuzz/test.ml
@@ -1,0 +1,164 @@
+(* This file contains a simple model of `Buf_read`, using a single string.
+   It runs random operations on both the model and the real buffer and
+   checks they always give the same result. *)
+
+open Astring
+
+let debug = false
+
+module Buf_read = Eio.Buf_read
+exception Buffer_limit_exceeded = Buf_read.Buffer_limit_exceeded
+
+let initial_size = 10
+let max_size = 100
+
+let mock_flow next = object (self : #Eio.Flow.read)
+  val mutable next = next
+
+  method read_methods = []
+
+  method read_into buf =
+    match next with
+    | [] ->
+      raise End_of_file
+    | "" :: xs ->
+      next <- xs;
+      self#read_into buf
+    | x :: xs ->
+      let len = min (Cstruct.length buf) (String.length x) in
+      Cstruct.blit_from_string x 0 buf 0 len;
+      let x' = String.with_index_range x ~first:len in
+      next <- (if x' = "" then xs else x' :: xs);
+      len
+end
+
+module Model = struct
+  type t = string ref
+
+  let of_chunks chunks = ref (String.concat chunks)
+
+  let take_all t =
+    let old = !t in
+    if String.length old >= max_size then raise Buffer_limit_exceeded;
+    t := "";
+    old
+
+  let line t =
+    match String.cut ~sep:"\n" !t with
+    | Some (line, rest) ->
+      if String.length line >= max_size then raise Buffer_limit_exceeded;
+      t := rest;
+      if String.is_suffix ~affix:"\r" line then String.with_index_range line ~last:(String.length line - 2)
+      else line
+    | None when !t = "" -> raise End_of_file
+    | None when String.length !t >= max_size -> raise Buffer_limit_exceeded
+    | None -> take_all t
+
+  let any_char t =
+    match !t with
+    | "" -> raise End_of_file
+    | s ->
+      t := String.with_index_range s ~first:1;
+      String.get_head s
+
+  let peek_char t = String.head !t
+
+  let consume t n =
+    t := String.with_index_range !t ~first:n
+
+  let char c t =
+    match peek_char t with
+    | Some c2 when c = c2 -> consume t 1
+    | Some _ -> failwith "char"
+    | None -> raise End_of_file
+
+  let string s t =
+    if debug then Fmt.pr "string %S@." s;
+    let len_t = String.length !t in
+    if not (String.is_prefix ~affix:(String.with_range s ~len:len_t) !t) then failwith "string";
+    if String.length s > max_size then raise Buffer_limit_exceeded;
+    if String.is_prefix ~affix:s !t then consume t (String.length s)
+    else raise End_of_file
+
+  let take n t =
+    if n < 0 then invalid_arg "neg";
+    if n > max_size then raise Buffer_limit_exceeded
+    else if String.length !t >= n then (
+      let data = String.with_range !t ~len:n in
+      t := String.with_range !t ~first:n;
+      data
+    ) else raise End_of_file
+
+  let take_while p t =
+    match String.find (Fun.negate p) !t with
+    | Some i when i >= max_size -> raise Buffer_limit_exceeded
+    | Some i ->
+      let data = String.with_range !t ~len:i in
+      consume t i;
+      data
+    | None -> take_all t
+
+  let skip_while p t =
+    match String.find (Fun.negate p) !t with
+    | Some i -> consume t i
+    | None -> t := ""
+
+  let skip n t =
+    if n < 0 then invalid_arg "skip";
+    if n > String.length !t then (
+      t := "";
+      raise End_of_file;
+    );
+    consume t n
+end
+
+type op = Op : 'a Crowbar.printer * 'a Buf_read.parser * (Model.t -> 'a) -> op
+
+let unit = Fmt.(const string) "()"
+let dump_char f c = Fmt.pf f "%C" c
+
+let digit = function
+  | '0'..'9' -> true
+  | _ -> false
+
+let op =
+  let label (name, gen) = Crowbar.with_printer Fmt.(const string name) gen in
+  Crowbar.choose @@ List.map label [
+    "line", Crowbar.const @@ Op (Fmt.Dump.string, Buf_read.line, Model.line);
+    "char 'x'", Crowbar.const @@ Op (unit, Buf_read.char 'x', Model.char 'x');
+    "any_char", Crowbar.const @@ Op (dump_char, Buf_read.any_char, Model.any_char);
+    "peek_char", Crowbar.const @@ Op (Fmt.Dump.option dump_char, Buf_read.peek_char, Model.peek_char);
+    "string", Crowbar.(map [bytes]) (fun s -> Op (unit, Buf_read.string s, Model.string s));
+    "take", Crowbar.(map [int]) (fun n -> Op (Fmt.Dump.string, Buf_read.take n, Model.take n));
+    "take_all", Crowbar.const @@ Op (Fmt.Dump.string, Buf_read.take_all, Model.take_all);
+    "take_while digit", Crowbar.const @@ Op (Fmt.Dump.string, Buf_read.take_while digit, Model.take_while digit);
+    "skip_while digit", Crowbar.const @@ Op (unit, Buf_read.skip_while digit, Model.skip_while digit);
+    "skip", Crowbar.(map [int]) (fun n -> Op (unit, Buf_read.skip n, Model.skip n));
+  ]
+
+let catch f x =
+  match f x with
+  | y -> Ok y
+  | exception End_of_file -> Error "EOF"
+  | exception Invalid_argument _ -> Error "Invalid"
+  | exception Failure _ -> Error "Failure"
+  | exception Buffer_limit_exceeded -> Error "TooBig"
+
+let random chunks ops =
+  let model = Model.of_chunks chunks in
+  let r = Buf_read.of_flow (mock_flow chunks) ~initial_size ~max_size in
+  if debug then print_endline "*** start ***";
+  let check_eq (Op (pp, a, b)) =
+    if debug then (
+      Fmt.pr "---@.";
+      Fmt.pr "real :%S@." (Cstruct.to_string (Buf_read.peek r));
+      Fmt.pr "model:%S@." !model;
+    );
+    let x = catch a r in
+    let y = catch b model in
+    Crowbar.check_eq ~pp:Fmt.(result ~ok:pp ~error:string) x y
+  in
+  List.iter check_eq ops
+
+let () =
+  Crowbar.(add_test ~name:"random ops" [list bytes; list op] random)

--- a/lib_eio/buf_read.ml
+++ b/lib_eio/buf_read.ml
@@ -5,6 +5,7 @@ type t = {
   mutable pos : int;
   mutable len : int;
   mutable flow : Flow.read option;      (* None if we've seen eof *)
+  mutable consumed : int;               (* Total bytes consumed so far *)
   max_size : int;
 }
 
@@ -35,6 +36,8 @@ module Syntax = struct
     b t
 end
 
+open Syntax
+
 let capacity t = Bigarray.Array1.dim t.buf
 
 let of_flow ?initial_size ~max_size flow =
@@ -42,7 +45,7 @@ let of_flow ?initial_size ~max_size flow =
   if max_size <= 0 then Fmt.invalid_arg "Max size %d should be positive!" max_size;
   let initial_size = Option.value initial_size ~default:(min 4096 max_size) in
   let buf = Bigarray.(Array1.create char c_layout initial_size) in
-  { buf; pos = 0; len = 0; flow = Some flow; max_size }
+  { buf; pos = 0; len = 0; flow = Some flow; max_size; consumed = 0 }
 
 let peek t =
   Cstruct.of_bigarray ~off:t.pos ~len:t.len t.buf
@@ -50,9 +53,16 @@ let peek t =
 let consume t n =
   if n < 0 || n > t.len then Fmt.invalid_arg "Can't consume %d bytes of a %d byte buffer!" n t.len;
   t.pos <- t.pos + n;
-  t.len <- t.len - n
+  t.len <- t.len - n;
+  t.consumed <- t.consumed + n
+
+let consume_all t =
+  t.consumed <- t.consumed + t.len;
+  t.len <- 0
 
 let buffered_bytes t = t.len
+
+let consumed_bytes t = t.consumed
 
 let eof_seen t = t.flow = None
 
@@ -206,7 +216,7 @@ let rec skip n t =
     consume t n
   ) else (
     let n = n - t.len in
-    t.len <- 0;
+    consume_all t;
     ensure t (min n (capacity t));
     skip n t
   )
@@ -241,3 +251,25 @@ let line t =
     let line = Cstruct.to_string (Cstruct.of_bigarray t.buf ~off:t.pos ~len) in
     consume t (nl + 1);
     line
+
+let eof t =
+  if t.len = 0 && eof_seen t then ()
+  else (
+    match ensure t 1 with
+    | () -> failwith "Unexpected data after parsing"
+    | exception End_of_file -> ()
+  )
+
+let pp_pos f t =
+  Fmt.pf f "at offset %d" (consumed_bytes t)
+
+let format_errors p t =
+  match p t with
+  | v -> Ok v
+  | exception Failure msg -> Fmt.error_msg "%s (%a)" msg pp_pos t
+  | exception End_of_file -> Fmt.error_msg "Unexpected end-of-file at offset %d" (t.consumed + t.len)
+  | exception Buffer_limit_exceeded -> Fmt.error_msg "Buffer size limit exceeded when reading %a" pp_pos t
+
+let parse ?initial_size ~max_size p flow =
+  let buf = of_flow flow ?initial_size ~max_size in
+  format_errors (p <* eof) buf

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -498,7 +498,7 @@ module Buf_read : sig
   (** An ['a parser] is a function that consumes and returns a value of type ['a].
       @raise Failure The flow can't be parsed as a value of type ['a].
       @raise End_of_file The flow ended without enough data to parse an ['a].
-      @raise Buffer_limit_exceeded The value was larger than the maximum requested buffer size. *)
+      @raise Buffer_limit_exceeded The value was larger than the requested maximum buffer size. *)
 
   val parse : ?initial_size:int -> max_size:int -> 'a parser -> #Flow.read -> ('a, [> `Msg of string]) result
   (** [parse p flow ~max_size] uses [p] to parse everything in [flow].

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -551,12 +551,14 @@ module Buf_read : sig
 
   val skip_while : (char -> bool) -> unit parser
   (** [skip_while p] skips zero or more bytes for which [p] is [true].
-      [skip_while p t] does the same thing as [ignore (take_while p t)]. *)
+      [skip_while p t] does the same thing as [ignore (take_while p t)],
+      except that it is not limited by the buffer size. *)
 
   val skip : int -> unit parser
   (** [skip n] discards the next [n] bytes.
       [skip n] = [map ignore (take n)],
-      except that the number of skipped bytes may be larger than the buffer (it will not grow). *)
+      except that the number of skipped bytes may be larger than the buffer (it will not grow).
+      Note: if [End_of_file] is raised, all bytes in the stream will have been consumed. *)
 
   (** {2 Combinators} *)
 

--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -431,3 +431,27 @@ Exception: Failure "Expected 'a' but got 'b'".
 +mock_flow returning 2 bytes
 - : char = 'b'
 ```
+
+## Error handling
+
+```ocaml
+# test ["abc"] R.(format_errors (take 3));;
++mock_flow returning 3 bytes
+- : (string, [> `Msg of string ]) result = Ok "abc"
+
+# test ["abc"] R.(format_errors (take 2 <* eof));;
++mock_flow returning 3 bytes
+- : (string, [> `Msg of string ]) result =
+Error (`Msg "Unexpected data after parsing (at offset 2)")
+
+# test ["abc"] R.(format_errors (take 4 <* eof));;
++mock_flow returning 3 bytes
++mock_flow returning Eof
+- : (string, [> `Msg of string ]) result =
+Error (`Msg "Unexpected end-of-file at offset 3")
+
+# test ~max_size:2 ["abc"] R.(format_errors line);;
++mock_flow returning 2 bytes
+- : (string, [> `Msg of string ]) result =
+Error (`Msg "Buffer size limit exceeded when reading at offset 0")
+```

--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -317,6 +317,8 @@ Exception: End_of_file.
 Exception: End_of_file.
 # R.string "bc" i;;
 - : unit = ()
+# peek i;;
+- : string = ""
 ```
 
 ## Scanning


### PR DESCRIPTION
This adds some more common functions and syntax (matching the Angstrom API): `peek_char`, `skip`, `pair`, `map`, `bind`, `*>` and `<*`.