### PR TITLE
Add Buf_read.{seq,lines} and Dir.{load,save} convenience functions

### DIFF
--- a/fuzz/test.ml
+++ b/fuzz/test.ml
@@ -111,8 +111,13 @@ module Model = struct
     );
     consume t n
 
-  let eof t =
+  let end_of_input t =
     if !t <> "" then failwith "not eof"
+
+  let rec lines t =
+    match line t with
+    | line -> line :: lines t
+    | exception End_of_file -> []
 end
 
 type op = Op : 'a Crowbar.printer * 'a Buf_read.parser * (Model.t -> 'a) -> op
@@ -137,7 +142,8 @@ let op =
     "take_while digit", Crowbar.const @@ Op (Fmt.Dump.string, Buf_read.take_while digit, Model.take_while digit);
     "skip_while digit", Crowbar.const @@ Op (unit, Buf_read.skip_while digit, Model.skip_while digit);
     "skip", Crowbar.(map [int]) (fun n -> Op (unit, Buf_read.skip n, Model.skip n));
-    "eof", Crowbar.const @@ Op (unit, Buf_read.eof, Model.eof);
+    "end_of_input", Crowbar.const @@ Op (unit, Buf_read.end_of_input, Model.end_of_input);
+    "lines", Crowbar.const @@ Op (Fmt.Dump.(list string), (Buf_read.(map List.of_seq lines)), Model.lines);
   ]
 
 let catch f x =

--- a/lib_eio/dir.ml
+++ b/lib_eio/dir.ml
@@ -45,3 +45,17 @@ let with_open_out ?append ~create (t:#t) path fn =
 
 let with_open_dir (t:#t) path fn =
   Switch.run @@ fun sw -> fn (open_dir ~sw t path)
+
+let with_lines (t:#t) path fn =
+  with_open_in t path @@ fun flow ->
+  let buf = Buf_read.of_flow flow ~max_size:max_int in
+  fn (Buf_read.lines buf)
+
+let load (t:#t) path =
+  with_open_in t path @@ fun flow ->
+  let buf = Buf_read.of_flow flow ~max_size:max_int in
+  Buf_read.take_all buf
+
+let save ?append ~create (t:#t) path data =
+  with_open_out ?append ~create t path @@ fun flow ->
+  Flow.copy_string data flow

--- a/lib_eio/utils/trace.ml
+++ b/lib_eio/utils/trace.ml
@@ -1,8 +1,10 @@
 let mutex = Mutex.create ()
 
 let default_traceln ?__POS__:pos fmt =
-  let b = Buffer.create 512 in
-  let k f =
+  let k go =
+    let b = Buffer.create 512 in
+    let f = Format.formatter_of_buffer b in
+    go f;
     Option.iter (fun (file, lnum, _, _) -> Format.fprintf f " [%s:%d]" file lnum) pos;
     Format.pp_close_box f ();
     Format.pp_print_flush f ();
@@ -14,4 +16,4 @@ let default_traceln ?__POS__:pos fmt =
     List.iter (Printf.eprintf "+%s\n") lines;
     flush stderr
   in
-  Format.kfprintf k (Format.formatter_of_buffer b) ("@[" ^^ fmt)
+  Format.kdprintf k ("@[" ^^ fmt)

--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -439,12 +439,12 @@ Exception: Failure "Expected 'a' but got 'b'".
 +mock_flow returning 3 bytes
 - : (string, [> `Msg of string ]) result = Ok "abc"
 
-# test ["abc"] R.(format_errors (take 2 <* eof));;
+# test ["abc"] R.(format_errors (take 2 <* end_of_input));;
 +mock_flow returning 3 bytes
 - : (string, [> `Msg of string ]) result =
 Error (`Msg "Unexpected data after parsing (at offset 2)")
 
-# test ["abc"] R.(format_errors (take 4 <* eof));;
+# test ["abc"] R.(format_errors (take 4 <* end_of_input));;
 +mock_flow returning 3 bytes
 +mock_flow returning Eof
 - : (string, [> `Msg of string ]) result =
@@ -454,4 +454,28 @@ Error (`Msg "Unexpected end-of-file at offset 3")
 +mock_flow returning 2 bytes
 - : (string, [> `Msg of string ]) result =
 Error (`Msg "Buffer size limit exceeded when reading at offset 0")
+```
+
+## Sequences
+
+```ocaml
+# test ["one"; "\ntwo\n"; "three"] R.lines |> Seq.iter (traceln "%S");;
++mock_flow returning 3 bytes
++mock_flow returning 5 bytes
++"one"
++"two"
++mock_flow returning 5 bytes
++mock_flow returning Eof
++"three"
+- : unit = ()
+
+# test ["abcd1234"] R.(seq (take 2)) |> List.of_seq |> String.concat ",";;
++mock_flow returning 8 bytes
++mock_flow returning Eof
+- : string = "ab,cd,12,34"
+
+# test ["abcd123"] R.(seq (take 2)) |> List.of_seq |> String.concat ",";;
++mock_flow returning 7 bytes
++mock_flow returning Eof
+Exception: End_of_file.
 ```


### PR DESCRIPTION
This makes it easy to load and save whole files, or to read a file line by line.

Also, adds `at_end_of_input` and renames `eof` to `end_of_input` to match Angstrom.

Also, fix a bug in `traceln` where partially applying it resulting in multiple uses sharing the same buffer.