### PR TITLE
Disable linux mdx test on non-linux platforms

### DIFF
--- a/lib_eio_linux/tests/dune
+++ b/lib_eio_linux/tests/dune
@@ -31,4 +31,5 @@
 
 (mdx
   (package eio_linux)
+  (enabled_if (= %{system} "linux"))
   (packages eio_linux))


### PR DESCRIPTION
[`enabled_if` for `mdx` stanzas was added in dune `2.9`](https://github.com/ocaml/dune/blob/main/CHANGES.md#290-29062021) so I think it's okay to do this, otherwise it won't work on macOS (or windows) for example.