### PR TITLE
Add Eio.Mutex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all:
 	dune build @runtest @all
 
 bench:
+	dune exec -- ./bench/bench_mutex.exe
 	dune exec -- ./bench/bench_yield.exe
 	dune exec -- ./bench/bench_promise.exe
 	dune exec -- ./bench/bench_stream.exe

--- a/bench/bench_mutex.ml
+++ b/bench/bench_mutex.ml
@@ -1,0 +1,58 @@
+open Eio.Std
+
+let v = ref 0
+
+let run_sender ~iters_per_thread mutex =
+  for _ = 1 to iters_per_thread do
+    Eio.Mutex.lock mutex;
+    let x = !v in
+    v := x + 1;
+    Fiber.yield ();
+    assert (!v = x + 1);
+    v := x;
+    Eio.Mutex.unlock mutex;
+  done
+
+let run_bench ~domain_mgr ~clock ~use_domains ~iters_per_thread ~threads =
+  let mutex = Eio.Mutex.create () in
+  Gc.full_major ();
+  let _minor0, prom0, _major0 = Gc.counters () in
+  let t0 = Eio.Time.now clock in
+  Switch.run (fun sw ->
+      for _ = 1 to threads do
+        Fiber.fork ~sw (fun () ->
+            if use_domains then (
+              Eio.Domain_manager.run domain_mgr @@ fun () ->
+              run_sender ~iters_per_thread mutex
+            ) else (
+              run_sender ~iters_per_thread mutex
+            )
+          )
+      done
+    );
+  assert (!v = 0);
+  let t1 = Eio.Time.now clock in
+  let time_total = t1 -. t0 in
+  let n_iters = iters_per_thread * threads in
+  let time_per_iter = time_total /. float n_iters in
+  let _minor1, prom1, _major1 = Gc.counters () in
+  let prom = prom1 -. prom0 in
+  Printf.printf "%11b, %12d, %8d, %8.2f, %13.4f\n%!" use_domains n_iters threads (1e9 *. time_per_iter) (prom /. float n_iters)
+
+let main ~domain_mgr ~clock =
+  Printf.printf "use_domains, iters/thread,  threads,  ns/iter, promoted/iter\n%!";
+  [false, 1_000_000, 1;
+   false, 1_000_000, 2;
+   false,   100_000, 8;
+   true,    100_000, 1;
+   true,     10_000, 2;
+   true,     10_000, 8]
+  |> List.iter (fun (use_domains, iters_per_thread, threads) ->
+      run_bench ~domain_mgr ~clock ~use_domains ~iters_per_thread ~threads
+    )
+
+let () =
+  Eio_main.run @@ fun env ->
+  main
+    ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+    ~clock:(Eio.Stdenv.clock env)

--- a/bench/dune
+++ b/bench/dune
@@ -1,3 +1,3 @@
 (executables
-  (names bench_stream bench_promise bench_semaphore bench_yield bench_cancel)
+  (names bench_stream bench_promise bench_semaphore bench_yield bench_cancel bench_mutex)
   (libraries eio_main))

--- a/lib_eio/ctf.ml
+++ b/lib_eio/ctf.ml
@@ -59,6 +59,7 @@ type event =
   | Semaphore
   | Switch
   | Stream
+  | Mutex
 
 type log_buffer = (char, int8_unsigned_elt, c_layout) Array1.t
 
@@ -85,6 +86,7 @@ let int_of_thread_type t =
   | Semaphore -> 16
   | Switch -> 17
   | Stream -> 18
+  | Mutex -> 19
 
 module Packet = struct
   let magic = 0xc1fc1fc1l

--- a/lib_eio/ctf.mli
+++ b/lib_eio/ctf.mli
@@ -47,6 +47,7 @@ type event =
   | Semaphore
   | Switch
   | Stream
+  | Mutex
 (** Types of threads or other recorded objects. *)
 
 val mint_id : unit -> id

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -33,6 +33,7 @@ module Std = struct
 end
 
 module Semaphore = Semaphore
