### PR TITLE
Eio_mock.Backend: detect deadlock

### DIFF
--- a/lib_eio/mock/backend.ml
+++ b/lib_eio/mock/backend.ml
@@ -2,6 +2,8 @@ module Fiber_context = Eio.Private.Fiber_context
 module Effect = Eio.Private.Effect    (* For compatibility with 4.12+domains *)
 module Lf_queue = Eio_utils.Lf_queue
 
+exception Deadlock_detected
+
 (* The scheduler could just return [unit], but this is clearer. *)
 type exit = Exit_scheduler
 
@@ -57,4 +59,6 @@ let run main =
   let new_fiber = Fiber_context.make_root () in
   let result = ref None in
   let Exit_scheduler = fork ~new_fiber (fun () -> result := Some (main ())) in
-  Option.get !result
+  match !result with
+  | None -> raise Deadlock_detected
+  | Some x -> x

--- a/lib_eio/mock/backend.mli
+++ b/lib_eio/mock/backend.mli
@@ -1,4 +1,12 @@
-(** A dummy Eio backend with no actual IO. *)
+(** A dummy Eio backend with no actual IO.
+
+    This backend does not support the use of multiple domains or systhreads,
+    but the tradeoff is that it can reliably detect deadlock, because if the
+    run queue is empty then it knows that no wake up event can be coming from
+    elsewhere. *)
+
+exception Deadlock_detected
 
 val run : (unit -> 'a) -> 'a
-(** [run fn] runs an event loop and then calls [fn env] within it. *)
+(** [run fn] runs an event loop and then calls [fn env] within it.
+    @raise Deadlock_detected if the run queue becomes empty but [fn] hasn't returned. *)

--- a/tests/mocks.md
+++ b/tests/mocks.md
@@ -99,3 +99,11 @@ The server handles a connection:
 - : unit = ()
 ```
 
+Because it doesn't support multiple threads or domains, it can detect deadlocks:
+
+```ocaml
+# Eio_mock.Backend.run @@ fun () ->
+  let p, _r = Promise.create () in
+  Promise.await p;;
+Exception: Eio_mock__Backend.Deadlock_detected.
+```


### PR DESCRIPTION
Deadlock detection doesn't work for most backends because they are always waiting for a signal from another domain, but the mock backend only supports a single domain anyway and it's useful to detect deadlocks in tests.