### PR TITLE
Update odoc for eio_main, eio_luv and eio_linux

### DIFF
--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -1,19 +1,19 @@
 open Eio.Private.Effect
 
-type _ Eio.Generic.ty += Unix_file_descr : [`Peek | `Take] -> Unix.file_descr Eio.Generic.ty
+module Private = struct
+  type _ Eio.Generic.ty += Unix_file_descr : [`Peek | `Take] -> Unix.file_descr Eio.Generic.ty
 
-module Effects = struct
   type _ eff += 
     | Await_readable : Unix.file_descr -> unit eff
     | Await_writable : Unix.file_descr -> unit eff
 end
 
-let await_readable fd = perform (Effects.Await_readable fd)
-let await_writable fd = perform (Effects.Await_writable fd)
+let await_readable fd = perform (Private.Await_readable fd)
+let await_writable fd = perform (Private.Await_writable fd)
 
 module FD = struct
-  let peek x = Eio.Generic.probe x (Unix_file_descr `Peek)
-  let take x = Eio.Generic.probe x (Unix_file_descr `Take)
+  let peek x = Eio.Generic.probe x (Private.Unix_file_descr `Peek)
+  let take x = Eio.Generic.probe x (Private.Unix_file_descr `Take)
 end
 
 module Ipaddr = struct

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -10,8 +10,7 @@ val await_readable : Unix.file_descr -> unit
 val await_writable : Unix.file_descr -> unit
 (** [await_writable fd] blocks until [fd] is writable (or has an error). *)
 
-type _ Eio.Generic.ty += Unix_file_descr : [`Peek | `Take] -> Unix.file_descr Eio.Generic.ty
-
+(** Get a [Unix.file_descr] from an Eio object. *)
 module FD : sig
   val peek : #Eio.Generic.t -> Unix.file_descr option
   (** [peek x] is the Unix file descriptor underlying [x], if any.
@@ -22,15 +21,22 @@ module FD : sig
       [x] can no longer be used after this, and the caller is responsible for closing the FD. *)
 end
 
+(** Convert between Eio.Net.Ipaddr and Unix.inet_addr. *)
 module Ipaddr : sig
+  (** Internally, these are actually the same type, so these are just casts. *)
+
   val to_unix : [< `V4 | `V6] Eio.Net.Ipaddr.t -> Unix.inet_addr
   val of_unix : Unix.inet_addr -> Eio.Net.Ipaddr.v4v6
 end
 
-module Effects : sig
+(** API for Eio backends only. *)
+module Private : sig
   open Eio.Private.Effect
 
+  type _ Eio.Generic.ty += Unix_file_descr : [`Peek | `Take] -> Unix.file_descr Eio.Generic.ty
+  (** See {!FD}. *)
+
   type _ eff += 
-    | Await_readable : Unix.file_descr -> unit eff
-    | Await_writable : Unix.file_descr -> unit eff
+    | Await_readable : Unix.file_descr -> unit eff      (** See {!await_readable} *)
+    | Await_writable : Unix.file_descr -> unit eff      (** See {!await_writable} *)
 end

--- a/lib_eio/utils/lf_queue.mli
+++ b/lib_eio/utils/lf_queue.mli
@@ -7,6 +7,7 @@ type 'a t
 exception Closed
 
 val create : unit -> 'a t
+(** [create ()] is a new empty queue. *)
 
 val push : 'a t -> 'a -> unit
 (** [push t x] adds [x] to the tail of the queue.
@@ -21,9 +22,11 @@ val push_head : 'a t -> 'a -> unit
 val pop : 'a t -> 'a option
 (** [pop t] removes the head item from [t] and returns it.
     Returns [None] if [t] is currently empty.
-    @raise Closed if [t] has been closed. *)
+    @raise Closed if [t] has been closed and is empty. *)
 
 val is_empty : 'a t -> bool
