### PR TITLE
Eio_linux: handle sleeping tasks that are now due before paused fibers

### DIFF
--- a/doc/prelude.ml
+++ b/doc/prelude.ml
@@ -13,7 +13,7 @@ module Eio_main = struct
          multiple times, they'll get woken in the right order. At the moment,
          the scheduler only checks for expired timers when the run-queue is
          empty, so this is a convenient way to wait for the system to be idle.
-         Will need revising if we make the scheduler fair at some point. *)
+         TODO: This is no longer true (since #213). *)
       Eio.Time.sleep_until real_clock time;
       now := max !now time
   end

--- a/tests/test_time.md
+++ b/tests/test_time.md
@@ -102,3 +102,18 @@ Check Unix debug clock:
 +Sleep done
 - : unit = ()
 ```
+
+Timer and busy loop:
+```ocaml
+let rec loop () =
+  Eio.Fiber.yield ();
+  loop ()
+```
+
+```ocaml
+# run @@ fun ~clock ->
+  Fiber.first
+    loop
+    (fun () -> Eio.Time.sleep clock 0.1);;
+- : unit = ()
+```


### PR DESCRIPTION
When using Eio I encountered an issue while porting a test in the mirage `arp` library. 

The failing code can be reduced to the following:
```ocaml
let rec loop () =
  Eio.Fiber.yield ();
  loop ()

let () = run @@ fun ~clock ->
  Fiber.first
    loop
    (fun () -> Eio.Time.sleep clock 0.1)
```

I expected this code to finish after `0.1s` of execution, but instead it does an infinite loop. This is because the scheduler prioritizes paused fibers before sleeping fibers that are now due. 

This PR adds a `Zzz.pop` before checking for paused fibers. 