### PR TITLE
UDP interface

### DIFF
--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -36,3 +36,6 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+pin-depends: [
+    ["uring.0.2" "git+https://github.com/patricoferris/ocaml-uring.git#a2cd6f45bd5ebf847987110ae97323e10faebed6"]
+]

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -37,5 +37,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
 pin-depends: [
-    ["uring.0.2" "git+https://github.com/patricoferris/ocaml-uring.git#a2cd6f45bd5ebf847987110ae97323e10faebed6"]
+    ["uring.0.2" "git+https://github.com/ocaml-multicore/ocaml-uring.git#a2cd6f45bd5ebf847987110ae97323e10faebed6"]
 ]

--- a/eio_linux.opam.template
+++ b/eio_linux.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-    ["uring.0.2" "git+https://github.com/patricoferris/ocaml-uring.git#a2cd6f45bd5ebf847987110ae97323e10faebed6"]
+    ["uring.0.2" "git+https://github.com/ocaml-multicore/ocaml-uring.git#a2cd6f45bd5ebf847987110ae97323e10faebed6"]
 ]

--- a/eio_linux.opam.template
+++ b/eio_linux.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+    ["uring.0.2" "git+https://github.com/patricoferris/ocaml-uring.git#a2cd6f45bd5ebf847987110ae97323e10faebed6"]
+]

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -920,15 +920,15 @@ module Net : sig
     method virtual accept : sw:Switch.t -> <Flow.two_way; Flow.close> * Sockaddr.stream
   end
 
