### PR TITLE
Fix typo in tests

### DIFF
--- a/lib_eio_linux/tests/fd_passing.md
+++ b/lib_eio_linux/tests/fd_passing.md
@@ -11,7 +11,7 @@ open Eio.Std
 Sending a file descriptor over a Unix domain socket:
 
 ```ocaml
-# Eio_main.run @@ fun env ->
+# Eio_linux.run @@ fun env ->
   Switch.run @@ fun sw ->
   let fd = Eio.Dir.open_out ~sw env#cwd "tmp.txt" ~create:(`Exclusive 0o600) in
   Eio.Flow.copy_string "Test data" fd;


### PR DESCRIPTION
Was causing uring tests to fail if run with `EIO_BACKEND=luv`.