### PR TITLE
Use Fun.protect

### DIFF
--- a/lib_eio/cancel.ml
+++ b/lib_eio/cancel.ml
@@ -112,9 +112,7 @@ let with_cc ~ctx:fiber ~parent ~protected fn =
   let deactivate = activate t ~parent in
   move_fiber_to t fiber;
   let cleanup () = move_fiber_to parent fiber; deactivate () in
-  match fn t with
-  | x            -> cleanup (); x
-  | exception ex -> cleanup (); raise ex
+  Fun.protect ~finally:cleanup @@ fun () -> fn t
 
 let protect fn =
   let ctx = Effect.perform Get_context in

--- a/lib_eio/stream.ml
+++ b/lib_eio/stream.ml
@@ -15,9 +15,7 @@ type 'a t = {
 
 let with_mutex t f =
   Mutex.lock t.mutex;
-  match f () with
-  | x -> Mutex.unlock t.mutex; x
-  | exception ex -> Mutex.unlock t.mutex; raise ex
+  Fun.protect f ~finally:(fun () -> Mutex.unlock t.mutex)
 
 (* Invariants *)
 let validate t =

--- a/lib_eio/switch.ml
+++ b/lib_eio/switch.ml
@@ -147,9 +147,7 @@ let run_in t fn =
   let ctx = Effect.perform Cancel.Get_context in
   let old_cc = ctx.cancel_context in
   Cancel.move_fiber_to t.cancel ctx;
-  match fn () with
-  | ()           -> Cancel.move_fiber_to old_cc ctx;
-  | exception ex -> Cancel.move_fiber_to old_cc ctx; raise ex
+  Fun.protect fn ~finally:(fun () -> Cancel.move_fiber_to old_cc ctx)
 
 let on_release_full t fn =
   if Domain.self () = t.cancel.domain then (


### PR DESCRIPTION
It seems the codebase is re-implementing `Fun.protect` at various places. It has the immediate advantage of preserving backtraces. The only danger of using `Fun.protect` is that, if the finalizer itself is raising an exception, that exception would be wrapped with `Fun.Finally_raised` and might be missed by the handlers which wish to capture it. I am not familiar with the codebase enough to assert that this would not happen, but these changes seem fine.