### PR TITLE
Eio_linux: cope with lack of fixed chunks

### DIFF
--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -37,5 +37,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
 pin-depends: [
-    ["uring.0.2" "git+https://github.com/ocaml-multicore/ocaml-uring.git#299f58f6ccf8e31562ba1057dde7dc75e6628ce4"]
+    ["uring.0.2" "git+https://github.com/ocaml-multicore/ocaml-uring.git#d24c68eceac84fba65057396adfea9d4f550d9db"]
 ]

--- a/eio_linux.opam.template
+++ b/eio_linux.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-    ["uring.0.2" "git+https://github.com/ocaml-multicore/ocaml-uring.git#299f58f6ccf8e31562ba1057dde7dc75e6628ce4"]
+    ["uring.0.2" "git+https://github.com/ocaml-multicore/ocaml-uring.git#d24c68eceac84fba65057396adfea9d4f550d9db"]
 ]

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -79,8 +79,15 @@ val pipe : Switch.t -> source * sink
 
 (** {1 Main Loop} *)
 
-val run : ?queue_depth:int -> ?block_size:int -> ?polling_timeout:int -> (stdenv -> unit) -> unit
+val run : ?queue_depth:int -> ?n_blocks:int -> ?block_size:int -> ?polling_timeout:int -> (stdenv -> unit) -> unit
 (** Run an event loop using io_uring.
+
+    Uses {!Uring.create} to create the io_uring,
+    and {!Uring.set_fixed_buffer} to set a [block_size * n_blocks] fixed buffer.
+
+    Note that if Linux resource limits prevent the requested fixed buffer from being allocated
+    then [run] will continue without one (and log a warning).
+
     For portable code, you should use {!Eio_main.run} instead, which will use this automatically
     if running on Linux with a recent-enough kernel version. *)
 
@@ -96,18 +103,28 @@ module Low_level : sig
   val sleep_until : float -> unit
   (** [sleep_until time] blocks until the current time is [time]. *)
 
-  (** {1 Memory allocation functions} *)
+  (** {1 Fixed-buffer memory allocation functions}
 
-  val alloc : unit -> Uring.Region.chunk
+      The size of the fixed buffer is set when calling {!run}, which attempts to allocate a fixed buffer.
+      However, that may fail due to resource limits. *)
+
+  val alloc_fixed : unit -> Uring.Region.chunk option
   (** Allocate a chunk of memory from the fixed buffer.
 
+      Warning: The memory is NOT zeroed out.
+
       Passing such memory to Linux can be faster than using normal memory, in certain cases.
-      There is a limited amount of such memory, and this will block until some is available. *)
+      There is a limited amount of such memory, and this will return [None] if none is available at present. *)
 
-  val free : Uring.Region.chunk -> unit
+  val alloc_fixed_or_wait : unit -> Uring.Region.chunk
+  (** Like {!alloc_fixed}, but if there are no chunks available then it waits until one is. *)
 
-  val with_chunk : (Uring.Region.chunk -> 'a) -> 'a
-  (** [with_chunk fn] runs [fn chunk] with a freshly allocated chunk and then frees it. *)
+  val free_fixed : Uring.Region.chunk -> unit
+
+  val with_chunk : fallback:(unit -> 'a) -> (Uring.Region.chunk -> 'a) -> 'a
+  (** [with_chunk ~fallback fn] runs [fn chunk] with a freshly allocated chunk and then frees it.
+
+      If no chunks are available, it runs [fallback ()] instead. *)
 
   (** {1 File manipulation functions} *)
 

--- a/lib_eio_linux/tests/basic_eio_linux.ml
+++ b/lib_eio_linux/tests/basic_eio_linux.ml
@@ -14,18 +14,18 @@ let () =
   Eio_linux.run @@ fun _stdenv ->
   Switch.run @@ fun sw ->
   let fd = Unix.handle_unix_error (openfile ~sw "test.txt" Unix.[O_RDONLY]) 0 in
-  let buf = alloc () in
+  let buf = alloc_fixed_or_wait () in
   let _ = read_exactly fd buf 5 in
   print_endline (Uring.Region.to_string ~len:5 buf);
   let _ = read_exactly fd ~file_offset:(Int63.of_int 3) buf 3 in
   print_endline (Uring.Region.to_string ~len:3 buf);
-  free buf;
+  free_fixed buf;
   (* With a sleep: *)
-  let buf = alloc () in
+  let buf = alloc_fixed_or_wait () in
   let _ = read_exactly fd buf 5 in
   Logs.debug (fun l -> l "sleeping at %f" (Unix.gettimeofday ()));
   sleep_until (Unix.gettimeofday () +. 1.0);
   print_endline (Uring.Region.to_string ~len:5 buf);
   let _ = read_exactly fd ~file_offset:(Int63.of_int 3) buf 3 in
   print_endline (Uring.Region.to_string ~len:3 buf);
-  free buf
+  free_fixed buf

--- a/lib_eio_linux/tests/eurcp_lib.ml
+++ b/lib_eio_linux/tests/eurcp_lib.ml
@@ -6,12 +6,12 @@ module U = Eio_linux.Low_level
 module Int63 = Optint.Int63
 
 let read_then_write_chunk infd outfd file_offset len =
-  let buf = U.alloc () in
+  let buf = U.alloc_fixed_or_wait () in
   Logs.debug (fun l -> l "r/w start %a (%d)" Int63.pp file_offset len);
   U.read_exactly ~file_offset infd buf len;
   U.write ~file_offset outfd buf len;
   Logs.debug (fun l -> l "r/w done  %a (%d)" Int63.pp file_offset len);
-  U.free buf
+  U.free_fixed buf
 
 let copy_file infd outfd insize block_size =
   Switch.run @@ fun sw ->
@@ -26,7 +26,7 @@ let copy_file infd outfd insize block_size =
   copy_block Int63.zero
 
 let run_cp block_size queue_depth infile outfile () =
-  Eio_linux.run ~queue_depth ~block_size @@ fun _stdenv ->
+  Eio_linux.run ~queue_depth ~n_blocks:queue_depth ~block_size @@ fun _stdenv ->
   Switch.run @@ fun sw ->
   let open Unix in
   let infd = U.openfile ~sw infile [O_RDONLY] 0 in


### PR DESCRIPTION
The fixed buffer is rarely any faster than using regular memory, and there is a risk of deadlock due to a shortage of chunks with the blocking API. Therefore, code needs to handle the case of there being no more chunks available. To help with this:

- `alloc` is now `alloc_fixed_or_wait` to make it clear that it waits until space is available. The new `alloc_fixed` immediately returns an option instead.
- `with_chunk` takes a fallback function to use if no chunks are available.
- `free` is now called `free_fixed`.
- `run` takes an `n_blocks` argument, so you can run without a fixed buffer if you want.
- If we try to allocate a fixed buffer and fail, we now just log a warning and continue without one.