### PR TITLE
Add Buf_read.{of_buffer, of_string, parse_string{,_exn}, return}

### DIFF
--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -564,3 +564,33 @@ Error (`Msg "Unexpected end-of-file at offset 1")
 +Failure: Unexpected end-of-file at offset 1
 - : unit = ()
 ```
+
+## Parsing strings
+
+There are some convenience functions for parsing strings:
+
+```ocaml
+# let r = R.of_string "hello\nworld\n";;
+val r : R.t = <abstr>
+# R.line r;;
+- : string = "hello"
+# R.line r;;
+- : string = "world"
+# R.line r;;
+Exception: End_of_file.
+```
+
+```ocaml
+# R.parse_string R.line "foo\n";;
+- : (string, [> `Msg of string ]) result = Ok "foo"
+
+# R.parse_string R.line "foo\nbar\n";;
+- : (string, [> `Msg of string ]) result =
+Error (`Msg "Unexpected data after parsing (at offset 4)")
+
+# R.parse_string_exn R.line "foo\n";;
+- : string = "foo"
+
+# R.parse_string_exn R.line "foo\nbar\n";;
+Exception: Failure "Unexpected data after parsing (at offset 4)".
+```


### PR DESCRIPTION
`Buf_read.of_buffer` is slightly more efficient than reading from a flow (in the case where you have all the data at the start), as it avoids allocating a fresh buffer and copying the data.

The others are simple convenience functions.