### PR TITLE
Rename Sink.write to Sink.copy

### DIFF
--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -545,7 +545,7 @@ module Flow : sig
   (** Consumer base class. *)
   class virtual sink : object
     inherit Generic.t
-    method virtual write : 'a. (#source as 'a) -> unit
+    method virtual copy : 'a. (#source as 'a) -> unit
   end
 
   val copy : #source -> #sink -> unit

--- a/lib_eio/flow.ml
+++ b/lib_eio/flow.ml
@@ -57,10 +57,10 @@ let string_source s = cstruct_source [Cstruct.of_string s]
 
 class virtual sink = object (_ : <Generic.t; ..>)
   method probe _ = None
-  method virtual write : 'a. (#source as 'a) -> unit
+  method virtual copy : 'a. (#source as 'a) -> unit
 end
 
-let copy (src : #source) (dst : #sink) = dst#write src
+let copy (src : #source) (dst : #sink) = dst#copy src
 
 let copy_string s = copy (string_source s)
 
@@ -68,7 +68,7 @@ let buffer_sink b =
   object
     inherit sink
 
-    method write src =
+    method copy src =
       let buf = Cstruct.create 4096 in
       try
         while true do

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -783,7 +783,7 @@ let flow fd =
 
     method read_methods = []
 
-    method write src =
+    method copy src =
       match get_fd_opt src with
       | Some src -> fast_copy_try_splice src fd
       | None ->

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -376,7 +376,7 @@ let flow fd = object (_ : <source; sink; ..>)
 
   method read_methods = []
 
-  method write src =
+  method copy src =
     let buf = Luv.Buffer.create 4096 in
     try
       while true do
@@ -401,7 +401,7 @@ let socket sock = object
     let buf = Cstruct.to_bigarray buf in
     Stream.read_into sock buf
 
-  method write src =
+  method copy src =
     let buf = Luv.Buffer.create 4096 in
     try
       while true do


### PR DESCRIPTION
This matches the function name, and also allows us to add a simple `write` method later.