### PR TITLE
Eio_linux: fix read_dir

### DIFF
--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -779,12 +779,12 @@ module Low_level = struct
       client, client_addr
     )
 
-    let open_dir ?dir ~sw path =
+    let open_dir ?dir ~sw ~resolve path =
       openat2 ~sw ~seekable:false ?dir path
           ~access:`R
           ~flags:Uring.Open_flags.(cloexec + directory)
           ~perm:0
-          ~resolve:Uring.Resolve.beneath
+          ~resolve
 
     let getdents dir =
       Eio_unix.run_in_systhread (fun () -> eio_getdents (FD.get "getdents" dir))
@@ -1096,7 +1096,7 @@ class dir fd = object
       | files -> read_all (acc @ files) fd
     in
     Switch.run (fun sw ->
-      let dir = Low_level.open_dir ~sw path in
+      let dir = Low_level.open_dir ?dir:fd ~resolve:resolve_flags ~sw path in
       read_all [] dir
     )
 

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1092,8 +1092,10 @@ class dir fd = object
   method read_dir path =
     let rec read_all acc fd =
       match Low_level.getdents fd with
-      | [] -> List.filter (function ".." | "." -> false | _ -> true) acc
-      | files -> read_all (acc @ files) fd
+      | [] -> acc
+      | files ->
+        let files = List.filter (function ".." | "." -> false | _ -> true) files in
+        read_all (files @ acc) fd
     in
     Switch.run (fun sw ->
       let dir = Low_level.open_dir ?dir:fd ~resolve:resolve_flags ~sw path in

--- a/tests/test_fs.md
+++ b/tests/test_fs.md
@@ -232,23 +232,18 @@ Reading directory entries under `cwd` and outside of `cwd`.
 # run @@ fun env ->
   let cwd = Eio.Stdenv.cwd env in
   try_mkdir cwd "readdir";
-  chdir "readdir";
-  Fun.protect ~finally:(fun () -> chdir "..") (fun () ->
-    try_mkdir cwd "test-1";
-    try_mkdir cwd "test-2";
-    let _entries = try_read_dir cwd "." in
-    let _perm_denied = try_read_dir cwd ".." in
-    let _non_existent = try_read_dir cwd "test-3" in
-    ()
-  );;
+  Eio.Dir.with_open_dir cwd "readdir" @@ fun tmpdir ->
+  try_mkdir tmpdir "test-1";
+  try_mkdir tmpdir "test-2";
+  try_read_dir tmpdir ".";
+  try_read_dir tmpdir "..";
+  try_read_dir tmpdir "test-3";;
 +mkdir "readdir" -> ok
-+chdir "readdir"
 +mkdir "test-1" -> ok
 +mkdir "test-2" -> ok
 +read_dir "." -> ["test-1"; "test-2"]
 +read_dir ".." -> Eio.Dir.Permission_denied ("..", _)
 +read_dir "test-3" -> Eio.Dir.Not_found ("test-3", _)
-+chdir ".."
 - : unit = ()
 ```
 


### PR DESCRIPTION
It was ignoring the directory and always reading from env#cwd.