+(** [is_empty t] is [true] if calling [pop] would return [None].
+    @raise Closed if [t] has been closed and is empty. *)
 
 val close : 'a t -> unit
 (** [close t] marks [t] as closed, preventing any further items from being pushed. *)

--- a/lib_eio/utils/trace.mli
+++ b/lib_eio/utils/trace.mli
@@ -1,11 +1,16 @@
 (** The default implementation of {!Eio.traceln}. *)
 
 val mutex : Mutex.t
+(** The mutex used to prevent two domains writing to stderr at once.
+
+    This might be useful if you want to write to it directly yourself,
+    e.g. for a log reporter. *)
 
 val default_traceln :
     ?__POS__:string * int * int * int ->
     ('a, Format.formatter, unit, unit) format4 -> 'a
 (** [default_traceln] is a suitable default implementation for {!Eio.Std.traceln}.
+
     It writes output to stderr, prefixing each line with a "+".
-    If [__POS__] is given, it also displays the file and line number from that
+    If [__POS__] is given, it also displays the file and line number from that.
     It uses {!mutex} so that only one domain's output is written at a time. *)

--- a/lib_eio/utils/zzz.ml
+++ b/lib_eio/utils/zzz.ml
@@ -1,5 +1,3 @@
-(** Keep track of scheduled alarms. *)
-
 module Key = struct
   type t = Optint.Int63.t
   let compare = Optint.Int63.compare

--- a/lib_eio/utils/zzz.mli
+++ b/lib_eio/utils/zzz.mli
@@ -1,11 +1,12 @@
 (** A set of timers. *)
 
+(** A handle to a registered timer. *)
 module Key : sig
   type t
 end
 
 type t
-(** A queue of scheduled events. *)
+(** A set of timers (implemented as a priority queue). *)
 
 val create : unit -> t
 (** [create ()] is a fresh empty queue. *)
@@ -13,7 +14,8 @@ val create : unit -> t
 val add : t -> float -> unit Suspended.t -> Key.t
 (** [add t time thread] adds a new event, due at [time], and returns its ID.
     You must use {!Eio.Private.Fibre_context.set_cancel_fn} on [thread] before
-    calling {!pop}. *)
+    calling {!pop}.
+    Your cancel function should call {!remove} (in addition to resuming [thread]). *)
 
 val remove : t -> Key.t -> unit
 (** [remove t key] removes an event previously added with [add]. *)

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -770,7 +770,7 @@ let flow fd =
 
     method probe : type a. a Eio.Generic.ty -> a option = function
       | FD -> Some fd
-      | Eio_unix.Unix_file_descr op -> Some (FD.to_unix op fd)
+      | Eio_unix.Private.Unix_file_descr op -> Some (FD.to_unix op fd)
       | _ -> None
 
     method read_into buf =
@@ -808,7 +808,7 @@ let listening_socket fd = object
   inherit Eio.Net.listening_socket
 
   method! probe : type a. a Eio.Generic.ty -> a option = function
-    | Eio_unix.Unix_file_descr op -> Some (FD.to_unix op fd)
+    | Eio_unix.Private.Unix_file_descr op -> Some (FD.to_unix op fd)
     | _ -> None
 
   method close = FD.close fd
@@ -1105,7 +1105,7 @@ let rec run ?(queue_depth=64) ?(block_size=4096) ?polling_timeout main =
                 )
             )
           | Eio.Private.Effects.Trace -> Some (fun k -> continue k Eio_utils.Trace.default_traceln)
-          | Eio_unix.Effects.Await_readable fd -> Some (fun k ->
+          | Eio_unix.Private.Await_readable fd -> Some (fun k ->
               match Fibre_context.get_error fibre with
               | Some e -> discontinue k e
               | None ->
@@ -1116,7 +1116,7 @@ let rec run ?(queue_depth=64) ?(block_size=4096) ?polling_timeout main =
                   );
                 schedule st
             )
