### PR TITLE
Add condition variables and concurrent-mutexes

### DIFF
--- a/lib_eio/condition.ml
+++ b/lib_eio/condition.ml
@@ -1,0 +1,27 @@
+type 'a or_exn = V of 'a | Exn of exn
+
+type 'a t = {
+  waiters: 'a or_exn Waiters.t; 
+  id: Ctf.id
+}
+
+let create () = {
+  waiters = Waiters.create ();
+  id = Ctf.mint_id ()}
+
+let wait ?mutex t = 
+  Option.iter Eio_mutex.unlock mutex;
+  let res = Waiters.await ~mutex:None t.waiters t.id in
+  Option.iter Eio_mutex.lock mutex;
+  match res with
+  | V v -> v
+  | Exn exn -> raise exn
+
+let signal t v = 
+  Waiters.wake_one t.waiters (V v) |> ignore
+
+let broadcast t v =
+  Waiters.wake_all t.waiters (V v)
+
+let broadcast_exn t v =
+  Waiters.wake_all t.waiters (Exn v)

--- a/lib_eio/ctf.ml
+++ b/lib_eio/ctf.ml
@@ -59,6 +59,7 @@ type event =
   | Semaphore
   | Switch
   | Stream
+  | Mutex
 
 type log_buffer = (char, int8_unsigned_elt, c_layout) Array1.t
 
@@ -85,6 +86,7 @@ let int_of_thread_type t =
   | Semaphore -> 16
   | Switch -> 17
   | Stream -> 18
+  | Mutex -> 19
 
 module Packet = struct
   let magic = 0xc1fc1fc1l

--- a/lib_eio/ctf.mli
+++ b/lib_eio/ctf.mli
@@ -47,6 +47,7 @@ type event =
   | Semaphore
   | Switch
   | Stream
+  | Mutex
 (** Types of threads or other recorded objects. *)
 
 val mint_id : unit -> id

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -33,7 +33,7 @@ module Std = struct
 end
 
 module Semaphore = Semaphore
-module Eio_mutex = Eio_mutex
+module Mutex = Eio_mutex
 module Condition = Condition
 module Stream = Stream
 module Exn = Exn

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -33,6 +33,8 @@ module Std = struct
 end
 
 module Semaphore = Semaphore
+module Eio_mutex = Eio_mutex
+module Condition = Condition
 module Stream = Stream
 module Exn = Exn
 module Generic = Generic

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -325,61 +325,58 @@ module Semaphore : sig
 end
 
 (** A mutex *)
-module Eio_mutex : sig 
+module Mutex : sig 
   
+  type t
   (** The type for a concurrency-friendly Mutex. 
       Do not mix it up with the Domain-wise Stdlib.Mutex. *)
-  type t
-
-  (** [create ()] creates an initially unlocked mutex*)
+  
   val create : unit -> t