-  class virtual ['addr] datagram_socket : object
-    method virtual send : 'addr -> Cstruct.t -> unit
-    method virtual recv : Cstruct.t -> 'addr * int
+  class virtual datagram_socket : object
+    method virtual send : Sockaddr.datagram -> Cstruct.t -> unit
+    method virtual recv : Cstruct.t -> Sockaddr.datagram * int
   end
 
   class virtual t : object
     method virtual listen : reuse_addr:bool -> reuse_port:bool -> backlog:int -> sw:Switch.t -> Sockaddr.stream -> listening_socket
     method virtual connect : sw:Switch.t -> Sockaddr.stream -> <Flow.two_way; Flow.close>
-    method virtual datagram_socket : sw:Switch.t -> Sockaddr.datagram -> Sockaddr.datagram datagram_socket
+    method virtual datagram_socket : sw:Switch.t -> Sockaddr.datagram -> datagram_socket
   end
 
   (** {2 Out-bound Connections} *)
@@ -976,15 +976,15 @@ module Net : sig
 
   (** {2 Datagram Sockets} *)
 
-  val datagram_socket : sw:Switch.t -> #t -> Sockaddr.datagram -> Sockaddr.datagram datagram_socket
-  (** [datagram_socket ~sw t addr] creates a new, datagram socket that data can be sent to
+  val datagram_socket : sw:Switch.t -> #t -> Sockaddr.datagram -> datagram_socket
+  (** [datagram_socket ~sw t addr] creates a new datagram socket that data can be sent to
       and received from. The new socket will be closed when [sw] finishes. *)
 
-  val send : 'addr datagram_socket -> 'addr -> Cstruct.t -> unit
+  val send : datagram_socket -> Sockaddr.datagram -> Cstruct.t -> unit
   (** [send sock addr buf] sends the data in [buf] to the address [addr] using the 
-      the socket [sock]. *)
+      the datagram socket [sock]. *)
 
-  val recv : 'addr datagram_socket -> Cstruct.t -> 'addr * int
+  val recv : datagram_socket -> Cstruct.t -> Sockaddr.datagram * int
   (** [recv sock buf] receives data from the socket [sock] putting it in [buf]. The number of bytes received is 
       returned along with the sender address and port. If the [buf] is too small then excess bytes may be discarded
       depending on the type of the socket the message is received from. *)

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -895,11 +895,19 @@ module Net : sig
 
   (** Network addresses. *)
   module Sockaddr : sig
-    type t = [
+    type stream = [
       | `Unix of string
       | `Tcp of Ipaddr.v4v6 * int
+    ]
+    (** Socket addresses that we can build a {! Flow.two_way} for i.e. stream-oriented
+        protocols. *)
+
+    type datagram = [
       | `Udp of Ipaddr.v4v6 * int
     ]
+    (** Socket addresses that are message-oriented. *)
+
+    type t = [ stream | datagram ]
 
     val pp : Format.formatter -> t -> unit
   end
@@ -909,30 +917,30 @@ module Net : sig
   class virtual listening_socket : object
     inherit Generic.t
     method virtual close : unit
-    method virtual accept : sw:Switch.t -> <Flow.two_way; Flow.close> * Sockaddr.t
+    method virtual accept : sw:Switch.t -> <Flow.two_way; Flow.close> * Sockaddr.stream
   end
 
   class virtual endpoint : object
-    method virtual send : Sockaddr.t -> Cstruct.t -> unit
+    method virtual send : Sockaddr.datagram -> Cstruct.t -> unit
     method virtual recv : Cstruct.t -> (Ipaddr.v4v6 * int) option * int
   end
 
   class virtual t : object
-    method virtual listen : reuse_addr:bool -> reuse_port:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> listening_socket
-    method virtual connect : sw:Switch.t -> Sockaddr.t -> <Flow.two_way; Flow.close>
-    method virtual endpoint : sw:Switch.t -> Sockaddr.t -> endpoint
+    method virtual listen : reuse_addr:bool -> reuse_port:bool -> backlog:int -> sw:Switch.t -> Sockaddr.stream -> listening_socket
+    method virtual connect : sw:Switch.t -> Sockaddr.stream -> <Flow.two_way; Flow.close>
+    method virtual endpoint : sw:Switch.t -> Sockaddr.datagram -> endpoint
   end
 
   (** {2 Out-bound Connections} *)
 
-  val connect : sw:Switch.t -> #t -> Sockaddr.t -> <Flow.two_way; Flow.close>
+  val connect : sw:Switch.t -> #t -> Sockaddr.stream -> <Flow.two_way; Flow.close>
   (** [connect ~sw t addr] is a new socket connected to remote address [addr].
 
       The new socket will be closed when [sw] finishes, unless closed manually first. *)
 
   (** {2 Incoming Connections} *)
 
-  val listen : ?reuse_addr:bool -> ?reuse_port:bool -> backlog:int -> sw:Switch.t -> #t -> Sockaddr.t -> listening_socket
+  val listen : ?reuse_addr:bool -> ?reuse_port:bool -> backlog:int -> sw:Switch.t -> #t -> Sockaddr.stream -> listening_socket
   (** [listen ~sw ~backlog t addr] is a new listening socket bound to local address [addr].
 
       The new socket will be closed when [sw] finishes, unless closed manually first.
@@ -947,7 +955,7 @@ module Net : sig
   val accept :
     sw:Switch.t ->
     #listening_socket ->
-    <Flow.two_way; Flow.close> * Sockaddr.t
+    <Flow.two_way; Flow.close> * Sockaddr.stream
   (** [accept ~sw socket] waits until a new connection is ready on [socket] and returns it.
 
       The new socket will be closed automatically when [sw] finishes, if not closed earlier.
@@ -957,7 +965,7 @@ module Net : sig
     sw:Switch.t ->
     #listening_socket ->
     on_error:(exn -> unit) ->
-    (sw:Switch.t -> <Flow.two_way; Flow.close> -> Sockaddr.t -> unit) ->
+    (sw:Switch.t -> <Flow.two_way; Flow.close> -> Sockaddr.stream -> unit) ->
     unit
   (** [accept socket fn] accepts a connection and handles it in a new fibre.
 
@@ -968,11 +976,11 @@ module Net : sig
 
   (** {2 Datagram Sockets} *)
 
-  val endpoint : sw:Switch.t -> #t -> Sockaddr.t -> endpoint
+  val endpoint : sw:Switch.t -> #t -> Sockaddr.datagram -> endpoint
   (** [endpoint ~sw t addr] creates a new, connectionless endpoint that data can be sent to
       and received from. The new socket will be closed when [sw] finishes. *)
 
-  val send : #endpoint -> Sockaddr.t -> Cstruct.t -> unit
+  val send : #endpoint -> Sockaddr.datagram -> Cstruct.t -> unit
   (** [send e addr buf] sends the data in [buf] to the address [addr] using the endpoint [e]. *)
 
   val recv : #endpoint -> Cstruct.t -> (Ipaddr.v4v6 * int) option * int

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -914,7 +914,7 @@ module Net : sig
 
   class virtual endpoint : object
     method virtual send : Sockaddr.t -> Cstruct.t -> unit
-    method virtual recv : Cstruct.t -> int
+    method virtual recv : Cstruct.t -> (Ipaddr.v4v6 * int) option * int
   end
 
   class virtual t : object
@@ -975,9 +975,10 @@ module Net : sig
   val send : #endpoint -> Sockaddr.t -> Cstruct.t -> unit
   (** [send e addr buf] sends the data in [buf] to the address [addr] using the endpoint [e]. *)
 
-  val recv : #endpoint -> Cstruct.t -> int
+  val recv : #endpoint -> Cstruct.t -> (Ipaddr.v4v6 * int) option * int
   (** [recv e buf] receives data from the endpoint [e] putting it in [buf]. The number of bytes received is 
-      returned, if the [buf] is too small the read my be partial. *)
+      returned along with the sender IP address and port if possible. If the [buf] is too small the read may 
+      be partial. *)
 end
 
 (** Parallel computation across multiple CPU cores. *)

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -144,18 +144,18 @@ let accept_sub ~sw (t : #listening_socket) ~on_error handle =
   let handle sw (flow, addr) = handle ~sw flow addr in
   Fibre.fork_on_accept ~sw accept handle ~on_handler_error:on_error
 
-class virtual ['addr] datagram_socket = object
-  method virtual send : 'addr -> Cstruct.t -> unit
-  method virtual recv : Cstruct.t -> 'addr * int
+class virtual datagram_socket = object
+  method virtual send : Sockaddr.datagram -> Cstruct.t -> unit
+  method virtual recv : Cstruct.t -> Sockaddr.datagram * int
 end
 
-let send (t:'addr #datagram_socket) = t#send
-let recv (t:'addr #datagram_socket) = t#recv
+let send (t:#datagram_socket) = t#send
+let recv (t:#datagram_socket) = t#recv
 
 class virtual t = object
   method virtual listen : reuse_addr:bool -> reuse_port:bool -> backlog:int -> sw:Switch.t -> Sockaddr.stream -> listening_socket
   method virtual connect : sw:Switch.t -> Sockaddr.stream -> <Flow.two_way; Flow.close>
-  method virtual datagram_socket : sw:Switch.t -> Sockaddr.datagram -> Sockaddr.datagram datagram_socket
+  method virtual datagram_socket : sw:Switch.t -> Sockaddr.datagram -> datagram_socket
 end
 
 let listen ?(reuse_addr=false) ?(reuse_port=false) ~backlog ~sw (t:#t) = t#listen ~reuse_addr ~reuse_port ~backlog ~sw

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -114,6 +114,7 @@ module Sockaddr = struct
   type t = [
     | `Unix of string
     | `Tcp of Ipaddr.v4v6 * int
+    | `Udp of Ipaddr.v4v6 * int
   ]
 
   let pp f = function
@@ -121,6 +122,8 @@ module Sockaddr = struct
       Format.fprintf f "unix:%s" path
     | `Tcp (addr, port) ->
       Format.fprintf f "tcp:%a:%d" Ipaddr.pp_for_uri addr port
+    | `Udp (addr, port) ->
+      Format.fprintf f "udp:%a:%d" Ipaddr.pp_for_uri addr port
 end
 
 class virtual listening_socket = object (_ : #Generic.t)
@@ -136,10 +139,21 @@ let accept_sub ~sw (t : #listening_socket) ~on_error handle =
   let handle sw (flow, addr) = handle ~sw flow addr in
   Fibre.fork_on_accept ~sw accept handle ~on_handler_error:on_error
 
+class virtual endpoint = object
+  method virtual send : Sockaddr.t -> Cstruct.t -> unit
+  method virtual recv : Cstruct.t -> int
+end
+
+let send (t:#endpoint) = t#send
+let recv (t:#endpoint) = t#recv
+
 class virtual t = object
   method virtual listen : reuse_addr:bool -> reuse_port:bool -> backlog:int -> sw:Switch.t -> Sockaddr.t -> listening_socket
   method virtual connect : sw:Switch.t -> Sockaddr.t -> <Flow.two_way; Flow.close>
+  method virtual endpoint : sw:Switch.t -> Sockaddr.t -> endpoint
 end
 
 let listen ?(reuse_addr=false) ?(reuse_port=false) ~backlog ~sw (t:#t) = t#listen ~reuse_addr ~reuse_port ~backlog ~sw
 let connect ~sw (t:#t) = t#connect ~sw
+
+let endpoint ~sw (t:#t) = t#endpoint ~sw

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -141,7 +141,7 @@ let accept_sub ~sw (t : #listening_socket) ~on_error handle =
 
 class virtual endpoint = object
   method virtual send : Sockaddr.t -> Cstruct.t -> unit
-  method virtual recv : Cstruct.t -> int
+  method virtual recv : Cstruct.t -> (Ipaddr.v4v6 * int) option * int
 end
 
 let send (t:#endpoint) = t#send

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -144,21 +144,21 @@ let accept_sub ~sw (t : #listening_socket) ~on_error handle =
   let handle sw (flow, addr) = handle ~sw flow addr in
   Fibre.fork_on_accept ~sw accept handle ~on_handler_error:on_error
 
-class virtual endpoint = object
-  method virtual send : Sockaddr.datagram -> Cstruct.t -> unit
-  method virtual recv : Cstruct.t -> (Ipaddr.v4v6 * int) option * int
+class virtual ['addr] datagram_socket = object
+  method virtual send : 'addr -> Cstruct.t -> unit
+  method virtual recv : Cstruct.t -> 'addr * int
 end
 
-let send (t:#endpoint) = t#send
-let recv (t:#endpoint) = t#recv
+let send (t:'addr #datagram_socket) = t#send
+let recv (t:'addr #datagram_socket) = t#recv
 
 class virtual t = object
   method virtual listen : reuse_addr:bool -> reuse_port:bool -> backlog:int -> sw:Switch.t -> Sockaddr.stream -> listening_socket
   method virtual connect : sw:Switch.t -> Sockaddr.stream -> <Flow.two_way; Flow.close>
-  method virtual endpoint : sw:Switch.t -> Sockaddr.datagram -> endpoint
+  method virtual datagram_socket : sw:Switch.t -> Sockaddr.datagram -> Sockaddr.datagram datagram_socket
 end
 
 let listen ?(reuse_addr=false) ?(reuse_port=false) ~backlog ~sw (t:#t) = t#listen ~reuse_addr ~reuse_port ~backlog ~sw
 let connect ~sw (t:#t) = t#connect ~sw
 
-let endpoint ~sw (t:#t) = t#endpoint ~sw
+let datagram_socket ~sw (t:#t) = t#datagram_socket ~sw

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -800,7 +800,7 @@ let fallback_copy src dst =
   with End_of_file -> ()
 
 let udp_socket sock = object
-  inherit [Eio.Net.Sockaddr.datagram] Eio.Net.datagram_socket
+  inherit Eio.Net.datagram_socket
 
   method send sockaddr buf = 
     let addr = match sockaddr with 
@@ -934,7 +934,6 @@ let net = object
       let host = Eio_unix.Ipaddr.to_unix host in
       let addr = Unix.ADDR_INET (host, port) in
       let sock_unix = Unix.socket Unix.PF_INET Unix.SOCK_DGRAM 0 in
-      (* TODO: Should expose these as arguments. *)
       Unix.setsockopt sock_unix Unix.SO_REUSEADDR true;
       Unix.setsockopt sock_unix Unix.SO_REUSEPORT true;
       let sock = FD.of_unix ~sw ~seekable:false ~close_unix:true sock_unix in

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -378,6 +378,26 @@ let rec enqueue_connect fd addr st action =
   if retry then (* wait until an sqe is available *)
     Queue.push (fun st -> enqueue_connect fd addr st action) st.io_q
 
+let rec enqueue_send_to fd addr buf st action =
+  Log.debug (fun l -> l "send_to: submitting call");
+  Ctf.label "send_to";
+  let retry = with_cancel_hook ~action st (fun () ->
+      Uring.send_msg st.uring (FD.get "send_to" fd) addr buf (Job action)
+    )
+  in
+  if retry then (* wait until an sqe is available *)
+    Queue.push (fun st -> enqueue_send_to fd addr buf st action) st.io_q
+
+let rec enqueue_recv_msg fd msghdr st action =
+  Log.debug (fun l -> l "recv_msg: submitting call");
+  Ctf.label "recv_msg";
+  let retry = with_cancel_hook ~action st (fun () ->
+      Uring.recv_msg st.uring (FD.get "recv_msg" fd) msghdr (Job action);
+    )
+  in
+  if retry then (* wait until an sqe is available *)
+    Queue.push (fun st -> enqueue_recv_msg fd msghdr st action) st.io_q 
+
 let rec enqueue_accept fd client_addr st action =
   Log.debug (fun l -> l "accept: submitting call");
   Ctf.label "accept";
@@ -630,6 +650,22 @@ module Low_level = struct
       raise (Unix.Unix_error (Uring.error_of_errno res, "connect", ""))
     )
 
+  let send_to fd addr buf =
+    let res = enter (enqueue_send_to fd addr buf) in
+    Log.debug (fun l -> l "send_to returned");
+    if res < 0 then (
+      raise (Unix.Unix_error (Uring.error_of_errno res, "send_to", ""))
+    )
+
+  let recv_msg fd buf =
+    let msghdr = Uring.Msghdr.create buf in
+    let res = enter (enqueue_recv_msg fd msghdr) in
+    Log.debug (fun l -> l "recv_msg returned");
+    if res < 0 then (
+      raise (Unix.Unix_error (Uring.error_of_errno res, "recv_msg", ""))
+    );
+    Uring.Msghdr.get_sockaddr msghdr, res
+
   let with_chunk fn =
     let chunk = alloc () in
     Fun.protect ~finally:(fun () -> free chunk) @@ fun () ->
@@ -763,6 +799,25 @@ let fallback_copy src dst =
     done
   with End_of_file -> ()
 
+let endpoint sock = object
+  inherit Eio.Net.endpoint
+
+  method send sockaddr buf = 
+    let addr = match sockaddr with 
+      | `Udp (host, port) -> 
+        let host = Eio_unix.Ipaddr.to_unix host in
+        Unix.ADDR_INET (host, port)
+    in
+    Low_level.send_to sock addr [buf] 
+  
+  method recv buf =
+    let addr, recv = Low_level.recv_msg sock [buf] in
+    match Uring.Sockaddr.get addr with
+      | Unix.ADDR_INET (inet, port) ->
+        Some (Eio_unix.Ipaddr.of_unix inet, port), recv
+      | Unix.ADDR_UNIX _ -> None, recv
+end
+
 let flow fd =
   let is_tty = lazy (Unix.isatty (FD.get "isatty" fd)) in
   object (_ : <source; sink; ..>)
@@ -872,6 +927,18 @@ let net = object
     let sock = FD.of_unix ~sw ~seekable:false ~close_unix:true sock_unix in
     Low_level.connect sock addr;
     (flow sock :> <Eio.Flow.two_way; Eio.Flow.close>)
+
+  method endpoint ~sw = function
+    | `Udp (host, port) ->
+      let host = Eio_unix.Ipaddr.to_unix host in
+      let addr = Unix.ADDR_INET (host, port) in
+      let sock_unix = Unix.socket Unix.PF_INET Unix.SOCK_DGRAM 0 in
+      (* TODO: Should expose these as arguments. *)
+      Unix.setsockopt sock_unix Unix.SO_REUSEADDR true;
+      Unix.setsockopt sock_unix Unix.SO_REUSEPORT true;
+      let sock = FD.of_unix ~sw ~seekable:false ~close_unix:true sock_unix in
+      Unix.bind sock_unix addr;
+      endpoint sock
 end
 
 type stdenv = <

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -434,7 +434,7 @@ class virtual ['a] listening_socket ~backlog sock = object (self)
   val ready = Eio.Semaphore.make 0
 
   method private virtual make_client : 'a Luv.Stream.t
-  method private virtual get_client_addr : 'a Stream.t -> Eio.Net.Sockaddr.t
+  method private virtual get_client_addr : 'a Stream.t -> Eio.Net.Sockaddr.stream
 
   method close = Handle.close sock
 
@@ -554,7 +554,6 @@ let net = object
       if String.length path > 0 && path.[0] <> Char.chr 0 then
         Switch.on_release sw (fun () -> Unix.unlink path);
       listening_unix_socket ~backlog sock
-    | _ -> assert false 
 
   (* todo: how do you cancel connect operations with luv? *)
   method connect ~sw = function
@@ -567,7 +566,6 @@ let net = object
       let sock = Luv.Pipe.init ~loop:(get_loop ()) () |> or_raise |> Handle.of_luv ~sw in
       await_exn (fun _loop _fibre -> Luv.Pipe.connect (Handle.get "connect" sock) path);
       socket sock
-    | _ -> assert false
 
   method endpoint ~sw = function
     | `Udp (host, port) -> 
@@ -576,7 +574,6 @@ let net = object
       let addr = luv_addr_of_eio host port in
       Luv.UDP.bind sock addr |> or_raise;
       endpoint (Handle.of_luv ~sw sock)
-    | _ -> assert false
 end
 
 let secure_random =

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -490,9 +490,9 @@ module Endpoint = struct
           )
       ) in
     match r with
-    | Ok (buf', _sockaddr, _recv_flags) -> 
-      (* if List.mem `PARTIAL recv_flags then print_endline "PARTIAL"; Should the Eio API expose partial reading when the buffer is too small *)
-      Luv.Buffer.size buf'
+    | Ok (buf', sockaddr, _recv_flags) -> 
+      (* if List.mem `PARTIAL recv_flags then raise Partial_read; Is this an exception? *)
+      Option.map luv_ip_addr_to_eio sockaddr, Luv.Buffer.size buf'
     | Error (`ECONNRESET as e) -> raise (Eio.Net.Connection_reset (Luv_error e))
     | Error x -> raise (Luv_error x)
 

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -577,9 +577,10 @@ let net = object
     | `Udp (host, port) -> 
       let domain = Eio.Net.Ipaddr.fold ~v4:(fun _ -> `INET) ~v6:(fun _ -> `INET6) host in
       let sock = Luv.UDP.init ~domain ~loop:(get_loop ()) () |> or_raise in
+      let dg_sock = Handle.of_luv ~sw sock in
       let addr = luv_addr_of_eio host port in
       Luv.UDP.bind sock addr |> or_raise;
-      udp_socket (Handle.of_luv ~sw sock)
+      udp_socket dg_sock
 end
 
 let secure_random =

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -510,7 +510,7 @@ module Udp = struct
 end
 
 let udp_socket endp = object
-  inherit [Eio.Net.Sockaddr.datagram] Eio.Net.datagram_socket
+  inherit Eio.Net.datagram_socket
 
   method send sockaddr bufs = Udp.send endp bufs sockaddr 
   method recv buf = 

--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -148,6 +148,30 @@ Calling accept when the switch is already off:
 Exception: Failure "Simulated error".
 ```
 
+Working with UDP and endpoints:
+
+```ocaml
+# run @@ fun ~net sw ->
+  let e1 = `Udp (Eio.Net.Ipaddr.V4.loopback, 8081) in
+  let e2 = `Udp (Eio.Net.Ipaddr.V4.loopback, 8082) in
+  Fibre.both
+    (fun () ->
+      let e = Eio.Net.endpoint ~sw net e2 in
+      let buf = Cstruct.create 20 in
+      traceln "Waiting to receive data from %a" Eio.Net.Sockaddr.pp e2;
+      let recv = Eio.Net.recv e buf in
+      traceln "Received message: %s" (Cstruct.(to_string (sub buf 0 recv)))
+    )
+    (fun () ->
+      let e = Eio.Net.endpoint ~sw net e1 in
+      traceln "Sending data from %a to %a" Eio.Net.Sockaddr.pp e1 Eio.Net.Sockaddr.pp e2;
+      Eio.Net.send e e2 (Cstruct.of_string "UDP Message"));;
++Waiting to receive data from udp:127.0.0.1:8082
++Sending data from udp:127.0.0.1:8081 to udp:127.0.0.1:8082
++Received message: UDP Message
+- : unit = ()
+```
+
 # Unix interop
 
 Extracting file descriptors from Eio objects:

--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -151,6 +151,10 @@ Exception: Failure "Simulated error".
 Working with UDP and endpoints:
 
 ```ocaml
+# let pp_addr ppf (addr, port) = 
+  Fmt.pf ppf "%a:%d" Eio.Net.Ipaddr.pp addr port;;
+val pp_addr :
+  Format.formatter -> [< `V4 | `V6 ] Eio.Net.Ipaddr.t * int -> unit = <fun>
 # run @@ fun ~net sw ->
   let e1 = `Udp (Eio.Net.Ipaddr.V4.loopback, 8081) in
   let e2 = `Udp (Eio.Net.Ipaddr.V4.loopback, 8082) in
@@ -158,17 +162,19 @@ Working with UDP and endpoints:
     (fun () ->
       let e = Eio.Net.endpoint ~sw net e2 in
       let buf = Cstruct.create 20 in
-      traceln "Waiting to receive data from %a" Eio.Net.Sockaddr.pp e2;
-      let recv = Eio.Net.recv e buf in
-      traceln "Received message: %s" (Cstruct.(to_string (sub buf 0 recv)))
+      traceln "Waiting to receive data on %a" Eio.Net.Sockaddr.pp e2;
+      let addr, recv = Eio.Net.recv e buf in
+      traceln "Received message from %a: %s"
+      (Fmt.option pp_addr) addr
+      (Cstruct.(to_string (sub buf 0 recv)))
     )
     (fun () ->
       let e = Eio.Net.endpoint ~sw net e1 in
       traceln "Sending data from %a to %a" Eio.Net.Sockaddr.pp e1 Eio.Net.Sockaddr.pp e2;
       Eio.Net.send e e2 (Cstruct.of_string "UDP Message"));;
-+Waiting to receive data from udp:127.0.0.1:8082
++Waiting to receive data on udp:127.0.0.1:8082
 +Sending data from udp:127.0.0.1:8081 to udp:127.0.0.1:8082
-+Received message: UDP Message
++Received message from 127.0.0.1:8081: UDP Message
 - : unit = ()
 ```
 

--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -151,30 +151,26 @@ Exception: Failure "Simulated error".
 Working with UDP and endpoints:
 
 ```ocaml
-# let pp_addr ppf (addr, port) = 
-  Fmt.pf ppf "%a:%d" Eio.Net.Ipaddr.pp addr port;;
-val pp_addr :
-  Format.formatter -> [< `V4 | `V6 ] Eio.Net.Ipaddr.t * int -> unit = <fun>
 # run @@ fun ~net sw ->
   let e1 = `Udp (Eio.Net.Ipaddr.V4.loopback, 8081) in
   let e2 = `Udp (Eio.Net.Ipaddr.V4.loopback, 8082) in
   Fibre.both
     (fun () ->
-      let e = Eio.Net.endpoint ~sw net e2 in
+      let e = Eio.Net.datagram_socket ~sw net e2 in
       let buf = Cstruct.create 20 in
       traceln "Waiting to receive data on %a" Eio.Net.Sockaddr.pp e2;
       let addr, recv = Eio.Net.recv e buf in
       traceln "Received message from %a: %s"
-      (Fmt.option pp_addr) addr
+      Eio.Net.Sockaddr.pp addr
       (Cstruct.(to_string (sub buf 0 recv)))
     )
     (fun () ->
-      let e = Eio.Net.endpoint ~sw net e1 in
+      let e = Eio.Net.datagram_socket ~sw net e1 in
       traceln "Sending data from %a to %a" Eio.Net.Sockaddr.pp e1 Eio.Net.Sockaddr.pp e2;
       Eio.Net.send e e2 (Cstruct.of_string "UDP Message"));;
 +Waiting to receive data on udp:127.0.0.1:8082
 +Sending data from udp:127.0.0.1:8081 to udp:127.0.0.1:8082
-+Received message from 127.0.0.1:8081: UDP Message
++Received message from udp:127.0.0.1:8081: UDP Message
 - : unit = ()
 ```
 

--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -154,12 +154,12 @@ Working with UDP and endpoints:
 # run @@ fun ~net sw ->
   let e1 = `Udp (Eio.Net.Ipaddr.V4.loopback, 8081) in
   let e2 = `Udp (Eio.Net.Ipaddr.V4.loopback, 8082) in
+  let listening_socket = Eio.Net.datagram_socket ~sw net e2 in
   Fibre.both
     (fun () ->
-      let e = Eio.Net.datagram_socket ~sw net e2 in
       let buf = Cstruct.create 20 in
       traceln "Waiting to receive data on %a" Eio.Net.Sockaddr.pp e2;
-      let addr, recv = Eio.Net.recv e buf in
+      let addr, recv = Eio.Net.recv listening_socket buf in
       traceln "Received message from %a: %s"
       Eio.Net.Sockaddr.pp addr
       (Cstruct.(to_string (sub buf 0 recv)))


### PR DESCRIPTION
This PR hopes to add UDP to Eio's networking interface, for now I'm still not sure about the actual interface so I'm opening this PR early (without uring support for now), in particular I have the following questions:

 - How to distinguish between "connectionful" and "connectionless" protocols, right now everything is just put into `Sockaddr.t` should they be separated ? I did something along those lines [here](https://github.com/patricoferris/eioio/blob/a285d2894cbd19c24ec317c0d0c36154d06289eb/lib_eio/net.ml#L116-L136).
 - Should Eio expose a "connected" UDP socket (like [luv's UDP.Connected](https://aantron.github.io/luv/luv/Luv/UDP/Connected/index.html) or [Tokio's `connect` function for UDP sockets](https://github.com/tokio-rs/tokio/blob/master/tokio/src/net/udp.rs)) which starts to feel more like an `Eio.Flow.two_way`?
 - At the moment the `endpoint` function always binds the host and port to the socket, maybe that shouldn't be the case? 
 - Should the `recv` pass through things like the sender address ?
 - How to handle/expose multicasting? 

Sorry that there's more questions than answers 😅 