### PR TITLE
Add Buf_read benchmark and optimise a bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all:
 	dune build @runtest @all
 
 bench:
+	dune exec -- ./bench/bench_buf_read.exe
 	dune exec -- ./bench/bench_mutex.exe
 	dune exec -- ./bench/bench_yield.exe
 	dune exec -- ./bench/bench_promise.exe

--- a/bench/bench_buf_read.ml
+++ b/bench/bench_buf_read.ml
@@ -1,0 +1,16 @@
+module R = Eio.Buf_read
+
+let test_data = String.init 100_000_000 (fun _ -> 'x')
+
+let () =
+  let r = R.of_string test_data in
+  let t0 = Unix.gettimeofday () in
+  let i = ref 0 in
+  try
+    while true do
+      assert (R.any_char r = 'x');
+      incr i
+    done
+  with End_of_file ->
+    let t1 = Unix.gettimeofday () in
+    Eio.traceln "Read %d bytes in %.3fs" !i (t1 -. t0)

--- a/bench/dune
+++ b/bench/dune
@@ -1,3 +1,4 @@
 (executables
-  (names bench_stream bench_promise bench_semaphore bench_yield bench_cancel bench_mutex)
+  (names bench_stream bench_promise bench_semaphore bench_yield bench_cancel bench_mutex
+         bench_buf_read)
   (libraries eio_main))


### PR DESCRIPTION
The first commit adds a trivial benchmark that parses individual characters in a tight loop, which should be about the worst case for parsing overhead.

The second splits out the slow path of `Buf_read.ensure`, so that the fast path can be inlined. This helps the benchmark a bit, on my machine at least:

    +Read 100000000 bytes in 0.558s     Before
    +Read 100000000 bytes in 0.402s     After

Note that calling `ensure` with a negative number is no longer considered an error.

I could further reduce it to 0.258s by:

- Removing the check that `consume`'s arguments are in range when called internally.
- Using `unsafe_get` to read the buffer.

However, it's less obvious that these changes are safe, and in real-world parsers this overhead is likely insignificant.