### PR TITLE
Add readdir feature

### DIFF
--- a/lib_eio/dir.ml
+++ b/lib_eio/dir.ml
@@ -36,7 +36,7 @@ let open_in ~sw (t:#t) = t#open_in ~sw
 let open_out ~sw ?(append=false) ~create (t:#t) path = t#open_out ~sw ~append ~create path
 let open_dir ~sw (t:#t) = t#open_dir ~sw
 let mkdir (t:#t) = t#mkdir
-let read_dir (t:#t) path = t#read_dir path
+let read_dir (t:#t) path = List.sort String.compare (t#read_dir path)
 
 let with_open_in (t:#t) path fn =
   Switch.run @@ fun sw -> fn (open_in ~sw t path)

--- a/lib_eio/dir.ml
+++ b/lib_eio/dir.ml
@@ -24,6 +24,7 @@ class virtual t = object
     path -> <rw; Flow.close>
   method virtual mkdir : perm:Unix_perm.t -> path -> unit
   method virtual open_dir : sw:Switch.t -> path -> t_with_close
+  method virtual read_dir : path -> string list
 end
 and virtual t_with_close = object
   (* This dummy class avoids an "Error: The type < .. > is not an object type" error from the compiler. *)
@@ -35,6 +36,7 @@ let open_in ~sw (t:#t) = t#open_in ~sw
 let open_out ~sw ?(append=false) ~create (t:#t) path = t#open_out ~sw ~append ~create path
 let open_dir ~sw (t:#t) = t#open_dir ~sw
 let mkdir (t:#t) = t#mkdir
+let read_dir (t:#t) path = t#read_dir path
 
 let with_open_in (t:#t) path fn =
   Switch.run @@ fun sw -> fn (open_in ~sw t path)

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -1186,7 +1186,7 @@ module Dir : sig
       it automatically when [fn] returns (if it hasn't already been closed by then). *)
 
   val read_dir : #t -> path -> string list
-  (** [read_dir t path] reads directory entries for [t/path].*)
+  (** [read_dir t path] reads directory entries for [t/path]. The entries are sorted using {! String.compare}.*)
 end
 
 (** The standard environment of a process. *)

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -1118,6 +1118,7 @@ module Dir : sig
       path -> <rw; Flow.close>
     method virtual mkdir : perm:Unix_perm.t -> path -> unit
     method virtual open_dir : sw:Switch.t -> path -> t_with_close
+    method virtual read_dir : path -> path list
   end
   and virtual t_with_close : object
     inherit t
@@ -1183,6 +1184,9 @@ module Dir : sig
   val with_open_dir : #t -> path -> (<t; Flow.close> -> 'a) -> 'a
   (** [with_open_dir] is like [open_dir], but calls [fn dir] with the new directory and closes
       it automatically when [fn] returns (if it hasn't already been closed by then). *)
+
+  val read_dir : #t -> path -> string list
+  (** [read_dir t path] reads directory entries for [t/path].*)
 end
 
 (** The standard environment of a process. *)

--- a/lib_eio/unix/dune
+++ b/lib_eio/unix/dune
@@ -1,4 +1,4 @@
 (library
  (name eio_unix)
  (public_name eio.unix)
- (libraries eio unix mtime.clock.os))
+ (libraries eio unix threads mtime.clock.os))

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -42,6 +42,10 @@ val sleep : float -> unit
     without having to plumb {!Eio.Stdenv.clock} through your code.
     It can also be used in programs that don't care about tracking determinism. *)
 
+val run_in_systhread : (unit -> 'a) -> 'a
+(** [run_in_systhread fn] runs the function [fn] in a newly created system thread (a {! Thread.t}).
+    This allows blocking calls to be made non-blocking. *)
+
 (** API for Eio backends only. *)
 module Private : sig
   open Eio.Private

--- a/lib_eio_linux/dune
+++ b/lib_eio_linux/dune
@@ -4,5 +4,6 @@
  (enabled_if (= %{system} "linux"))
  (foreign_stubs
   (language c)
+  (flags :standard -D_LARGEFILE64_SOURCE)
   (names eio_stubs))
  (libraries eio eio.utils eio.unix threads uring logs fmt))

--- a/lib_eio_linux/dune
+++ b/lib_eio_linux/dune
@@ -5,4 +5,4 @@
  (foreign_stubs
   (language c)
   (names eio_stubs))
- (libraries eio eio.utils eio.unix uring logs fmt))
+ (libraries eio eio.utils eio.unix threads uring logs fmt))

--- a/lib_eio_linux/dune
+++ b/lib_eio_linux/dune
@@ -6,4 +6,4 @@
   (language c)
   (flags :standard -D_LARGEFILE64_SOURCE)
   (names eio_stubs))
- (libraries eio eio.utils eio.unix threads uring logs fmt))
+ (libraries eio eio.utils eio.unix uring logs fmt))

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1077,6 +1077,10 @@ class dir fd = object
   method mkdir ~perm path =
     Low_level.mkdir_beneath ~perm ?dir:fd path
 
+  method read_dir _path =
+    (* TODO(patricoferris): Once liburing supports getdents64 https://github.com/axboe/liburing/issues/111 *)
+    assert false
+
   method close =
     FD.close (Option.get fd)
 end

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -205,6 +205,11 @@ module Low_level : sig
   val fstat : FD.t -> Unix.stats
   (** Like {!Unix.fstat}. *)
 
+  val getdents : FD.t -> string list
+  (** [getdents dir] gets directory entries from [dir], but not necessarily all of them.
+      The function can be called multiple times on the open directory and will return the
+      empty list when there are no more entries to be returned. *)
+
   (** {1 Sockets} *)
 
   val accept : sw:Switch.t -> FD.t -> (FD.t * Unix.sockaddr)

--- a/lib_eio_linux/eio_stubs.c
+++ b/lib_eio_linux/eio_stubs.c
@@ -2,13 +2,18 @@
 #include <sys/types.h>
 #include <sys/eventfd.h>
 #include <sys/random.h>
+#include <sys/syscall.h>
 #include <errno.h>
+#include <dirent.h>
 
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
+#include <caml/alloc.h>
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
 #include <caml/bigarray.h>
+
+#define DIRENT_BUF_SIZE 1024
 
 CAMLprim value caml_eio_eventfd(value v_initval) {
   int ret;
@@ -44,4 +49,38 @@ CAMLprim value caml_eio_getrandom(value v_ba, value v_off, value v_len) {
   } while (ret == -1 && errno == EINTR);
   if (ret == -1) uerror("getrandom", Nothing);
   CAMLreturn(Val_long(ret));
+}
+
+struct linux_dirent64 {
+    ino64_t        d_ino;    /* 64-bit inode number */
+    off64_t        d_off;    /* 64-bit offset to next structure */
+    unsigned short d_reclen; /* Size of this dirent */
+    unsigned char  d_type;   /* File type */
+    char           d_name[]; /* Filename (null-terminated) */
+};
+
+CAMLprim value caml_eio_getdents(value v_fd) {
+  CAMLparam1(v_fd);
+  CAMLlocal1(result);
+  char buf[DIRENT_BUF_SIZE];
+  struct linux_dirent64 *d;
+  int nread, pos;
+  caml_enter_blocking_section();
+  nread = syscall(SYS_getdents64, Int_val(v_fd), buf, DIRENT_BUF_SIZE);
+  caml_leave_blocking_section();
+  if (nread == -1) uerror("getdents", Nothing);
+
+  result = Val_int(0); /* The empty list */
+
+  for (pos = 0; pos < nread;) {
+    d = (struct linux_dirent64 *) (buf + pos);
+    CAMLlocal1 (r);
+    r = caml_alloc(2, 0);
+    Store_field(r, 0, caml_copy_string_of_os(d->d_name));
+    Store_field(r, 1, result);
+    result = r;
+    pos += d->d_reclen;
+  }
+
+  CAMLreturn(result);
 }

--- a/lib_eio_linux/eio_stubs.c
+++ b/lib_eio_linux/eio_stubs.c
@@ -51,19 +51,11 @@ CAMLprim value caml_eio_getrandom(value v_ba, value v_off, value v_len) {
   CAMLreturn(Val_long(ret));
 }
 
-struct linux_dirent64 {
-    ino64_t        d_ino;    /* 64-bit inode number */
-    off64_t        d_off;    /* 64-bit offset to next structure */
-    unsigned short d_reclen; /* Size of this dirent */
-    unsigned char  d_type;   /* File type */
-    char           d_name[]; /* Filename (null-terminated) */
-};
-
 CAMLprim value caml_eio_getdents(value v_fd) {
   CAMLparam1(v_fd);
-  CAMLlocal1(result);
+  CAMLlocal2(result, cons);
   char buf[DIRENT_BUF_SIZE];
-  struct linux_dirent64 *d;
+  struct dirent64 *d;
   int nread, pos;
   caml_enter_blocking_section();
   nread = syscall(SYS_getdents64, Int_val(v_fd), buf, DIRENT_BUF_SIZE);
@@ -73,12 +65,11 @@ CAMLprim value caml_eio_getdents(value v_fd) {
   result = Val_int(0); /* The empty list */
 
   for (pos = 0; pos < nread;) {
-    d = (struct linux_dirent64 *) (buf + pos);
-    CAMLlocal1 (r);
-    r = caml_alloc(2, 0);
-    Store_field(r, 0, caml_copy_string_of_os(d->d_name));
-    Store_field(r, 1, result);
-    result = r;
+    d = (struct dirent64 *) (buf + pos);
+    cons = caml_alloc(2, 0);
+    Store_field(cons, 0, caml_copy_string_of_os(d->d_name)); // Head
+    Store_field(cons, 1, result);                            // Tail
+    result = cons;
     pos += d->d_reclen;
   }
 

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -67,6 +67,8 @@ module Low_level : sig
     val mkdir : mode:Luv.File.Mode.t list -> string -> unit or_error
     (** Wraps {!Luv.File.mkdir} *)
 
+    val readdir : string -> string list or_error
+    (** Wraps {!Luv.File.readdir}. [readdir] opens and closes the directory for reading for the user. *)
   end
 
   module Random : sig

--- a/tests/test_fs.md
+++ b/tests/test_fs.md
@@ -33,8 +33,8 @@ let try_mkdir dir path =
 
 let try_read_dir dir path =
   match Eio.Dir.read_dir dir path with
-  | names -> traceln "read_dir [ %a ] -> ok" Fmt.(list ~sep:Fmt.comma string) names
-  | exception ex -> traceln "read_dir %a" Fmt.exn ex
+  | names -> traceln "read_dir %S -> %a" path Fmt.Dump.(list string) names
+  | exception ex -> traceln "read_dir %S -> %a" path Fmt.exn ex
 
 let chdir path =
   traceln "chdir %S" path;
@@ -245,9 +245,9 @@ Reading directory entries under `cwd` and outside of `cwd`.
 +chdir "readdir"
 +mkdir "test-1" -> ok
 +mkdir "test-2" -> ok
-+read_dir [ test-1, test-2 ] -> ok
-+read_dir Eio.Dir.Permission_denied ("..", _)
-+read_dir Eio.Dir.Not_found ("test-3", _)
++read_dir "." -> ["test-1"; "test-2"]
++read_dir ".." -> Eio.Dir.Permission_denied ("..", _)
++read_dir "test-3" -> Eio.Dir.Not_found ("test-3", _)
 +chdir ".."
 - : unit = ()
 ```

--- a/tests/test_fs.md
+++ b/tests/test_fs.md
@@ -238,6 +238,7 @@ Reading directory entries under `cwd` and outside of `cwd`.
     try_mkdir cwd "test-2";
     let _entries = try_read_dir cwd "." in
     let _perm_denied = try_read_dir cwd ".." in
+    let _non_existent = try_read_dir cwd "test-3" in
     ()
   );;
 +mkdir "readdir" -> ok
@@ -246,6 +247,7 @@ Reading directory entries under `cwd` and outside of `cwd`.
 +mkdir "test-2" -> ok
 +read_dir [ test-1, test-2 ] -> ok
 +read_dir Eio.Dir.Permission_denied ("..", _)
++read_dir Eio.Dir.Not_found ("test-3", _)
 +chdir ".."
 - : unit = ()
 ```


### PR DESCRIPTION
This PR starts the implementation of a `readdir` feature for Eio. I opened it mainly to have a conversation about the API.
 
  - What should be returned when you read the contents of a directory? This PR only returns the names of the contents, libuv does expose the `kind` of the entries which probably would be nice to add?
  - What should the name of the function be, here it is `read_dir` but I have seen `readdir` to follow the convention used by the C function, `contents` used by `Bos` etc.
 
At the moment I don't see a way to provide an asynchronous version with uring? I think with the 5.17 kernel there will be a `getdents64` uring submission function which could then be used.

Will fix #206 