### PR TITLE
eio_linux: make read_dir faster

### DIFF
--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -205,10 +205,10 @@ module Low_level : sig
   val fstat : FD.t -> Unix.stats
   (** Like {!Unix.fstat}. *)
 
-  val getdents : FD.t -> string list
-  (** [getdents dir] gets directory entries from [dir], but not necessarily all of them.
-      The function can be called multiple times on the open directory and will return the
-      empty list when there are no more entries to be returned. *)
+  val read_dir : FD.t -> string list
+  (** [read_dir dir] reads all directory entries from [dir].
+      The entries are not returned in any particular order
+      (not even necessarily the order in which Linux returns them). *)
 
   (** {1 Sockets} *)
 

--- a/lib_eio_linux/eio_stubs.c
+++ b/lib_eio_linux/eio_stubs.c
@@ -3,6 +3,7 @@
 #include <sys/eventfd.h>
 #include <sys/random.h>
 #include <sys/syscall.h>
+#include <limits.h>
 #include <errno.h>
 #include <dirent.h>
 
@@ -13,7 +14,8 @@
 #include <caml/unixsupport.h>
 #include <caml/bigarray.h>
 
-#define DIRENT_BUF_SIZE 1024
+// Make sure we have enough space for at least one entry.
+#define DIRENT_BUF_SIZE (PATH_MAX + sizeof(struct dirent64))
 
 CAMLprim value caml_eio_eventfd(value v_initval) {
   int ret;


### PR DESCRIPTION
This further improves the performance of directory reads by using a larger buffer and by performing all reads in a single systhread, rather than creating a new one for each chunk.

- `Read 152448 items in 1.188156 seconds` with the old code.
- `Read 152448 items in 0.217013 seconds` with the new code.

(continues #218)