### PR TITLE
Minor updates for 5.0.0~alpha0

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ You can get it like this:
 opam switch create 4.12.0+domains --repositories=multicore=git+https://github.com/ocaml-multicore/multicore-opam.git,default
 ```
 
-To use 5.0.0+trunk (which is needed on ARM), use this command instead:
+To use 5.0.0~alpha0 (which is needed on ARM), use this command instead:
 
 ```
-opam switch create 5.0.0+trunk --repo=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
+opam switch create 5.0.0~alpha0 --repo=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
 ```
 
 If you want to run the latest development version from Git, run these commands

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -1272,7 +1272,7 @@ module Dir : sig
 
   (** {1 Directories} *)
 
-  val mkdir : #t -> perm:Unix.file_perm -> path -> unit
+  val mkdir : #t -> perm:Unix_perm.t -> path -> unit
   (** [mkdir t ~perm path] creates a new directory [t/path] with permissions [perm]. *)
 
   val open_dir : sw:Switch.t -> #t -> path -> <t; Flow.close>


### PR DESCRIPTION
Once merlin, etc, is working with 5.0 we'll drop support for 4.12+domains, but for now this just avoids a compiler warning and changes the instructions for installing 5.0 to say to use the alpha.