### PR TITLE
Simplify Flow interface

### DIFF
--- a/fuzz/test.ml
+++ b/fuzz/test.ml
@@ -12,7 +12,9 @@ exception Buffer_limit_exceeded = Buf_read.Buffer_limit_exceeded
 let initial_size = 10
 let max_size = 100
 
-let mock_flow next = object (self : #Eio.Flow.read)
+let mock_flow next = object (self)
+  inherit Eio.Flow.source
+
   val mutable next = next
 
   method read_methods = []

--- a/lib_eio/dir.ml
+++ b/lib_eio/dir.ml
@@ -8,10 +8,8 @@ exception Already_exists of path * exn
 exception Not_found of path * exn
 exception Permission_denied of path * exn
 
-class virtual rw = object (_ : #Generic.t)
+class virtual rw = object (_ : <Generic.t; Flow.source; Flow.sink; ..>)
   method probe _ = None
-  inherit Flow.read
-  inherit Flow.write
 end
 
 type create = [`Never | `If_missing of Unix_perm.t | `Or_truncate of Unix_perm.t | `Exclusive of Unix_perm.t]

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -756,7 +756,7 @@ module Objects = struct
     let chunk_cs = Uring.Region.to_cstruct chunk in
     try
       while true do
-        let got = Eio.Flow.read_into src chunk_cs in
+        let got = Eio.Flow.read src chunk_cs in
         write dst chunk got
       done
     with End_of_file -> ()

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -374,7 +374,7 @@ module Objects = struct
       let buf = Luv.Buffer.create 4096 in
       try
         while true do
-          let got = Eio.Flow.read_into src (Cstruct.of_bigarray buf) in
+          let got = Eio.Flow.read src (Cstruct.of_bigarray buf) in
           let sub = Luv.Buffer.sub buf ~offset:0 ~length:got in
           File.write fd [sub]
         done
@@ -401,7 +401,7 @@ module Objects = struct
       let buf = Luv.Buffer.create 4096 in
       try
         while true do
-          let got = Eio.Flow.read_into src (Cstruct.of_bigarray buf) in
+          let got = Eio.Flow.read src (Cstruct.of_bigarray buf) in
           let buf' = Luv.Buffer.sub buf ~offset:0 ~length:got in
           Stream.write sock [buf']
         done

--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -19,7 +19,9 @@ let ensure t n =
 (* The next data to be returned by `mock_flow`. `[]` to raise `End_of_file`: *)
 let next = ref []
 
-let mock_flow = object (_ : #Eio.Flow.read)
+let mock_flow = object
+  inherit Eio.Flow.source
+
   method read_methods = []
 
   method read_into buf =
@@ -38,7 +40,7 @@ end
 
 let read flow n =
   let buf = Cstruct.create n in
-  let len = Eio.Flow.read_into flow buf in
+  let len = Eio.Flow.read flow buf in
   traceln "Read %S" (Cstruct.to_string buf ~len)
 
 let is_digit = function
@@ -231,7 +233,7 @@ Exception: End_of_file.
 
 ```ocaml
 # let bflow = R.of_flow mock_flow ~max_size:100 |> R.as_flow;;
-val bflow : Eio.Flow.read = <obj>
+val bflow : Eio.Flow.source = <obj>
 # next := ["foo"; "bar"]; read bflow 2;;
 +mock_flow returning 3 bytes
 +Read "fo"


### PR DESCRIPTION
Remove `read` and `write` classes and just use `source` and `sink` for everything.

Rename `Flow.read_into src buf` to just `Flow.read src buf`, which makes more sense.