### PR TITLE
Handle EINTR error when calling `getrandom` system call

### DIFF
--- a/lib_eio_linux/eio_stubs.c
+++ b/lib_eio_linux/eio_stubs.c
@@ -2,6 +2,7 @@
 #include <sys/types.h>
 #include <sys/eventfd.h>
 #include <sys/random.h>
+#include <errno.h>
 
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
@@ -33,10 +34,16 @@ CAMLprim value caml_eio_mkdirat(value v_fd, value v_path, value v_perm) {
 CAMLprim value caml_eio_getrandom(value v_ba, value v_off, value v_len) {
   CAMLparam1(v_ba);
   ssize_t ret;
-  void *buf = Caml_ba_data_val(v_ba) + Long_val(v_off);
-  caml_enter_blocking_section();
-  ret = getrandom(buf, Long_val(v_len), 0);
-  caml_leave_blocking_section();
-  if (ret == -1) uerror("getrandom", Nothing);
+  size_t off = (size_t)Long_val(v_off);
+  size_t len = (size_t)Long_val(v_len);
+  while (off < len) {
+    void *buf = Caml_ba_data_val(v_ba) + off;
+    caml_enter_blocking_section();
+    ret = getrandom(buf, len - off, 0);
+    caml_leave_blocking_section();
+    if (ret < 0 && errno == EINTR) continue;
+    else if (ret < 0) uerror("getrandom", Nothing);
+    off += ret;
+  }
   CAMLreturn(Val_long(ret));
 }

--- a/lib_eio_linux/eio_stubs.c
+++ b/lib_eio_linux/eio_stubs.c
@@ -34,16 +34,14 @@ CAMLprim value caml_eio_mkdirat(value v_fd, value v_path, value v_perm) {
 CAMLprim value caml_eio_getrandom(value v_ba, value v_off, value v_len) {
   CAMLparam1(v_ba);
   ssize_t ret;
-  size_t off = (size_t)Long_val(v_off);
-  size_t len = (size_t)Long_val(v_len);
-  while (off < len) {
+  ssize_t off = (ssize_t)Long_val(v_off);
+  ssize_t len = (ssize_t)Long_val(v_len);
+  do {
     void *buf = Caml_ba_data_val(v_ba) + off;
     caml_enter_blocking_section();
-    ret = getrandom(buf, len - off, 0);
+    ret = getrandom(buf, len, 0);
     caml_leave_blocking_section();
-    if (ret < 0 && errno == EINTR) continue;
-    else if (ret < 0) uerror("getrandom", Nothing);
-    off += ret;
-  }
+  } while (ret == -1 && errno == EINTR);
+  if (ret == -1) uerror("getrandom", Nothing);
   CAMLreturn(Val_long(ret));
 }

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -260,9 +260,12 @@ module Low_level = struct
   end
 
   module Random = struct
-    let fill buf =
+    let rec fill buf =
       let request = Luv.Random.Request.make () in
-      await_with_cancel ~request (fun loop -> Luv.Random.random ~loop ~request buf) |> or_raise
+      match await_with_cancel ~request (fun loop -> Luv.Random.random ~loop ~request buf) with
+      | Ok x -> x 
+      | Error `EINTR -> fill buf
+      | Error x -> raise (Luv_error x)
   end
 
   module Stream = struct


### PR DESCRIPTION
This PR handles EINTR error return code when `getrandom` is called via eio_linux or eio_luv packages.

Fixes part of https://github.com/ocaml-multicore/eio/issues/211
Required by https://github.com/mirage/mirage-crypto/pull/155