### PR TITLE
Allow short writes in Read_source_buffer

### DIFF
--- a/lib_eio/flow.ml
+++ b/lib_eio/flow.ml
@@ -1,7 +1,7 @@
 type shutdown_command = [ `Receive | `Send | `All ]
 
 type read_method = ..
-type read_method += Read_source_buffer of ((Cstruct.t list -> unit) -> unit)
+type read_method += Read_source_buffer of ((Cstruct.t list -> int) -> unit)
 
 class type close = object
   method close : unit
@@ -39,7 +39,9 @@ let cstruct_source data : source =
         match data with
         | [] -> raise End_of_file
         | x :: xs when Cstruct.length x = 0 -> data <- xs; aux ()
-        | xs -> data <- []; fn xs
+        | xs ->
+          let n = fn xs in
+          data <- Cstruct.shiftv xs n 
       in
       aux ()
 

--- a/lib_eio/flow.mli
+++ b/lib_eio/flow.mli
@@ -47,9 +47,9 @@ val string_source : string -> source
 val cstruct_source : Cstruct.t list -> source
 (** [cstruct_source cs] is a source that gives the bytes of [cs]. *)
 
-type read_method += Read_source_buffer of ((Cstruct.t list -> unit) -> unit)
+type read_method += Read_source_buffer of ((Cstruct.t list -> int) -> unit)
 (** If a source offers [Read_source_buffer rsb] then the user can call [rsb fn]
-    to borrow a view of the source's buffers.
+    to borrow a view of the source's buffers. [fn] returns the number of bytes it consumed.
 
     [rsb] will raise [End_of_file] if no more data will be produced.
     If no data is currently available, [rsb] will wait for some to become available before calling [fn].

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -186,6 +186,10 @@ module Low_level : sig
       If multiple buffers are given, they are sent in order.
       It will make multiple OS calls if the OS doesn't write all of it at once. *)
 
+  val writev_single : ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> int
+  (** [writev_single] is like [writev] but only performs a single write operation.
+      It returns the number of bytes written, which may be smaller than the requested amount. *)
+
   val splice : FD.t -> dst:FD.t -> len:int -> int
   (** [splice src ~dst ~len] attempts to copy up to [len] bytes of data from [src] to [dst].
 

--- a/tests/test_flow.md
+++ b/tests/test_flow.md
@@ -89,7 +89,7 @@ Copying from src using `Read_source_buffer`:
   Eio_mock.Flow.set_copy_method dst `Read_source_buffer;
   Eio_mock.Flow.on_copy_bytes dst [`Return 3; `Return 5];
   Eio.Flow.copy src dst;;
-+dst: wrote (rsb) "foo"
-+dst: wrote (rsb) "bar"
++dst: wrote (rsb) ["foo"]
++dst: wrote (rsb) ["bar"]
 - : unit = ()
 ```


### PR DESCRIPTION
When performing buffered writes and the OS doesn't write all the data in one go, it probably means it isn't ready for more. We can let the application produce more data while we're waiting and then do the next
write with more buffers, instead of trying to finish the original shorter write first.

This changes `Read_source_buffer` to allow returning the number of bytes written. It also updates the mock output to show the individual buffers being written rather than the combined string.

Also, add `Linux_eio.Low_level.writev_single` to expose this behaviour directly.