+module Mutex = Eio_mutex
 module Stream = Stream
 module Exn = Exn
 module Generic = Generic

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -324,6 +324,35 @@ module Semaphore : sig
   (** [get_value t] returns the current value of semaphore [t]. *)
 end
 
+(** A mutex *)
+module Mutex : sig 
+  
+  type t
+  (** The type for a concurrency-friendly Mutex. 
+      Do not mix it up with the Domain-wise Stdlib.Mutex. *)
+  
+  val create : unit -> t
+  (** [create ()] creates an initially unlocked mutex. *)
+  
+  val lock : t -> unit
+  (** [lock t] tries to lock the mutex:
+      - if it's already locked, the fiber is paused until it's unlocked.
+      - if it's unlocked, the mutex is locked and the fiber continues. *)
+  
+  exception Already_unlocked
+
+  val unlock : t -> unit
+  (** [unlock t] unlocks the mutex. If the mutex was already unlocked, 
+      this function raises `Already_unlocked`. *)
+  
+  val is_locked : t -> bool
+  (** [is_locked t] returns true if the mutex is currently locked *)
+
+  val with_lock : t -> (unit -> 'a) -> 'a
+  (** [with_lock t fn] holds the mutex locked while executing [fn] *)
+  
+end
+
 (** A stream/queue. *)
 module Stream : sig
   (** Reading from an empty queue will wait until an item is available.

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -327,17 +327,49 @@ end
 (** Mutual exclusion. *)
 module Mutex : sig 
   (** A mutex can be used to ensure that only one piece of code can access a shared resource at one time.
+
       Unlike {!Stdlib.Mutex}, which blocks the whole domain while waiting to take the mutex,
       this module allows other Eio fibers to run while waiting.
       You should use this module if your critical section may perform blocking operations,
       while [Stdlib.Mutex] may be more efficient if the lock is held only briefly and
-      the critial section does not switch fibers. *)
+      the critial section does not switch fibers.
+
+      Note that mutexes are often unnecessary for code running in a single domain, as
+      the scheduler will only switch to another fiber if you perform an operation that
+      can block. *)
   
   type t
-  (** The type for a concurrency-friendly Mutex. *)
+  (** The type for a concurrency-friendly mutex. *)
+
+  exception Poisoned of exn
+  (** Raised if you attempt to use a mutex that has been disabled. *)
   
   val create : unit -> t
   (** [create ()] creates an initially unlocked mutex. *)
+
+  val use_rw : protect:bool -> t -> (unit -> 'a) -> 'a
+  (** [use_rw ~protect t fn] waits for the mutex to be free and then executes [fn ()] while holding the mutex locked.
+      [fn] may mutate the resource protected by the mutex,
+      but must ensure the resource is in a consistent state before returning.
+      If [fn] raises an exception, the mutex is disabled and cannot be used again.
+      @param protect If [true], uses {!Cancel.protect} to prevent the critical section from being cancelled.
+                     Cancellation is not prevented while waiting to take the lock. *)
+
+  val use_ro : t -> (unit -> 'a) -> 'a
+  (** [use_ro t fn] is like {!use_rw ~protect:false},
+      but if [fn] raises an exception it unlocks the mutex instead of disabling it.
+      Use this if you only need read-only access to the mutex's resource and so
+      know that it will be in a consistent state even if an exception is raised. *)
+
+  (** {2 Low-level API}
+
+      Care must be taken when locking a mutex manually. It is easy to forget to unlock it in some cases,
+      which will result in deadlock the next time a fiber tries to use it.
+      In particular, you need to consider:
+
+      - What happens if your critical section raises an exception.
+      - What happens if your fiber is cancelled while in its critical section.
+   *)
   
   val lock : t -> unit
   (** Lock the given mutex. Only one fiber can have the mutex locked at any time.
@@ -352,13 +384,6 @@ module Mutex : sig
   val try_lock : t -> bool
   (** Same as {!lock}, but does not suspend the calling thread if the mutex is already locked:
       just return [false] immediately in that case. If the mutex is unlocked, lock it and return [true]. *)
-
-  val with_lock : ?on_exn:[`Unlock | `Poison] -> t -> (unit -> 'a) -> 'a
-  (** [with_lock ~on_exn t fn] holds the mutex locked while executing [fn].
-      @param on_exn Determines what to do if [fn] raises an exception.
-                    If [`Unlock] then the mutex is unlocked (useful for read-only operations).
-                    If [`Poison] (the default) then the mutex is marked as unusable.
-                    In either case, [with_lock] re-raises the exception. *)
 end
 
 (** A stream/queue. *)

--- a/lib_eio/eio_mutex.ml
+++ b/lib_eio/eio_mutex.ml
@@ -8,52 +8,71 @@ exception Poisoned of exn
 type t = {
   id : Ctf.id;
   mutex : Mutex.t;
-  mutable state : state;
-  waiters : unit Waiters.t;
+  mutable state : state;                        (* Owned by [t.mutex] *)
+  waiters : [`Take | `Error of exn] Waiters.t;  (* Owned by [t.mutex] *)
 }
+(* Invariant: t.state <> Locked -> is_empty t.waiters *)
 
+(* When [t.state = Unlocked], [t] owns the user resource that [t] protects.
+   [mutex t R] means [t] is a share of a reference to a mutex with an invariant R.
+   [locked t] means the holder has the ability to unlock [t]. *)
+
+(* {R} t = create () {mutex t R} *)
 let create () =
   let id = Ctf.mint_id () in
   Ctf.note_created id Ctf.Mutex;
   {
     id;
     mutex = Mutex.create ();
-    state = Unlocked;
+    state = Unlocked;                   (* Takes ownership of R *)
     waiters = Waiters.create ();
   }
 
+(* {mutex t R * locked t * R} unlock t {mutex t R}
+   If [t] is in an invalid state, it raises an exception and nothing changes. *)
 let unlock t =
   Mutex.lock t.mutex;
+  (* We now have ownership of [t.state] and [t.waiters]. *)
   Ctf.note_signal t.id;
   match t.state with
   | Unlocked -> 
     Mutex.unlock t.mutex;
-    raise (Sys_error "Eio.Mutex.unlock: already unlocked!")
+    let ex = Sys_error "Eio.Mutex.unlock: already unlocked!" in
+    t.state <- Poisoned ex;
+    raise ex
   | Locked ->
-    begin match Waiters.wake_one t.waiters () with
-      | `Ok -> ()
-      | `Queue_empty -> t.state <- Unlocked
+    begin match Waiters.wake_one t.waiters `Take with
+      | `Ok -> ()       (* We transferred [locked t * R] to a waiter; [t] remains [Locked]. *)
+      | `Queue_empty -> t.state <- Unlocked     (* The state now owns R. *)
     end;
     Mutex.unlock t.mutex
   | Poisoned ex ->
     Mutex.unlock t.mutex;
     raise (Poisoned ex)
 
+(* {mutex t R} lock t {mutex t R * locked t * R} *)
 let lock t =
   Mutex.lock t.mutex;
   match t.state with
   | Locked ->
     Ctf.note_try_read t.id;
-    Waiters.await ~mutex:(Some t.mutex) t.waiters t.id
-    (* The unlocker didn't change the state, so it's still locked, as required. *)
+    begin match Waiters.await ~mutex:(Some t.mutex) t.waiters t.id with
+      | `Error ex -> raise ex   (* Poisoned; stop waiting *)
+      | `Take ->
+        (* The unlocker didn't change the state, so it's still Locked, as required.
+           {locked t * R} *)
+        ()
+    end
   | Unlocked -> 
     Ctf.note_read t.id;
-    t.state <- Locked;
+    t.state <- Locked;          (* We transfer R from the state to our caller. *)
+    (* {locked t * R} *)
     Mutex.unlock t.mutex
   | Poisoned ex ->
     Mutex.unlock t.mutex;
     raise (Poisoned ex)
 
+(* {mutex t R} v = try_lock t { mutex t R * if v then locked t * R else [] } *)
 let try_lock t =
   Mutex.lock t.mutex;
   match t.state with
@@ -63,23 +82,38 @@ let try_lock t =
     false
   | Unlocked -> 
     Ctf.note_read t.id;
-    t.state <- Locked;
+    t.state <- Locked;          (* We transfer R from the state to our caller. *)
     Mutex.unlock t.mutex;
+    (* {locked t * R} *)
     true
   | Poisoned ex ->
     Mutex.unlock t.mutex;
     raise (Poisoned ex)
 
+(* {mutex t R * locked t} poison t ex {mutex t R} *)
 let poison t ex =
   Mutex.lock t.mutex;
   t.state <- Poisoned ex;
+  Waiters.wake_all t.waiters (`Error (Poisoned ex));
   Mutex.unlock t.mutex
 
-let with_lock ?(on_exn=`Poison) t fn =
+(* {locked t * R} fn () {locked t * R} ->
+   {mutex t R} use_ro t fn {mutex t R} *)
+let use_ro t fn =
   lock t;
+  (* {mutex t R * locked t * R} *)
   match fn () with
   | x -> unlock t; x
+  | exception ex -> unlock t; raise ex
+
+(* {locked t * R} v = match fn () with _ -> true | exception _ -> false {locked t * if v then R else []} ->
+   {mutex t R} use_rw ~protect t fn {mutex t R} *)
+let use_rw ~protect t fn =
+  lock t;
+  (* {mutex t R * locked t * R} *)
+  match if protect then Cancel.protect fn else fn () with
+  | x -> unlock t; x
   | exception ex ->
-    match on_exn with
-    | `Unlock -> unlock t; raise ex
-    | `Poison -> poison t ex; raise ex
+    (* {mutex t R * locked t} *)
+    poison t ex;
+    raise ex

--- a/lib_eio/eio_mutex.ml
+++ b/lib_eio/eio_mutex.ml
@@ -1,12 +1,15 @@
 type state =
   | Unlocked                    (* can be locked *)
-  | Locked                      (* is locked, no threads waiting *)
-  | Waiting of unit Waiters.t   (* is locked, threads waiting *)
+  | Locked                      (* is locked; threads may be waiting *)
+  | Poisoned of exn             (* disabled due to exception in critical section *)
+
+exception Poisoned of exn
 
 type t = {
   id : Ctf.id;
   mutex : Mutex.t;
   mutable state : state;
+  waiters : unit Waiters.t;
 }
 
 let create () =
@@ -16,17 +19,8 @@ let create () =
     id;
     mutex = Mutex.create ();
     state = Unlocked;
+    waiters = Waiters.create ();
   }
-
-let is_locked t =
-  Mutex.lock t.mutex;
-  let s = t.state in
-  Mutex.unlock t.mutex;
-  match s with
-  | Unlocked -> false
-  | Locked | Waiting _ -> true
-
-exception Already_unlocked
 
 let unlock t =
   Mutex.lock t.mutex;
@@ -34,32 +28,58 @@ let unlock t =
   match t.state with
   | Unlocked -> 
     Mutex.unlock t.mutex;
-    raise Already_unlocked
+    raise (Sys_error "Eio.Mutex.unlock: already unlocked!")
   | Locked ->
-    t.state <- Unlocked;
-    Mutex.unlock t.mutex
-  | Waiting q ->
-    begin match Waiters.wake_one q () with
+    begin match Waiters.wake_one t.waiters () with
       | `Ok -> ()
       | `Queue_empty -> t.state <- Unlocked
     end;
     Mutex.unlock t.mutex
+  | Poisoned ex ->
+    Mutex.unlock t.mutex;
+    raise (Poisoned ex)
 
-let rec lock t =
+let lock t =
   Mutex.lock t.mutex;
   match t.state with
-  | Waiting q ->
-    Ctf.note_try_read t.id;
-    Waiters.await ~mutex:(Some t.mutex) q t.id
   | Locked ->
-    t.state <- Waiting (Waiters.create ());
-    Mutex.unlock t.mutex;
-    lock t
+    Ctf.note_try_read t.id;
+    Waiters.await ~mutex:(Some t.mutex) t.waiters t.id
+    (* The unlocker didn't change the state, so it's still locked, as required. *)
   | Unlocked -> 
     Ctf.note_read t.id;
     t.state <- Locked;
     Mutex.unlock t.mutex
+  | Poisoned ex ->
+    Mutex.unlock t.mutex;
+    raise (Poisoned ex)
 
-let with_lock t fn =
+let try_lock t =
+  Mutex.lock t.mutex;
+  match t.state with
+  | Locked ->
+    Ctf.note_try_read t.id;
+    Mutex.unlock t.mutex;
+    false
+  | Unlocked -> 
+    Ctf.note_read t.id;
+    t.state <- Locked;
+    Mutex.unlock t.mutex;
+    true
+  | Poisoned ex ->
+    Mutex.unlock t.mutex;
+    raise (Poisoned ex)
+
+let poison t ex =
+  Mutex.lock t.mutex;
+  t.state <- Poisoned ex;
+  Mutex.unlock t.mutex
+
+let with_lock ?(on_exn=`Poison) t fn =
   lock t;
-  Fun.protect ~finally:(fun () -> unlock t) fn
+  match fn () with
+  | x -> unlock t; x
+  | exception ex ->
+    match on_exn with
+    | `Unlock -> unlock t; raise ex
+    | `Poison -> poison t ex; raise ex

--- a/lib_eio/eio_mutex.ml
+++ b/lib_eio/eio_mutex.ml
@@ -1,0 +1,65 @@
+type state =
+  | Unlocked                    (* can be locked *)
+  | Locked                      (* is locked, no threads waiting *)
+  | Waiting of unit Waiters.t   (* is locked, threads waiting *)
+
+type t = {
+  id : Ctf.id;
+  mutex : Mutex.t;
+  mutable state : state;
+}
+
+let create () =
+  let id = Ctf.mint_id () in
+  Ctf.note_created id Ctf.Mutex;
+  {
+    id;
+    mutex = Mutex.create ();
+    state = Unlocked;
+  }
+
+let is_locked t =
+  Mutex.lock t.mutex;
+  let s = t.state in
+  Mutex.unlock t.mutex;
+  match s with
+  | Unlocked -> false
+  | Locked | Waiting _ -> true
+
+exception Already_unlocked
+
+let unlock t =
+  Mutex.lock t.mutex;
+  Ctf.note_signal t.id;
+  match t.state with
+  | Unlocked -> 
+    Mutex.unlock t.mutex;
+    raise Already_unlocked
+  | Locked ->
+    t.state <- Unlocked;
+    Mutex.unlock t.mutex
+  | Waiting q ->
+    begin match Waiters.wake_one q () with
+      | `Ok -> ()
+      | `Queue_empty -> t.state <- Unlocked
+    end;
+    Mutex.unlock t.mutex
+
+let rec lock t =
+  Mutex.lock t.mutex;
+  match t.state with
+  | Waiting q ->
+    Ctf.note_try_read t.id;
+    Waiters.await ~mutex:(Some t.mutex) q t.id
+  | Locked ->
+    t.state <- Waiting (Waiters.create ());
+    Mutex.unlock t.mutex;
+    lock t
+  | Unlocked -> 
+    Ctf.note_read t.id;
+    t.state <- Locked;
+    Mutex.unlock t.mutex
+
+let with_lock t fn =
+  lock t;
+  Fun.protect ~finally:(fun () -> unlock t) fn

--- a/tests/test_mutex.md
+++ b/tests/test_mutex.md
@@ -86,5 +86,77 @@ Double unlock raises an exception
   M.lock t;
   M.unlock t;
   M.unlock t;;
-Exception: Eio__Eio_mutex.Already_unlocked.
+Exception: Sys_error "Eio.Mutex.unlock: already unlocked!".
+```
+
+## With_lock
+
+```ocaml
+# run @@ fun () ->
+  let t = M.create () in
+  let fn () =
+    traceln "Entered critical section";
+    Fiber.yield ();
+    traceln "Leaving critical section"
+  in
+  Fiber.both
+    (fun () -> M.with_lock t ~on_exn:`Poison fn)
+    (fun () -> M.with_lock t ~on_exn:`Poison fn);;
++Entered critical section
++Leaving critical section
++Entered critical section
++Leaving critical section
+- : unit = ()
+```
+
+A failed critical section can poison the mutex:
+
+```ocaml
+# run @@ fun () ->
+  let t = M.create () in
+  try
+    M.with_lock t (fun () -> failwith "Simulated error");
+  with Failure _ ->
+    traceln "Trying to use the failed lock again fails:";
+    M.lock t;;
++Trying to use the failed lock again fails:
+Exception: Eio__Eio_mutex.Poisoned (Failure "Simulated error").
+```
+
+Alternatively, you can just unlock on error:
+
+```ocaml
+# run @@ fun () ->
+  let t = M.create () in
+  try
+    M.with_lock t ~on_exn:`Unlock (fun () -> failwith "Simulated error");
+  with Failure _ ->
+    traceln "Trying to use the lock again is OK:";
+    M.lock t;;
++Trying to use the lock again is OK:
+- : unit = ()
+```
+
+## Try_lock
+
+```ocaml
+# run @@ fun () ->
+  let t = M.create () in
+  let fn () =
+    match M.try_lock t with
+    | true ->
+      traceln "Entered critical section";
+      Fiber.yield ();
+      traceln "Leaving critical section";
+      M.unlock t
+    | false ->
+      traceln "Failed to get lock"
+  in
+  Fiber.both fn fn;
+  M.with_lock t (fun () -> traceln "Lock still works");;
++Entered critical section
++Failed to get lock
++Leaving critical section
++Lock still works
+- : unit = ()
 ```

--- a/tests/test_mutex.md
+++ b/tests/test_mutex.md
@@ -1,0 +1,90 @@
+# Setting up the environment
+
+```ocaml
+# #require "eio_main";;
+```
+
+```ocaml
+open Eio.Std
+
+module M = Eio.Mutex
+
+let run fn =
+  Eio_main.run @@ fun _ ->
+  fn ()
+
+let lock t =
+  traceln "Locking";
+  M.lock t;
+  traceln "Locked"
+
+let unlock t =
+  traceln "Unlocking";
+  M.unlock t;
+  traceln "Unlocked"
+```
+
+# Test cases
+
+Simple case
+
+```ocaml
+# run @@ fun () ->
+  let t = M.create () in
+  lock t;
+  unlock t;
+  lock t;
+  unlock t;;
++Locking
++Locked
++Unlocking
++Unlocked
++Locking
++Locked
++Unlocking
++Unlocked
+- : unit = ()
+```
+
+Concurrent access to the mutex
+
+
+```ocaml
+# run @@ fun () ->
+  let t = M.create () in
+  let fn () = 
+    lock t;
+    Eio.Fiber.yield ();
+    unlock t
+  in
+  List.init 4 (fun _ -> fn)
+  |> Fiber.all;;
++Locking
++Locked
++Locking
++Locking
++Locking
++Unlocking
++Unlocked
++Locked
++Unlocking
++Unlocked
++Locked
++Unlocking
++Unlocked
++Locked
++Unlocking
++Unlocked
+- : unit = ()
+```
+
+Double unlock raises an exception
+
+```ocaml
+# run @@ fun () ->
+  let t = M.create () in
+  M.lock t;
+  M.unlock t;
+  M.unlock t;;
+Exception: Eio__Eio_mutex.Already_unlocked.
+```


### PR DESCRIPTION
This extracts the Mutex module from #210, to simplify review.

@TheLortex : I made some changes - do these look reasonable to you?

- Add benchmarks for the mutex.
- Make `waiters` be a field. This simplifies the code by removing one state, and doesn't seem to affect performance.
- Make the API and documentation closer to Stdlib.Mutex.
- Replace `is_locked` with `try_lock`, since the result of `is_locked` isn't generally useful as it might already have changed.
- Add poisoning to `with_lock`.