### PR TITLE
Add a dependency on OCaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ See [Awesome Multicore OCaml][] for links to work migrating other projects to Ei
 - `eio_linux` provides a Linux io-uring backend for these APIs,
   plus a low-level API that can be used directly (in non-portable code).
 - `eio_main` selects an appropriate backend (e.g. `eio_linux` or `eio_luv`), depending on your platform.
-- `ctf` provides tracing support.
 
 ## Getting Started
 

--- a/dune-project
+++ b/dune-project
@@ -11,6 +11,7 @@
  (synopsis "Effect-based direct-style IO API for OCaml")
  (description "An effect-based IO API for multicore OCaml with fibres.")
  (depends
+  (ocaml (>= 4.12.0))
   base-domains
   (cstruct (>= 6.0.1))
   lwt-dllist

--- a/eio.opam
+++ b/eio.opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
   "base-domains"
   "cstruct" {>= "6.0.1"}
   "lwt-dllist"


### PR DESCRIPTION
Not really needed at the moment as all versions with base-domains work, but it makes it a bit clearer.

Requested by @avsm in https://github.com/ocaml/opam-repository/pull/20682#issuecomment-1032897611.