-          | Eio_unix.Effects.Await_writable fd -> Some (fun k ->
+          | Eio_unix.Private.Await_writable fd -> Some (fun k ->
               match Fibre_context.get_error fibre with
               | Some e -> discontinue k e
               | None ->

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -365,7 +365,7 @@ let flow fd = object (_ : <source; sink; ..>)
 
   method probe : type a. a Eio.Generic.ty -> a option = function
     | FD -> Some fd
-    | Eio_unix.Unix_file_descr op -> Some (File.to_unix op fd)
+    | Eio_unix.Private.Unix_file_descr op -> Some (File.to_unix op fd)
     | _ -> None
 
   method read_into buf =
@@ -394,7 +394,7 @@ let socket sock = object
   inherit Eio.Flow.two_way as super
 
   method! probe : type a. a Eio.Generic.ty -> a option = function
-    | Eio_unix.Unix_file_descr op -> Stream.to_unix_opt op sock
+    | Eio_unix.Private.Unix_file_descr op -> Stream.to_unix_opt op sock
     | x -> super#probe x
 
   method read_into buf =
@@ -426,7 +426,7 @@ class virtual ['a] listening_socket ~backlog sock = object (self)
   inherit Eio.Net.listening_socket as super
 
   method! probe : type a. a Eio.Generic.ty -> a option = function
-    | Eio_unix.Unix_file_descr op -> Stream.to_unix_opt op sock
+    | Eio_unix.Private.Unix_file_descr op -> Stream.to_unix_opt op sock
     | x -> super#probe x
 
   val ready = Eio.Semaphore.make 0
@@ -738,14 +738,14 @@ let rec run main =
               let k = { Suspended.k; fibre } in
               fn fibre (enqueue_result_thread st k)
             )
-        | Eio_unix.Effects.Await_readable fd -> Some (fun k ->
+        | Eio_unix.Private.Await_readable fd -> Some (fun k ->
             match Fibre_context.get_error fibre with
             | Some e -> discontinue k e
             | None ->
               let k = { Suspended.k; fibre } in
               Poll.await_readable st k fd
           )
-        | Eio_unix.Effects.Await_writable fd -> Some (fun k ->
+        | Eio_unix.Private.Await_writable fd -> Some (fun k ->
             match Fibre_context.get_error fibre with
             | Some e -> discontinue k e
             | None ->

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -1,18 +1,9 @@
-(*
- * Copyright (C) 2021 Thomas Leonard
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *)
+(** Eio backend using libuv.
+
+    You will normally not use this module directly.
+    Instead, use {!Eio_main.run} to start an event loop and then use the API in the {!Eio} module.
+
+    However, it is possible to use this module directly if you only want to support libuv. *)
 
 open Eio.Std
 

--- a/lib_main/eio_main.mli
+++ b/lib_main/eio_main.mli
@@ -1,0 +1,22 @@
+(** Select a suitable event loop for Eio. *)
+
+val run : (Eio.Stdenv.t -> unit) -> unit
+(** [run fn] runs an event loop and then calls [fn env] within it.
+
+    [env] provides access to the process's environment (file-system, network, etc).
+
+    When [fn] ends, the event loop finishes.
+
+    This should be called once, at the entry point of an application.
+    It {b must not} be called by libraries.
+    Doing so would force the library to depend on Unix
+    (making it unusable from unikernels or browsers),
+    prevent the user from choosing their own event loop,
+    and prevent using the library with other Eio libraries.
+
+    [run] will select an appropriate event loop for the current platform.
+    On many systems, it will use {!Eio_luv.run}.
+
+    On recent-enough versions of Linux, it will use {!Eio_linux.run}.
+    You can override this by setting the $EIO_BACKEND environment variable to
+    either "io-uring" or "luv". *)


### PR DESCRIPTION
Also, some minor clean-ups to the API:

- Moved some private stuff in `Eio_unix` to a `Private` submodule.
- Added `eio_main.mli` to document it and avoid exposing internal functions.
- Hide (unused) `Eio_linux.t`.