### PR TITLE
Move low-level backend functions to submodules

### DIFF
--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -46,133 +46,135 @@ module FD : sig
       @raise Invalid_arg if [t] is closed. *)
 end
 
-val noop : unit -> unit
-(** [noop ()] performs a uring noop. This is only useful for benchmarking. *)
-
-(** {1 Time functions} *)
-
-val sleep_until : float -> unit
-(** [sleep_until time] blocks until the current time is [time]. *)
-
-(** {1 Memory allocation functions} *)
-
-val alloc : unit -> Uring.Region.chunk
-
-val free : Uring.Region.chunk -> unit
-
-val with_chunk : (Uring.Region.chunk -> 'a) -> 'a
-(** [with_chunk fn] runs [fn chunk] with a freshly allocated chunk and then frees it. *)
-
-(** {1 File manipulation functions} *)
-
-val openfile : sw:Switch.t -> string -> Unix.open_flag list -> int -> FD.t
-(** Like {!Unix.open_file}. *)
-
-val openat2 :
-  sw:Switch.t ->
-  ?seekable:bool ->
-  access:[`R|`W|`RW] ->
-  flags:Uring.Open_flags.t ->
-  perm:Unix.file_perm ->
-  resolve:Uring.Resolve.t ->
-  ?dir:FD.t -> string -> FD.t
-(** [openat2 ~sw ~flags ~perm ~resolve ~dir path] opens [dir/path].
-    See {!Uring.openat2} for details. *)
-
-val read_upto : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> int
-(** [read_upto fd chunk len] reads at most [len] bytes from [fd],
-    returning as soon as some data is available.
-    @param file_offset Read from the given position in [fd] (default: 0).
-    @raise End_of_file Raised if all data has already been read. *)
-
-val read_exactly : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> unit
-(** [read_exactly fd chunk len] reads exactly [len] bytes from [fd],
-    performing multiple read operations if necessary.
-    @param file_offset Read from the given position in [fd] (default: 0).
-    @raise End_of_file Raised if the stream ends before [len] bytes have been read. *)
-
-val readv : ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> int
-(** [readv] is like {!read_upto} but can read into any cstruct(s),
-    not just chunks of the pre-shared buffer.
-    If multiple buffers are given, they are filled in order. *)
-
-val write : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> unit
-(** [write fd buf len] writes exactly [len] bytes from [buf] to [fd].
-    It blocks until the OS confirms the write is done,
-    and resubmits automatically if the OS doesn't write all of it at once. *)
-
-val writev : ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> unit
-(** [writev] is like {!write} but can write from any cstruct(s),
-    not just chunks of the pre-shared buffer.
-    If multiple buffers are given, they are sent in order.
-    It will make multiple OS calls if the OS doesn't write all of it at once. *)
-
-val splice : FD.t -> dst:FD.t -> len:int -> int
-(** [splice src ~dst ~len] attempts to copy up to [len] bytes of data from [src] to [dst].
-    @return The number of bytes copied.
-    @raise End_of_file [src] is at the end of the file.
-    @raise Unix.Unix_error(EINVAL, "splice", _) if splice is not supported for these FDs. *)
-
-val connect : FD.t -> Unix.sockaddr -> unit
-(** [connect fd addr] attempts to connect socket [fd] to [addr]. *)
-
-val await_readable : FD.t -> unit
-(** [await_readable fd] blocks until [fd] is readable (or has an error). *)
-
-val await_writable : FD.t -> unit
-(** [await_writable fd] blocks until [fd] is writable (or has an error). *)
-
-val fstat : FD.t -> Unix.stats
-(** Like {!Unix.fstat}. *)
-
-(** {1 Sockets} *)
-
-val accept : sw:Switch.t -> FD.t -> (FD.t * Unix.sockaddr)
-(** [accept ~sw t] blocks until a new connection is received on listening socket [t].
-    It returns the new connection and the address of the connecting peer.
-    The new connection has the close-on-exec flag set automatically.
-    The new connection is attached to [sw] and will be closed when that finishes, if
-    not already closed manually by then. *)
-
-val shutdown : FD.t -> Unix.shutdown_command -> unit
-(** Like {!Unix.shutdown}. *)
-
-(** {1 Randomness} *)
-
-val getrandom : Cstruct.t -> int
-(**[ getrandom buf] reads some random bytes into [buf] and returns the number of bytes written.
-   It uses Linux's [getrandom] call, which is like reading from /dev/urandom
-   except that it will block (the whole domain) if used at early boot
-   when the random system hasn't been initialised yet. *)
-
 (** {1 Eio API} *)
 
-module Objects : sig
-  type has_fd = < fd : FD.t >
-  type source = < Eio.Flow.source; Eio.Flow.close; has_fd >
-  type sink   = < Eio.Flow.sink  ; Eio.Flow.close; has_fd >
+type has_fd = < fd : FD.t >
+type source = < Eio.Flow.source; Eio.Flow.close; has_fd >
+type sink   = < Eio.Flow.sink  ; Eio.Flow.close; has_fd >
 
-  type stdenv = <
-    stdin  : source;
-    stdout : sink;
-    stderr : sink;
-    net : Eio.Net.t;
-    domain_mgr : Eio.Domain_manager.t;
-    clock : Eio.Time.clock;
-    fs : Eio.Dir.t;
-    cwd : Eio.Dir.t;
-    secure_random : Eio.Flow.source;
-  >
+type stdenv = <
+  stdin  : source;
+  stdout : sink;
+  stderr : sink;
+  net : Eio.Net.t;
+  domain_mgr : Eio.Domain_manager.t;
+  clock : Eio.Time.clock;
+  fs : Eio.Dir.t;
+  cwd : Eio.Dir.t;
+  secure_random : Eio.Flow.source;
+>
 
-  val get_fd : <has_fd; ..> -> FD.t
-  val get_fd_opt : #Eio.Generic.t -> FD.t option
-end
+val get_fd : <has_fd; ..> -> FD.t
+val get_fd_opt : #Eio.Generic.t -> FD.t option
 
-val pipe : Switch.t -> Objects.source * Objects.sink
+val pipe : Switch.t -> source * sink
 (** [pipe sw] is a source-sink pair [(r, w)], where data written to [w] can be read from [r].
     It is implemented as a Unix pipe. *)
 
 (** {1 Main Loop} *)
 
-val run : ?queue_depth:int -> ?block_size:int -> ?polling_timeout:int -> (Objects.stdenv -> unit) -> unit
-(** FIXME queue_depth and block_size should be in a handler and not the mainloop *)
+val run : ?queue_depth:int -> ?block_size:int -> ?polling_timeout:int -> (stdenv -> unit) -> unit
+(** Run an event loop using io_uring.
+    For portable code, you should use {!Eio_main.run} instead, which will use this automatically
+    if running on Linux with a recent-enough kernel version. *)
+
+module Low_level : sig
+  val noop : unit -> unit
+  (** [noop ()] performs a uring noop. This is only useful for benchmarking. *)
+
+  (** {1 Time functions} *)
+
+  val sleep_until : float -> unit
+  (** [sleep_until time] blocks until the current time is [time]. *)
+
+  (** {1 Memory allocation functions} *)
+
+  val alloc : unit -> Uring.Region.chunk
+
+  val free : Uring.Region.chunk -> unit
+
+  val with_chunk : (Uring.Region.chunk -> 'a) -> 'a
+  (** [with_chunk fn] runs [fn chunk] with a freshly allocated chunk and then frees it. *)
+
+  (** {1 File manipulation functions} *)
+
+  val openfile : sw:Switch.t -> string -> Unix.open_flag list -> int -> FD.t
+  (** Like {!Unix.open_file}. *)
+
+  val openat2 :
+    sw:Switch.t ->
+    ?seekable:bool ->
+    access:[`R|`W|`RW] ->
+    flags:Uring.Open_flags.t ->
+    perm:Unix.file_perm ->
+    resolve:Uring.Resolve.t ->
+    ?dir:FD.t -> string -> FD.t
+  (** [openat2 ~sw ~flags ~perm ~resolve ~dir path] opens [dir/path].
+      See {!Uring.openat2} for details. *)
+
+  val read_upto : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> int
+  (** [read_upto fd chunk len] reads at most [len] bytes from [fd],
+      returning as soon as some data is available.
+      @param file_offset Read from the given position in [fd] (default: 0).
+      @raise End_of_file Raised if all data has already been read. *)
+
+  val read_exactly : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> unit
+  (** [read_exactly fd chunk len] reads exactly [len] bytes from [fd],
+      performing multiple read operations if necessary.
+      @param file_offset Read from the given position in [fd] (default: 0).
+      @raise End_of_file Raised if the stream ends before [len] bytes have been read. *)
+
+  val readv : ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> int
+  (** [readv] is like {!read_upto} but can read into any cstruct(s),
+      not just chunks of the pre-shared buffer.
+      If multiple buffers are given, they are filled in order. *)
+
+  val write : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> unit
+  (** [write fd buf len] writes exactly [len] bytes from [buf] to [fd].
+      It blocks until the OS confirms the write is done,
+      and resubmits automatically if the OS doesn't write all of it at once. *)
+
+  val writev : ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> unit
+  (** [writev] is like {!write} but can write from any cstruct(s),
+      not just chunks of the pre-shared buffer.
+      If multiple buffers are given, they are sent in order.
+      It will make multiple OS calls if the OS doesn't write all of it at once. *)
+
+  val splice : FD.t -> dst:FD.t -> len:int -> int
+  (** [splice src ~dst ~len] attempts to copy up to [len] bytes of data from [src] to [dst].
+      @return The number of bytes copied.
+      @raise End_of_file [src] is at the end of the file.
+      @raise Unix.Unix_error(EINVAL, "splice", _) if splice is not supported for these FDs. *)
+
+  val connect : FD.t -> Unix.sockaddr -> unit
+  (** [connect fd addr] attempts to connect socket [fd] to [addr]. *)
+
+  val await_readable : FD.t -> unit
+  (** [await_readable fd] blocks until [fd] is readable (or has an error). *)
+
+  val await_writable : FD.t -> unit
+  (** [await_writable fd] blocks until [fd] is writable (or has an error). *)
+
+  val fstat : FD.t -> Unix.stats
+  (** Like {!Unix.fstat}. *)
+
+  (** {1 Sockets} *)
+
+  val accept : sw:Switch.t -> FD.t -> (FD.t * Unix.sockaddr)
+  (** [accept ~sw t] blocks until a new connection is received on listening socket [t].
+      It returns the new connection and the address of the connecting peer.
+      The new connection has the close-on-exec flag set automatically.
+      The new connection is attached to [sw] and will be closed when that finishes, if
+      not already closed manually by then. *)
+
+  val shutdown : FD.t -> Unix.shutdown_command -> unit
+  (** Like {!Unix.shutdown}. *)
+
+  (** {1 Randomness} *)
+
+  val getrandom : Cstruct.t -> int
+  (**[ getrandom buf] reads some random bytes into [buf] and returns the number of bytes written.
+     It uses Linux's [getrandom] call, which is like reading from /dev/urandom
+     except that it will block (the whole domain) if used at early boot
+     when the random system hasn't been initialised yet. *)
+end

--- a/lib_eio_linux/tests/basic_eio_linux.ml
+++ b/lib_eio_linux/tests/basic_eio_linux.ml
@@ -1,6 +1,6 @@
 (* basic tests using effects *)
 
-open Eio_linux
+open Eio_linux.Low_level
 open Eio.Std
 module Int63 = Optint.Int63
 
@@ -11,7 +11,7 @@ let setup_log level =
 
 let () =
   setup_log (Some Logs.Debug);
-  run @@ fun _stdenv ->
+  Eio_linux.run @@ fun _stdenv ->
   Switch.run @@ fun sw ->
   let fd = Unix.handle_unix_error (openfile ~sw "test.txt" Unix.[O_RDONLY]) 0 in
   let buf = alloc () in

--- a/lib_eio_linux/tests/bench_noop.ml
+++ b/lib_eio_linux/tests/bench_noop.ml
@@ -13,7 +13,7 @@ let main ~clock =
           for _ = 1 to n_fibres do
             Fibre.fork ~sw (fun () ->
                 for _ = 1 to n_iters do
-                  Eio_linux.noop ()
+                  Eio_linux.Low_level.noop ()
                 done
               )
           done

--- a/lib_eio_linux/tests/eurcp_lib.ml
+++ b/lib_eio_linux/tests/eurcp_lib.ml
@@ -2,7 +2,7 @@
 
 open Eio.Std
 
-module U = Eio_linux
+module U = Eio_linux.Low_level
 module Int63 = Optint.Int63
 
 let read_then_write_chunk infd outfd file_offset len =
@@ -26,12 +26,12 @@ let copy_file infd outfd insize block_size =
   copy_block Int63.zero
 
 let run_cp block_size queue_depth infile outfile () =
-  U.run ~queue_depth ~block_size @@ fun _stdenv ->
+  Eio_linux.run ~queue_depth ~block_size @@ fun _stdenv ->
   Switch.run @@ fun sw ->
   let open Unix in
-  let infd = Eio_linux.openfile ~sw infile [O_RDONLY] 0 in
-  let outfd = Eio_linux.openfile ~sw outfile [O_WRONLY; O_CREAT; O_TRUNC] 0o644 in
-  let insize = Eio_linux.fstat infd |> fun {st_size; _} -> Int63.of_int st_size in
+  let infd = U.openfile ~sw infile [O_RDONLY] 0 in
+  let outfd = U.openfile ~sw outfile [O_WRONLY; O_CREAT; O_TRUNC] 0o644 in
+  let insize = U.fstat infd |> fun {st_size; _} -> Int63.of_int st_size in
   Logs.debug (fun l -> l "eurcp: %s -> %s size %a queue %d bs %d"
                  infile
                  outfile

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -16,115 +16,115 @@
 
 open Eio.Std
 
-type 'a or_error = ('a, Luv.Error.t) result
+module Low_level : sig
+  type 'a or_error = ('a, Luv.Error.t) result
 
-exception Luv_error of Luv.Error.t
+  exception Luv_error of Luv.Error.t
 
-val or_raise : 'a or_error -> 'a
-(** [or_error (Error e)] raises [Luv_error e]. *)
+  val or_raise : 'a or_error -> 'a
+  (** [or_raise (Error e)] raises [Luv_error e]. *)
 
-val await_with_cancel :
-  request:[< `File | `Addr_info | `Name_info | `Random | `Thread_pool ] Luv.Request.t ->
-  (Luv.Loop.t -> ('a -> unit) -> unit) -> 'a
-(** [await_with_cancel ~request fn] converts a function using a luv-style callback to one using effects.
-    It sets the fibre's cancel function to cancel [request], and clears it when the operation completes. *)
+  val await_with_cancel :
+    request:[< `File | `Addr_info | `Name_info | `Random | `Thread_pool ] Luv.Request.t ->
+    (Luv.Loop.t -> ('a -> unit) -> unit) -> 'a
+  (** [await_with_cancel ~request fn] converts a function using a luv-style callback to one using effects.
+      It sets the fibre's cancel function to cancel [request], and clears it when the operation completes. *)
 
-(** {1 Time functions} *)
+  (** {1 Time functions} *)
 
-val sleep_until : float -> unit
-(** [sleep_until time] blocks until the current time is [time]. *)
+  val sleep_until : float -> unit
+  (** [sleep_until time] blocks until the current time is [time]. *)
 
-(** {1 Low-level wrappers for Luv functions} *)
+  (** {1 Low-level wrappers for Luv functions} *)
 
-module File : sig
-  type t
+  module File : sig
+    type t
 
-  val is_open : t -> bool
-  (** [is_open t] is [true] if {!close} hasn't been called yet. *)
+    val is_open : t -> bool
+    (** [is_open t] is [true] if {!close} hasn't been called yet. *)
 
-  val close : t -> unit
-  (** [close t] closes [t].
-      @raise Invalid_arg if [t] is already closed. *)
+    val close : t -> unit
+    (** [close t] closes [t].
+        @raise Invalid_arg if [t] is already closed. *)
 
-  val of_luv : sw:Switch.t -> Luv.File.t -> t
-  (** [of_luv ~sw fd] wraps [fd] as an open file descriptor.
-      This is unsafe if [fd] is closed directly (before or after wrapping it).
-      @param sw The FD is closed when [sw] is released, if not closed manually first. *)
+    val of_luv : sw:Switch.t -> Luv.File.t -> t
+    (** [of_luv ~sw fd] wraps [fd] as an open file descriptor.
+        This is unsafe if [fd] is closed directly (before or after wrapping it).
+        @param sw The FD is closed when [sw] is released, if not closed manually first. *)
 
-  val to_luv : t -> Luv.File.t
-  (** [to_luv t] returns the wrapped descriptor.
-      This allows unsafe access to the FD.
-      @raise Invalid_arg if [t] is closed. *)
+    val to_luv : t -> Luv.File.t
+    (** [to_luv t] returns the wrapped descriptor.
+        This allows unsafe access to the FD.
+        @raise Invalid_arg if [t] is closed. *)
 
-  val open_ :
-    sw:Switch.t ->
-    ?mode:Luv.File.Mode.t list ->
-    string -> Luv.File.Open_flag.t list -> t or_error
-  (** Wraps {!Luv.File.open_} *)
+    val open_ :
+      sw:Switch.t ->
+      ?mode:Luv.File.Mode.t list ->
+      string -> Luv.File.Open_flag.t list -> t or_error
+    (** Wraps {!Luv.File.open_} *)
 
-  val read : t -> Luv.Buffer.t list -> Unsigned.Size_t.t or_error
-  (** Wraps {!Luv.File.read} *)
+    val read : t -> Luv.Buffer.t list -> Unsigned.Size_t.t or_error
+    (** Wraps {!Luv.File.read} *)
 
-  val write : t -> Luv.Buffer.t list -> unit
-  (** [write t bufs] writes all the data in [bufs] (which may take several calls to {!Luv.File.write}). *)
+    val write : t -> Luv.Buffer.t list -> unit
+    (** [write t bufs] writes all the data in [bufs] (which may take several calls to {!Luv.File.write}). *)
 
-  val realpath : string -> string or_error
-  (** Wraps {!Luv.File.realpath} *)
+    val realpath : string -> string or_error
+    (** Wraps {!Luv.File.realpath} *)
 
-  val mkdir : mode:Luv.File.Mode.t list -> string -> unit or_error
-  (** Wraps {!Luv.File.mkdir} *)
+    val mkdir : mode:Luv.File.Mode.t list -> string -> unit or_error
+    (** Wraps {!Luv.File.mkdir} *)
 
-end
+  end
 
-module Random : sig
-  val fill : Luv.Buffer.t -> unit
-  (** Wraps {!Luv.Random.random} *)
-end
+  module Random : sig
+    val fill : Luv.Buffer.t -> unit
+    (** Wraps {!Luv.Random.random} *)
+  end
 
-module Handle : sig
-  type 'a t
+  module Handle : sig
+    type 'a t
 
-  val is_open : 'a t -> bool
-  (** [is_open t] is [true] if {!close} hasn't been called yet. *)
+    val is_open : 'a t -> bool
+    (** [is_open t] is [true] if {!close} hasn't been called yet. *)
 
-  val close : 'a t -> unit
-  (** [close t] closes [t].
-      @raise Invalid_arg if [t] is already closed. *)
+    val close : 'a t -> unit
+    (** [close t] closes [t].
+        @raise Invalid_arg if [t] is already closed. *)
 
-  val to_luv : 'a t -> 'a Luv.Handle.t
-  (** [to_luv t] returns the wrapped handle.
-      This allows unsafe access to the handle.
-      @raise Invalid_arg if [t] is closed. *)
+    val to_luv : 'a t -> 'a Luv.Handle.t
+    (** [to_luv t] returns the wrapped handle.
+        This allows unsafe access to the handle.
+        @raise Invalid_arg if [t] is closed. *)
 
-  val of_luv : sw:Switch.t -> 'a Luv.Handle.t -> 'a t
-  (** [of_luv ~sw h] wraps [h] as an open handle.
-      This is unsafe if [h] is closed directly (before or after wrapping it).
-      @param sw The handle is closed when [sw] is released, if not closed manually first. *)
+    val of_luv : sw:Switch.t -> 'a Luv.Handle.t -> 'a t
+    (** [of_luv ~sw h] wraps [h] as an open handle.
+        This is unsafe if [h] is closed directly (before or after wrapping it).
+        @param sw The handle is closed when [sw] is released, if not closed manually first. *)
+  end
 end
 
 (** {1 Eio API} *)
 
-module Objects : sig
-  type has_fd = < fd : File.t >
-  type source = < Eio.Flow.source; Eio.Flow.close; has_fd >
-  type sink   = < Eio.Flow.sink  ; Eio.Flow.close; has_fd >
+type has_fd = < fd : Low_level.File.t >
+type source = < Eio.Flow.source; Eio.Flow.close; has_fd >
+type sink   = < Eio.Flow.sink  ; Eio.Flow.close; has_fd >
 
-  type stdenv = <
-    stdin  : source;
-    stdout : sink;
-    stderr : sink;
-    net : Eio.Net.t;
-    domain_mgr : Eio.Domain_manager.t;
-    clock : Eio.Time.clock;
-    fs : Eio.Dir.t;
-    cwd : Eio.Dir.t;
-    secure_random : Eio.Flow.source;
-  >
+type stdenv = <
+  stdin  : source;
+  stdout : sink;
+  stderr : sink;
+  net : Eio.Net.t;
+  domain_mgr : Eio.Domain_manager.t;
+  clock : Eio.Time.clock;
+  fs : Eio.Dir.t;
+  cwd : Eio.Dir.t;
+  secure_random : Eio.Flow.source;
+>
 
-  val get_fd : <has_fd; ..> -> File.t
-  val get_fd_opt : #Eio.Generic.t -> File.t option
-end
+val get_fd : <has_fd; ..> -> Low_level.File.t
+val get_fd_opt : #Eio.Generic.t -> Low_level.File.t option
 
 (** {1 Main Loop} *)
 
-val run : (Objects.stdenv -> unit) -> unit
+val run : (stdenv -> unit) -> unit

--- a/lib_eio_luv/tests/files.md
+++ b/lib_eio_luv/tests/files.md
@@ -9,7 +9,7 @@
 let rec read_exactly fd buf =
   let size = Luv.Buffer.size buf in
   if size > 0 then (
-    let got = Eio_luv.File.read fd [buf] |> Eio_luv.or_raise |> Unsigned.Size_t.to_int in
+    let got = Eio_luv.Low_level.File.read fd [buf] |> Eio_luv.Low_level.or_raise |> Unsigned.Size_t.to_int in
     let next = Luv.Buffer.sub buf ~offset:got ~length:(size - got) in
     read_exactly fd next
   )
@@ -33,11 +33,11 @@ Hello, world!
 ```ocaml
 let main _stdenv =
   Switch.run @@ fun sw ->
-  let fd = Eio_luv.File.open_ ~sw "/dev/zero" [] |> Eio_luv.or_raise in
+  let fd = Eio_luv.Low_level.File.open_ ~sw "/dev/zero" [] |> Eio_luv.Low_level.or_raise in
   let buf = Luv.Buffer.create 4 in
   read_exactly fd buf;
   traceln "Read %S" (Luv.Buffer.to_string buf);
-  Eio_luv.File.close fd
+  Eio_luv.Low_level.File.close fd
 ```
 
 ```ocaml
@@ -54,7 +54,7 @@ let main env =
   Unix.mkfifo name 0o700;
   Fun.protect ~finally:(fun () -> Unix.unlink name) @@ fun () ->
   Switch.run @@ fun sw ->
-  let fd = Eio_luv.File.open_ ~sw name [`NONBLOCK] |> Eio_luv.or_raise in
+  let fd = Eio_luv.Low_level.File.open_ ~sw name [`NONBLOCK] |> Eio_luv.Low_level.or_raise in
   Fibre.both
     (fun () -> read_exactly fd (Luv.Buffer.create 1))
     (fun () -> raise Exit);;


### PR DESCRIPTION
The backends were written before the Eio abstraction was added, and so they started by exposing their own low-level APIs. Then their implementation of Eio got added as a sub-module. This PR reverses that.

So e.g. we now have `Eio_linux.get_fd` (which works on Eio flows) as a top-level function, and `Eio_linux.Low_level.connect` is now burried a bit as you should be using `Eio.Net.connect` instead.