### PR TITLE
Tidy up forking API

### DIFF
--- a/doc/eio_null.md
+++ b/doc/eio_null.md
@@ -55,13 +55,7 @@ module Eio_null = struct
                 (* Arrange for the forking fibre to run immediately after the new one. *)
                 t.run_q <- Deep.continue k :: t.run_q;
                 (* Create and run the new fibre (using fibre context [new_fibre]). *)
-                fork ~new_fibre (fun () ->
-                    try f ()
-                    with _ ->
-                      (* Fibre.fork handles exceptions for us.
-                         This is just to allow for tracing. *)
-                      ()
-                  )
+                fork ~new_fibre f
               )
             | Eio.Private.Effects.Get_context -> Some (fun k ->
                 Deep.continue k fibre

--- a/lib_eio/cancel.ml
+++ b/lib_eio/cancel.ml
@@ -158,9 +158,11 @@ let cancel t ex =
       | () -> aux fns
       | exception ex2 -> ex2 :: aux fns
   in
-  match protect (fun () -> aux fns) with
-  | [] -> ()
-  | exns -> raise (Cancel_hook_failed exns)
+  if fns <> [] then (
+    match protect (fun () -> aux fns) with
+    | [] -> ()
+    | exns -> raise (Cancel_hook_failed exns)
+  )
 
 let sub fn =
   let ctx = perform Get_context in

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -1309,7 +1309,8 @@ module Private : sig
           [fn] should arrange for [enqueue] to be called once the thread is ready to run again. *)
 
       | Fork : Fibre_context.t * (unit -> unit) -> unit eff
-      (** See {!Fibre.fork} *)
+      (** [perform (Fork new_context f)] creates a new fibre and runs [f] in it, with context [new_context].
+          [f] must not raise an exception. See {!Fibre.fork}. *)
 
       | Trace : (?__POS__:(string * int * int * int) -> ('a, Format.formatter, unit, unit) format4 -> 'a) eff
       (** [perform Trace fmt] writes trace logging to the configured trace output.
@@ -1318,6 +1319,7 @@ module Private : sig
           the whole domain must block until it is. *)
 
       | Get_context : Fibre_context.t eff
+      (** [perform Get_context] immediately returns the current fibre's context (without switching fibres). *)
   end
 
   (** Temporary hack for compatibility with ocaml.4.12+domains *)

--- a/lib_eio/switch.ml
+++ b/lib_eio/switch.ml
@@ -27,9 +27,12 @@ let dump f t =
 
 let is_finished t = Cancel.is_finished t.cancel
 
+(* Check switch belongs to this domain (and isn't finished). It's OK if it's cancelling. *)
 let check_our_domain t =
+  if is_finished t then invalid_arg "Switch finished!";
   if Domain.self () <> t.cancel.domain then invalid_arg "Switch accessed from wrong domain!"
 
+(* Check isn't cancelled (or finished). *)
 let check t =
   if is_finished t then invalid_arg "Switch finished!";
   Cancel.check t.cancel
@@ -41,6 +44,7 @@ let combine_exn ex = function
   | None -> ex
   | Some ex1 -> Exn.combine ex1 ex
 
+(* Note: raises if [t] is finished or called from wrong domain. *)
 let fail ?(bt=Printexc.get_raw_backtrace ()) t ex =
   check_our_domain t;
   if t.exs = None then

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1097,13 +1097,7 @@ let rec run ?(queue_depth=64) ?(block_size=4096) ?polling_timeout main =
           | Eio.Private.Effects.Fork (new_fibre, f) -> Some (fun k ->
               let k = { Suspended.k; fibre } in
               enqueue_at_head st k ();
-              fork ~new_fibre (fun () ->
-                  match f () with
-                  | () ->
-                    Ctf.note_resolved (Fibre_context.tid new_fibre) ~ex:None
-                  | exception ex ->
-                    Ctf.note_resolved (Fibre_context.tid new_fibre) ~ex:(Some ex)
-                )
+              fork ~new_fibre f
             )
           | Eio.Private.Effects.Trace -> Some (fun k -> continue k Eio_utils.Trace.default_traceln)
           | Eio_unix.Private.Await_readable fd -> Some (fun k ->

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -717,15 +717,10 @@ let rec run main =
           Some (fun k -> continue k Eio_utils.Trace.default_traceln)
         | Eio.Private.Effects.Fork (new_fibre, f) ->
           Some (fun k -> 
-            let k = { Suspended.k; fibre } in
-            enqueue_at_head st k ();
-            fork ~new_fibre (fun () ->
-                match f () with
-                | () ->
-                  Ctf.note_resolved (Fibre_context.tid new_fibre) ~ex:None
-                | exception ex ->
-                  Ctf.note_resolved (Fibre_context.tid new_fibre) ~ex:(Some ex)
-              ))
+              let k = { Suspended.k; fibre } in
+              enqueue_at_head st k ();
+              fork ~new_fibre f
+            )
         | Eio.Private.Effects.Get_context -> Some (fun k -> continue k fibre)
         | Enter_unchecked fn -> Some (fun k ->
             fn st { Suspended.k; fibre }

--- a/tests/test_switch.md
+++ b/tests/test_switch.md
@@ -76,11 +76,11 @@ Exception: Failure "Failed".
 Exception: Failure "Failed".
 ```
 
-`Fibre.both`, first fails but the other doesn't stop:
+`Fibre.both`, first fails immediately and the other doesn't start:
 
 ```ocaml
 # run (fun sw ->
-      Fibre.both (fun () -> failwith "Failed") ignore;
+      Fibre.both (fun () -> failwith "Failed") (fun () -> traceln "Second OK");
       traceln "Not reached"
     );;
 Exception: Failure "Failed".


### PR DESCRIPTION
There was some code for recording the fibre result duplicated in each backend. Also, it didn't do much because we handle errors before that. And for `fork_promise` we want to report the result against the promise.

Also, optimise `Cancel.cancel` slightly. No need to make a new context for the cancel functions if there aren't any.