### PR TITLE
Suppress cmdliner deprecation warning

### DIFF
--- a/lib_eio_linux/tests/eurcp.ml
+++ b/lib_eio_linux/tests/eurcp.ml
@@ -1,3 +1,5 @@
+[@@@warning "-deprecated"]
+
 let setup_log style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level level;


### PR DESCRIPTION
This is only used for a test. We can't upgrade to the new API due to crowbar (which we also need for testing) requiring the old one.