### PR TITLE
Add Eio_unix.FD.as_socket

### DIFF
--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -7,6 +7,7 @@ module Private = struct
     | Await_readable : Unix.file_descr -> unit eff
     | Await_writable : Unix.file_descr -> unit eff
     | Get_system_clock : Eio.Time.clock eff
+    | Socket_of_fd : Eio.Switch.t * bool * Unix.file_descr -> < Eio.Flow.two_way; Eio.Flow.close > eff
 end
 
 let await_readable fd = perform (Private.Await_readable fd)
@@ -18,6 +19,8 @@ let sleep d =
 module FD = struct
   let peek x = Eio.Generic.probe x (Private.Unix_file_descr `Peek)
   let take x = Eio.Generic.probe x (Private.Unix_file_descr `Take)
+
+  let as_socket ~sw ~close_unix fd = perform (Private.Socket_of_fd (sw, close_unix, fd))
 end
 
 module Ipaddr = struct

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1190,6 +1190,10 @@ let rec run ?(queue_depth=64) ?(block_size=4096) ?polling_timeout main =
                 schedule st
             )
           | Eio_unix.Private.Get_system_clock -> Some (fun k -> continue k clock)
+          | Eio_unix.Private.Socket_of_fd (sw, close_unix, fd) -> Some (fun k ->
+              let fd = FD.of_unix ~sw ~seekable:false ~close_unix fd in
+              continue k (flow fd :> < Eio.Flow.two_way; Eio.Flow.close >)
+            )
           | Low_level.Alloc -> Some (fun k ->
               let k = { Suspended.k; fiber } in
               Low_level.alloc_buf st k

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -38,10 +38,11 @@ module Low_level : sig
     (** [close t] closes [t].
         @raise Invalid_arg if [t] is already closed. *)
 
-    val of_luv : sw:Switch.t -> Luv.File.t -> t
+    val of_luv : ?close_unix:bool -> sw:Switch.t -> Luv.File.t -> t
     (** [of_luv ~sw fd] wraps [fd] as an open file descriptor.
         This is unsafe if [fd] is closed directly (before or after wrapping it).
-        @param sw The FD is closed when [sw] is released, if not closed manually first. *)
+        @param sw The FD is closed when [sw] is released, if not closed manually first.
+        @param close_unix if [true] (the default), calling [close] also closes [fd]. *)
 
     val to_luv : t -> Luv.File.t
     (** [to_luv t] returns the wrapped descriptor.
@@ -88,10 +89,11 @@ module Low_level : sig
         This allows unsafe access to the handle.
         @raise Invalid_arg if [t] is closed. *)
 
-    val of_luv : sw:Switch.t -> 'a Luv.Handle.t -> 'a t
+    val of_luv : ?close_unix:bool -> sw:Switch.t -> 'a Luv.Handle.t -> 'a t
     (** [of_luv ~sw h] wraps [h] as an open handle.
         This is unsafe if [h] is closed directly (before or after wrapping it).
-        @param sw The handle is closed when [sw] is released, if not closed manually first. *)
+        @param sw The handle is closed when [sw] is released, if not closed manually first.
+        @param close_unix if [true] (the default), calling [close] also closes [fd]. *)
   end
 end
 


### PR DESCRIPTION
Useful for working with existing libraries that provide a Unix.file_descr, or for receiving FDs from elsewhere (e.g. socket activation).

Also, the `Luv.{File,Handle}.of_luv` functions now allow controlling whether to close the wrapped FD.