### PR TITLE
Check for cancellation when creating a non-protected child context

### DIFF
--- a/lib_eio/cancel.ml
+++ b/lib_eio/cancel.ml
@@ -108,6 +108,7 @@ let activate t ~parent =
 
 (* Runs [fn] with a fresh cancellation context. *)
 let with_cc ~ctx:fiber ~parent ~protected fn =
+  if not protected then check parent;
   let t = create ~protected in
   let deactivate = activate t ~parent in
   move_fiber_to t fiber;

--- a/tests/test_fibre.md
+++ b/tests/test_fibre.md
@@ -469,3 +469,18 @@ The child outlives the forking context. The error handler runs in `bg_switch`, s
 +Main fiber result
 - : unit = ()
 ```
+
+# Forking while cancelled
+
+```ocaml
+# run @@ fun () ->
+  Fiber.first
+    (fun () -> failwith "Simulated error")
+    (fun () ->
+       Fiber.both
+         (fun () -> traceln "Not reached")
+         (fun () -> traceln "Not reached");
+       assert false
+    );;
+Exception: Failure "Simulated error".
+```


### PR DESCRIPTION
Otherwise we can end up with a cancelled parent context with a non-cancelled and non-protected child.