### PR TITLE
Remove "broken" state from promises

### DIFF
--- a/lib_eio_linux/tests/test.ml
+++ b/lib_eio_linux/tests/test.ml
@@ -25,7 +25,7 @@ let test_poll_add () =
   Eio_linux.Low_level.await_writable w;
   let sent = Unix.write (Eio_linux.FD.to_unix `Peek w) (Bytes.of_string "!") 0 1 in
   assert (sent = 1);
-  let result = Promise.await thread in
+  let result = Promise.await_exn thread in
   Alcotest.(check string) "Received data" "!" result
 
 let test_poll_add_busy () =
@@ -38,9 +38,9 @@ let test_poll_add_busy () =
   let w = Option.get (Eio_linux.get_fd_opt w) |> Eio_linux.FD.to_unix `Peek in
   let sent = Unix.write w (Bytes.of_string "!!") 0 2 in
   assert (sent = 2);
-  let a = Promise.await a in
+  let a = Promise.await_exn a in
   Alcotest.(check string) "Received data" "!" a;
-  let b = Promise.await b in
+  let b = Promise.await_exn b in
   Alcotest.(check string) "Received data" "!" b
 
 (* Write a string to a pipe and read it out again. *)

--- a/tests/test_fibre.md
+++ b/tests/test_fibre.md
@@ -240,7 +240,7 @@ Exception: Failure "simulated error".
          Fibre.await_cancel ()
       ) in
       Switch.fail sw Exit;
-      Promise.await child
+      Promise.await_exn child
     );
   "not reached";;
 +Forked child

--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -127,7 +127,7 @@ Cancelling the read:
       let flow = Eio.Net.connect ~sw net addr in
       traceln "Connection opened - cancelling server's read";
       Fibre.yield ();
-      Promise.fulfill set_shutdown Graceful_shutdown;
+      Promise.resolve set_shutdown Graceful_shutdown;
       let msg = read_all flow in
       traceln "Client received: %S" msg
     );;


### PR DESCRIPTION
Lwt needs this because it uses promises for thread results, and threads can always raise. But we don't use promises for that, and so can afford to be more explicit.

- A promise is now simply unresolved or resolved.
- `Promise.fulfill` is now `Promise.resolve`.
- `Promise.break` and `Promise.broken` are gone.
- `Promise.await` doesn't raise; `await_result` is gone.
- `Promise.state` is now `Promise.peek` and returns an option.
- `Promise.fulfilled` is now `Promise.create_resolved`.

Some helpers using result types are provided to handle cases that need exceptions:

- `type 'a or_exn = ('a, exn) result t`.
- `resolve_ok` and `resolve_error` wrap the value in `Ok` or `Error`.
- `await_exn` awaits a result promise and raises the error.