### PR TITLE
Add Eio_unix.sleep

### DIFF
--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -6,10 +6,14 @@ module Private = struct
   type _ eff += 
     | Await_readable : Unix.file_descr -> unit eff
     | Await_writable : Unix.file_descr -> unit eff
+    | Get_system_clock : Eio.Time.clock eff
 end
 
 let await_readable fd = perform (Private.Await_readable fd)
 let await_writable fd = perform (Private.Await_writable fd)
+
+let sleep d =
+  Eio.Time.sleep (perform Private.Get_system_clock) d
 
 module FD = struct
   let peek x = Eio.Generic.probe x (Private.Unix_file_descr `Peek)

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -29,6 +29,12 @@ module Ipaddr : sig
   val of_unix : Unix.inet_addr -> Eio.Net.Ipaddr.v4v6
 end
 
+val sleep : float -> unit
+(** [sleep d] sleeps for [d] seconds, allowing other fibres to run.
+    This is can be useful for debugging (e.g. to introduce delays to trigger a race condition)
+    without having to plumb {!Eio.Stdenv.clock} through your code.
+    It can also be used in programs that don't care about tracking determinism. *)
+
 (** API for Eio backends only. *)
 module Private : sig
   open Eio.Private.Effect
@@ -39,6 +45,7 @@ module Private : sig
   type _ eff += 
     | Await_readable : Unix.file_descr -> unit eff      (** See {!await_readable} *)
     | Await_writable : Unix.file_descr -> unit eff      (** See {!await_writable} *)
+    | Get_system_clock : Eio.Time.clock eff             (** See {!sleep} *)
 end
 
 module Ctf = Ctf_unix

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1128,6 +1128,7 @@ let rec run ?(queue_depth=64) ?(block_size=4096) ?polling_timeout main =
                   );
                 schedule st
             )
+          | Eio_unix.Private.Get_system_clock -> Some (fun k -> continue k clock)
           | Low_level.Alloc -> Some (fun k ->
               let k = { Suspended.k; fibre } in
               Low_level.alloc_buf st k

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -754,6 +754,7 @@ let rec run main =
               let k = { Suspended.k; fibre } in
               Poll.await_writable st k fd
           )
+        | Eio_unix.Private.Get_system_clock -> Some (fun k -> continue k clock)
         | _ -> None
     }
   in

--- a/tests/test_time.md
+++ b/tests/test_time.md
@@ -90,3 +90,15 @@ Check ordering works:
 +Short timer finished
 Exception: Failure "Simulated cancel".
 ```
+
+Check Unix debug clock:
+```ocaml
+# Eio_main.run @@ fun _ ->
+  Fibre.both
+    (fun () -> traceln "First thread starts"; Eio_unix.sleep 0.001; traceln "Sleep done")
+    (fun () -> traceln "Second thread starts");;
++First thread starts
++Second thread starts
++Sleep done
+- : unit = ()
+```


### PR DESCRIPTION
Based on feedback that some people don't want to have to treat time as a capability. Possibly also useful for debugging race conditions. This is intended as an easy replacement for `Lwt_unix.sleep`.