### PR TITLE
Update to 5.0.0~alpha0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+_build
+.git
+**/*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ocaml/opam:debian-11-ocaml-5.0
+# Make sure we're using opam-2.1:
+RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
+# Add the alpha repository with some required preview versions of dependencies:
+RUN opam remote add alpha git+https://github.com/kit-ty-kate/opam-alpha-repository.git
+# Install utop for interactive use:
+RUN opam install utop
+# Install Eio's dependencies (adding just the opam files first to help with caching):
+RUN mkdir eio
+WORKDIR eio
+COPY *.opam ./
+RUN opam install --deps-only -t .
+# Build and test Eio:
+COPY . ./
+RUN opam install -t .

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,6 @@ bench:
 test_luv:
 	rm -rf _build
 	EIO_BACKEND=luv dune runtest
+
+docker:
+	docker build -t eio .

--- a/README.md
+++ b/README.md
@@ -1257,4 +1257,4 @@ Some background about the effects system can be found in:
 [Eio_main]: https://ocaml-multicore.github.io/eio/eio_main/Eio_main/index.html
 [Eio.traceln]: https://ocaml-multicore.github.io/eio/eio/Eio/index.html#val-traceln
 [Eio_main.run]: https://ocaml-multicore.github.io/eio/eio_main/Eio_main/index.html#val-run
-[Eio_mock]: https://github.com/ocaml-multicore/eio/blob/main/lib_eio/mock/eio_mock.mli
+[Eio_mock]: https://ocaml-multicore.github.io/eio/eio/Eio_mock/index.html

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Eio replaces existing concurrency libraries such as Lwt
 * [Motivation](#motivation)
 * [Current Status](#current-status)
 * [Structure of the Code](#structure-of-the-code)
-* [Getting Started](#getting-started)
+* [Getting OCaml 5.0](#getting-ocaml-50)
+* [Getting Eio](#getting-eio)
+* [Running Eio](#running-eio)
 * [Testing with Mocks](#testing-with-mocks)
 * [Fibers](#fibers)
 * [Tracing](#tracing)
@@ -66,8 +68,6 @@ and we hope that Eio will be that API.
 
 ## Current Status
 
-Eio can be used with OCaml 5.0.0+trunk or with 4.12.0+domains.
-
 Eio is able to run a web-server with [good performance][http-bench],
 but you are likely to encounter missing features while using it.
 If you'd like to help out, please try porting your program to use Eio and submit PRs or open issues when you find problems.
@@ -99,22 +99,22 @@ See [Awesome Multicore OCaml][] for links to work migrating other projects to Ei
   plus a low-level API that can be used directly (in non-portable code).
 - [Eio_main][] selects an appropriate backend (e.g. `eio_linux` or `eio_luv`), depending on your platform.
 
-## Getting Started
+## Getting OCaml 5.0
 
-You'll need a version of the OCaml compiler with effects.
-`5.0.0+trunk` often works but is a moving target, so we suggest using `4.12.0+domains` for now
-(however, this only supports x86_64 systems).
-You can get it like this:
+You'll need OCaml 5.0.0~alpha0 or later.
+You can either install it yourself or build the included [Dockerfile](./Dockerfile).
 
-```
-opam switch create 4.12.0+domains --repositories=multicore=git+https://github.com/ocaml-multicore/multicore-opam.git,default
-```
+To install it yourself:
 
-To use 5.0.0~alpha0 (which is needed on ARM), use this command instead:
+1. Make sure you have opam 2.1 or later (run `opam --version` to check).
 
-```
-opam switch create 5.0.0~alpha0 --repo=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
-```
+2. Use opam to install OCaml 5.0.0~alpha0 or later:
+
+   ```
+   opam switch create 5.0.0~alpha0 --repo=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
+   ```
+
+## Getting Eio
 
 If you want to run the latest development version from Git, run these commands
 (otherwise, skip them and you'll get the latest release from opam):
@@ -125,13 +125,13 @@ cd eio
 opam pin -yn .
 ```
 
-Finally, install this library (and `utop` if you want to try it interactively):
+Either way, install `eio_main` (and `utop` if you want to try it interactively):
 
 ```
-opam depext -i eio_main utop		# (for opam 2.0)
-opam install eio_main utop		# (for opam 2.1)
+opam install eio_main utop
 ```
-(Run `opam --version` if you're not sure which one you have installed.)
+
+## Running Eio
 
 Try out the examples interactively by running `utop` in the shell.
 

--- a/doc/prelude.ml
+++ b/doc/prelude.ml
@@ -24,16 +24,13 @@ module Eio_main = struct
     method run_raw fn = fn ()
   end
 
-  (* https://github.com/ocaml/ocaml/issues/10324 *)
-  let dontcrash = Sys.opaque_identity
-
   let run fn =
     Eio_main.run @@ fun env ->
     fn @@ object
-      method net        = dontcrash env#net
-      method stdin      = dontcrash env#stdin
-      method stdout     = dontcrash env#stdout
-      method cwd        = dontcrash env#cwd
+      method net        = env#net
+      method stdin      = env#stdin
+      method stdout     = env#stdout
+      method cwd        = env#cwd
       method domain_mgr = fake_domain_mgr
       method clock      = fake_clock env#clock
     end

--- a/dune-project
+++ b/dune-project
@@ -12,8 +12,7 @@
  (synopsis "Effect-based direct-style IO API for OCaml")
  (description "An effect-based IO API for multicore OCaml with fibers.")
  (depends
-  (ocaml (>= 4.12.0))
-  base-domains
+  (ocaml (>= 5.0.0~alpha0))
   (bigstringaf (>= 0.9.0))
   (cstruct (>= 6.0.1))
   lwt-dllist
@@ -30,7 +29,6 @@
  (description "An eio implementation for Linux using io-uring.")
  (depends
   (alcotest (and (>= 1.4.0) :with-test))
-  base-domains
   (eio (= :version))
   (mdx (and (>= 1.10.0) :with-test))
   (logs (>= 0.7.0))
@@ -42,7 +40,6 @@
  (synopsis "Eio implementation using luv (libuv)")
  (description "An eio implementation for most platforms, using luv.")
  (depends
-  base-domains
   (eio (= :version))
   (luv (>= 0.5.11))
   (luv_unix (>= 0.5.0))

--- a/eio.opam
+++ b/eio.opam
@@ -10,8 +10,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.12.0"}
-  "base-domains"
+  "ocaml" {>= "5.0.0~alpha0"}
   "bigstringaf" {>= "0.9.0"}
   "cstruct" {>= "6.0.1"}
   "lwt-dllist"

--- a/eio.opam
+++ b/eio.opam
@@ -40,3 +40,6 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+pin-depends: [
+  ["odoc-parser.1.0.0.1~alpha-repo" "git+https://github.com/ocaml-doc/odoc-parser.git#d573aadbdefcfc1830676ed3ccd91c84774331c4"]
+]

--- a/eio.opam.template
+++ b/eio.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  ["odoc-parser.1.0.0.1~alpha-repo" "git+https://github.com/ocaml-doc/odoc-parser.git#d573aadbdefcfc1830676ed3ccd91c84774331c4"]
+]

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -11,7 +11,6 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
   "alcotest" {>= "1.4.0" & with-test}
-  "base-domains"
   "eio" {= version}
   "mdx" {>= "1.10.0" & with-test}
   "logs" {>= "0.7.0"}

--- a/eio_luv.opam
+++ b/eio_luv.opam
@@ -10,7 +10,6 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "base-domains"
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}

--- a/lib_eio/core/dune
+++ b/lib_eio/core/dune
@@ -2,15 +2,3 @@
   (name eio__core)
   (public_name eio.core)
   (libraries cstruct lwt-dllist fmt))
-
-(rule
-  (target effect.ml)
-  (enabled_if (>= %{ocaml_version} "5.0"))
-  (action
-    (copy effect.new.ml effect.ml)))
-
-(rule
-  (target effect.ml)
-  (enabled_if (< %{ocaml_version} "5.0"))
-  (action
-    (copy effect.compat.ml effect.ml)))

--- a/lib_eio/core/effect.compat.ml
+++ b/lib_eio/core/effect.compat.ml
@@ -1,2 +1,0 @@
-include Stdlib.EffectHandlers
-type 'a t = 'a eff = ..

--- a/lib_eio/core/effect.new.ml
+++ b/lib_eio/core/effect.new.ml
@@ -1,1 +1,0 @@
-include Stdlib.Effect

--- a/lib_eio/core/eio__core.ml
+++ b/lib_eio/core/eio__core.ml
@@ -18,8 +18,6 @@ module Private = struct
       | Trace : (?__POS__:(string * int * int * int) -> ('a, Format.formatter, unit, unit) format4 -> 'a) Effect.t
   end
 
-  module Effect = Effect
-
   let traceln_mutex = Mutex.create ()
 
   let default_traceln ?__POS__:pos fmt =

--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -455,9 +455,6 @@ module Private : sig
     (** [get_error t] is [Cancel.get_error (cancellation_context t)] *)
   end
 
-  (** Temporary hack for compatibility with ocaml.4.12+domains *)
-  module Effect = Effect
-
   module Effects : sig
     type 'a enqueue = ('a, exn) result -> unit
     (** A function provided by the scheduler to reschedule a previously-suspended thread. *)

--- a/lib_eio/mock/backend.ml
+++ b/lib_eio/mock/backend.ml
@@ -1,5 +1,4 @@
 module Fiber_context = Eio.Private.Fiber_context
-module Effect = Eio.Private.Effect    (* For compatibility with 4.12+domains *)
 module Lf_queue = Eio_utils.Lf_queue
 
 exception Deadlock_detected

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -1,5 +1,3 @@
-module Effect = Eio.Private.Effect
-
 module Private = struct
   type _ Eio.Generic.ty += Unix_file_descr : [`Peek | `Take] -> Unix.file_descr Eio.Generic.ty
 

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -48,8 +48,6 @@ val run_in_systhread : (unit -> 'a) -> 'a
 
 (** API for Eio backends only. *)
 module Private : sig
-  open Eio.Private
-
   type _ Eio.Generic.ty += Unix_file_descr : [`Peek | `Take] -> Unix.file_descr Eio.Generic.ty
   (** See {!FD}. *)
 

--- a/lib_eio/utils/suspended.ml
+++ b/lib_eio/utils/suspended.ml
@@ -1,6 +1,6 @@
 (** A suspended fiber with its context. *)
 
-open Eio.Private.Effect.Deep
+open Effect.Deep
 module Ctf = Eio.Private.Ctf
 
 type 'a t = {

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -18,7 +18,6 @@ let src = Logs.Src.create "eio_linux" ~doc:"Effect-based IO system for Linux/io-
 module Log = (val Logs.src_log src : Logs.LOG)
 
 open Eio.Std
-module Effect = Eio.Private.Effect
 
 module Fiber_context = Eio.Private.Fiber_context
 module Ctf = Eio.Private.Ctf

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -18,7 +18,6 @@ let src = Logs.Src.create "eio_luv" ~doc:"Eio backend using luv"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 open Eio.Std
-module Effect = Eio.Private.Effect
 
 module Ctf = Eio.Private.Ctf
 


### PR DESCRIPTION
Drop compatibility with 4.12+domains.

Before merging, this needs:

- https://github.com/ocurrent/ocaml-ci/pull/473
- merlin and utop working on 5.0.

Work-arounds for testing:
```
opam pin add lwt https://github.com/dra27/lwt.git#check-symbols-caml_unix
opam pin utop https://github.com/dra27/utop.git#lib-layout
```