-
+  (** [create ()] creates an initially unlocked mutex*)
+  
+  val lock : t -> unit
   (** [lock t] tries to lock the mutex:
       - if it's already locked, the fiber is paused until it's unlocked.
       - if it's unlocked, the mutex is locked and the fiber continues. *)
-  val lock : t -> unit
-
-  (** [unlock t] unlocks the mutex *)
+  
   val unlock : t -> unit
-
-  (** [is_locked t] returns true if the mutex is currently locked *)
+  (** [unlock t] unlocks the mutex *)
+  
   val is_locked : t -> bool
+  (** [is_locked t] returns true if the mutex is currently locked *)
 
-  (** [is_empty t] returns true if the mutex is currently empty *)
-  val is_empty : t -> bool
-
-  (** [with_lock t fn] holds the mutex locked while executing [fn] *)
   val with_lock : t -> (unit -> 'a) -> 'a
-
+  (** [with_lock t fn] holds the mutex locked while executing [fn] *)
+  
 end
 
 (** A condition variable *)
 module Condition : sig 
 
-  (** Condition variables to synchronize between fibers. *)
   type 'a t
-
-  (** [create ()] creates a new condition variable signaling values of type ['a] *)
+  (** Condition variables to synchronize between fibers. *)
+  
   val create : unit -> 'a t
-
+  (** [create ()] creates a new condition variable signaling values of type ['a] *)
+  
+  val wait : ?mutex:Mutex.t -> 'a t -> 'a
   (** [wait ~mutex cond] pauses the current fiber until it is notified by [cond]. 
       If [mutex] is set, it is unlocked while the fiber is waiting and locked when 
       it is woken up.
   *)
-  val wait : ?mutex:Eio_mutex.t -> 'a t -> 'a
-
+  
+  val signal : 'a t -> 'a -> unit
   (** [signal cond value] wakes up a single waiting fiber with the given [value]. 
       If no fibers are waiting, nothing happens. *)
-  val signal : 'a t -> 'a -> unit
-
+  
+  val broadcast : 'a t -> 'a -> unit
   (** [broadcast cond value] wakes up a waiting fibers with the given [value]. 
       If no fibers are waiting, nothing happens. *)
-  val broadcast : 'a t -> 'a -> unit
-
+  
+  val broadcast_exn : 'a t -> exn -> unit
   (** [broadcast_exn cond exn] wakes up a waiting fibers with an exception [exn]. 
       If no fibers are waiting, nothing happens. *)
-  val broadcast_exn : 'a t -> exn -> unit
-
+  
 end
 
 (** A stream/queue. *)

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -356,29 +356,21 @@ end
 (** A condition variable *)
 module Condition : sig 
 
-  type 'a t
+  type t
   (** Condition variables to synchronize between fibers. *)
   
-  val create : unit -> 'a t
-  (** [create ()] creates a new condition variable signaling values of type ['a] *)
+  val create : unit -> t
+  (** [create ()] creates a new condition variable *)
   
-  val wait : ?mutex:Mutex.t -> 'a t -> 'a
-  (** [wait ~mutex cond] pauses the current fiber until it is notified by [cond]. 
+  val await : ?mutex:Mutex.t -> t -> unit
+  (** [await ~mutex cond] pauses the current fiber until it is notified by [cond]. 
       If [mutex] is set, it is unlocked while the fiber is waiting and locked when 
       it is woken up.
   *)
   
-  val signal : 'a t -> 'a -> unit
-  (** [signal cond value] wakes up a single waiting fiber with the given [value]. 
-      If no fibers are waiting, nothing happens. *)
-  
-  val broadcast : 'a t -> 'a -> unit
-  (** [broadcast cond value] wakes up a waiting fibers with the given [value]. 
-      If no fibers are waiting, nothing happens. *)
-  
-  val broadcast_exn : 'a t -> exn -> unit
-  (** [broadcast_exn cond exn] wakes up a waiting fibers with an exception [exn]. 
-      If no fibers are waiting, nothing happens. *)
+  val broadcast : t -> unit
+  (** [broadcast cond] wakes up waiting fibers. 
+      If no fibers are waiting, nothing happens and the function returns. *)
   
 end
 

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -332,15 +332,18 @@ module Mutex : sig
       Do not mix it up with the Domain-wise Stdlib.Mutex. *)
   
   val create : unit -> t
-  (** [create ()] creates an initially unlocked mutex*)
+  (** [create ()] creates an initially unlocked mutex. *)
   
   val lock : t -> unit
   (** [lock t] tries to lock the mutex:
       - if it's already locked, the fiber is paused until it's unlocked.
       - if it's unlocked, the mutex is locked and the fiber continues. *)
   
+  exception Already_unlocked
+
   val unlock : t -> unit
-  (** [unlock t] unlocks the mutex *)
+  (** [unlock t] unlocks the mutex. If the mutex was already unlocked, 
+      this function raises `Already_unlocked`. *)
   
   val is_locked : t -> bool
   (** [is_locked t] returns true if the mutex is currently locked *)

--- a/lib_eio/eio_mutex.ml
+++ b/lib_eio/eio_mutex.ml
@@ -1,0 +1,15 @@
+type t = Semaphore.t
+
+let create () = Semaphore.make 1
+
+let is_empty t = Semaphore.get_value t == 1
+
+let is_locked t = Semaphore.get_value t == 0
+
+let unlock = Semaphore.release
+
+let lock = Semaphore.acquire
+
+let with_lock t fn =
+  lock t;
+  Fun.protect ~finally:(fun () -> unlock t) fn

--- a/lib_eio/eio_mutex.ml
+++ b/lib_eio/eio_mutex.ml
@@ -1,14 +1,64 @@
-type t = Semaphore.t
+type state =
+  | Unlocked                    (* can be locked *)
+  | Locked                      (* is locked, no threads waiting *)
+  | Waiting of unit Waiters.t   (* is locked, threads waiting *)
 
-let create () = Semaphore.make 1
+type t = {
+  id : Ctf.id;
+  mutex : Mutex.t;
+  mutable state : state;
+}
 
-let is_empty t = Semaphore.get_value t == 1
+let create () =
+  let id = Ctf.mint_id () in
+  Ctf.note_created id Ctf.Mutex;
+  {
+    id;
+    mutex = Mutex.create ();
+    state = Unlocked;
+  }
 
-let is_locked t = Semaphore.get_value t == 0
+let is_locked t =
+  Mutex.lock t.mutex;
+  let s = t.state in
+  Mutex.unlock t.mutex;
+  match s with
+  | Unlocked -> false
+  | Locked | Waiting _ -> true
 
-let unlock = Semaphore.release
+exception Already_unlocked
 
-let lock = Semaphore.acquire
+let unlock t =
+  Mutex.lock t.mutex;
+  Ctf.note_signal t.id;
+  match t.state with
+  | Unlocked -> 
+    Mutex.unlock t.mutex;
+    raise Already_unlocked
+  | Locked ->
+    t.state <- Unlocked;
+    Mutex.unlock t.mutex
+  | Waiting q ->
+    begin match Waiters.wake_one q () with
+      | `Ok -> ()
+      | `Queue_empty -> t.state <- Unlocked
+    end;
+    Mutex.unlock t.mutex
+
+let rec lock t =
+  Mutex.lock t.mutex;
+  match t.state with
+  | Waiting q ->
+    Ctf.note_try_read t.id;
+    Waiters.await ~mutex:(Some t.mutex) q t.id
+  | Locked ->
+    t.state <- Waiting (Waiters.create ());
+    Mutex.unlock t.mutex;
+    lock t
+  | Unlocked -> 
+    Ctf.note_read t.id;
+    t.state <- Locked;
+    Mutex.unlock t.mutex
 
 let with_lock t fn =
   lock t;

--- a/tests/test_condition.md
+++ b/tests/test_condition.md
@@ -1,0 +1,106 @@
+# Setting up the environment
+
+```ocaml
+# #require "eio_main";;
+```
+
+```ocaml
+open Eio.Std
+
+module C = Eio.Condition
+
+let run fn =
+  Eio_main.run @@ fun _ ->
+  fn ()
+```
+
+# Test cases
+
+
+Simple case:
+
+```ocaml
+# run @@ fun () ->
+  Switch.run @@ fun sw ->
+  let condition = C.create () in
+  Fiber.all
+    [
+    (fun () -> 
+        traceln "1: wait for condition"; 
+        C.wait condition;
+        traceln "1: finished");
+    (fun () -> 
+        traceln "2: signal condition";
+        C.signal condition ();
+        traceln "2: finished")
+    ];;
++1: wait for condition
++2: signal condition
++2: finished
++1: finished
+- : unit = ()
+```
+
+Signal wakes a single waiter:
+
+```ocaml
+# run @@ fun () ->
+  Switch.run @@ fun sw ->
+  let condition = C.create () in
+  Fiber.all
+    [
+    (fun () -> 
+        traceln "1: wait for condition"; 
+        C.wait condition;
+        traceln "1: finished");
+    (fun () -> 
+        traceln "2: wait for condition"; 
+        C.wait condition;
+        traceln "2: finished");
+    (fun () -> 
+        traceln "3: signal first condition";
+        C.signal condition ();
+        Eio.Fiber.yield ();
+        traceln "3: signal second condition";
+        C.signal condition ();
+        traceln "3: finished")
+    ];;
++1: wait for condition
++2: wait for condition
++3: signal first condition
++1: finished
++3: signal second condition
++3: finished
++2: finished
+- : unit = ()
+```
+
+Broadcast wakes all waiters at once:
+
+```ocaml
+# run @@ fun () ->
+  Switch.run @@ fun sw ->
+  let condition = C.create () in
+  Fiber.all
+    [
+    (fun () -> 
+        traceln "1: wait for condition"; 
+        C.wait condition;
+        traceln "1: finished");
+    (fun () -> 
+        traceln "2: wait for condition"; 
+        C.wait condition;
+        traceln "2: finished");
+    (fun () -> 
+        traceln "3: broadcast condition";
+        C.broadcast condition ();
+        traceln "3: finished")
+    ];;
++1: wait for condition
++2: wait for condition
++3: broadcast condition
++3: finished
++1: finished
++2: finished
+- : unit = ()
+```

--- a/tests/test_condition.md
+++ b/tests/test_condition.md
@@ -27,51 +27,31 @@ Simple case:
     [
     (fun () -> 
         traceln "1: wait for condition"; 
-        C.wait condition;
+        C.await condition;
         traceln "1: finished");
     (fun () -> 
-        traceln "2: signal condition";
-        C.signal condition ();
+        traceln "2: broadcast condition";
+        C.broadcast condition;
         traceln "2: finished")
     ];;
 +1: wait for condition
-+2: signal condition
++2: broadcast condition
 +2: finished
 +1: finished
 - : unit = ()
 ```
 
-Signal wakes a single waiter:
+Broadcast when no one is waiting doesn't block:
 
 ```ocaml
 # run @@ fun () ->
   Switch.run @@ fun sw ->
   let condition = C.create () in
-  Fiber.all
-    [
-    (fun () -> 
-        traceln "1: wait for condition"; 
-        C.wait condition;
-        traceln "1: finished");
-    (fun () -> 
-        traceln "2: wait for condition"; 
-        C.wait condition;
-        traceln "2: finished");
-    (fun () -> 
-        traceln "3: signal first condition";
-        C.signal condition ();
-        Eio.Fiber.yield ();
-        traceln "3: signal second condition";
-        C.signal condition ();
-        traceln "3: finished")
-    ];;
-+1: wait for condition
-+2: wait for condition
-+3: signal first condition
-+1: finished
-+3: signal second condition
-+3: finished
-+2: finished
+    traceln "broadcast condition";
+    C.broadcast condition;
+    traceln "finished";;
++broadcast condition
++finished
 - : unit = ()
 ```
 
@@ -85,15 +65,15 @@ Broadcast wakes all waiters at once:
     [
     (fun () -> 
         traceln "1: wait for condition"; 
-        C.wait condition;
+        C.await condition;
         traceln "1: finished");
     (fun () -> 
         traceln "2: wait for condition"; 
-        C.wait condition;
+        C.await condition;
         traceln "2: finished");
     (fun () -> 
         traceln "3: broadcast condition";
-        C.broadcast condition ();
+        C.broadcast condition;
         traceln "3: finished")
     ];;
 +1: wait for condition

--- a/tests/test_mutex.md
+++ b/tests/test_mutex.md
@@ -7,7 +7,7 @@
 ```ocaml
 open Eio.Std
 
-module M = Eio.Eio_mutex
+module M = Eio.Mutex
 
 let run fn =
   Eio_main.run @@ fun _ ->

--- a/tests/test_mutex.md
+++ b/tests/test_mutex.md
@@ -77,3 +77,14 @@ Concurrent access to the mutex
 +Unlocked
 - : unit = ()
 ```
+
+Double unlock raises an exception
+
+```ocaml
+# run @@ fun () ->
+  let t = M.create () in
+  M.lock t;
+  M.unlock t;
+  M.unlock t;;
+Exception: Eio__Eio_mutex.Already_unlocked.
+```

--- a/tests/test_mutex.md
+++ b/tests/test_mutex.md
@@ -1,0 +1,79 @@
+# Setting up the environment
+
+```ocaml
+# #require "eio_main";;
+```
+
+```ocaml
+open Eio.Std
+
+module M = Eio.Eio_mutex
+
+let run fn =
+  Eio_main.run @@ fun _ ->
+  fn ()
+
+let lock t =
+  traceln "Locking";
+  M.lock t;
+  traceln "Locked"
+
+let unlock t =
+  traceln "Unlocking";
+  M.unlock t;
+  traceln "Unlocked"
+```
+
+# Test cases
+
+Simple case
+
+```ocaml
+# run @@ fun () ->
+  let t = M.create () in
+  lock t;
+  unlock t;
+  lock t;
+  unlock t;;
++Locking
++Locked
++Unlocking
++Unlocked
++Locking
++Locked
++Unlocking
++Unlocked
+- : unit = ()
+```
+
+Concurrent access to the mutex
+
+
+```ocaml
+# run @@ fun () ->
+  let t = M.create () in
+  let fn () = 
+    lock t;
+    Eio.Fiber.yield ();
+    unlock t
+  in
+  List.init 4 (fun _ -> fn)
+  |> Fiber.all;;
++Locking
++Locked
++Locking
++Locking
++Locking
++Unlocking
++Unlocked
++Locked
++Unlocking
++Unlocked
++Locked
++Unlocking
++Unlocked
++Locked
++Unlocking
++Unlocked
+- : unit = ()
+```


### PR DESCRIPTION
Hi, when porting the lwt-based Mirage networking stack to `eio` I have encountered an extensive use of the 
[Lwt_condition](https://ocsigen.org/lwt/latest/api/Lwt_condition) and  [Lwt_mutex](https://ocsigen.org/lwt/latest/api/Lwt_mutex) modules. This PR adds eio-equivalents: `Condition` and `Eio_mutex` (`Eio_mutex` is prefixed because of the already existing `Stdlib.Mutex`).

Both features have straightforward implementations by using existing modules (`Semaphore` / `Waiters`) but I think it can ease the transition from `lwt` to `eio` to have them.

This is obviously open for discussion.