### PR TITLE
Tests: use local directory for test socket

### DIFF
--- a/tests/test_network.md
+++ b/tests/test_network.md
@@ -80,7 +80,7 @@ Exception: Graceful_shutdown.
 Handling one connection on a Unix domain socket:
 
 ```ocaml
-# run (test_address (`Unix "/tmp/eio-test.sock"));;
+# run (test_address (`Unix "eio-test.sock"));;
 +Connecting to server...
 +Server accepted connection from client
 +Server received: "Hello from client"


### PR DESCRIPTION
opam-repo-ci uses a read-only /tmp.