### PR TITLE
Do not allow close on accept_fork socket

### DIFF
--- a/lib_eio/mock/eio_mock.mli
+++ b/lib_eio/mock/eio_mock.mli
@@ -119,8 +119,8 @@ module Net : sig
   type t = <
     Eio.Net.t;
     on_listen : Eio.Net.listening_socket Handler.t;
-    on_connect : Eio.Net.stream_socket Handler.t;
-    on_datagram_socket : Eio.Net.datagram_socket Handler.t;
+    on_connect : <Eio.Net.stream_socket; Eio.Flow.close> Handler.t;
+    on_datagram_socket : <Eio.Net.datagram_socket; Eio.Flow.close> Handler.t;
   >
 
   type listening_socket = <
@@ -131,13 +131,13 @@ module Net : sig
   val make : string -> t
   (** [make label] is a new mock network. *)
 
-  val on_connect : t -> #Eio.Net.stream_socket Handler.actions -> unit
+  val on_connect : t -> <Eio.Net.stream_socket; Eio.Flow.close; ..> Handler.actions -> unit
   (** [on_connect t actions] configures what to do when a client tries to connect somewhere. *)
 
   val on_listen : t -> #Eio.Net.listening_socket Handler.actions -> unit
   (** [on_listen t actions] configures what to do when a server starts listening for incoming connections. *)
 
-  val on_datagram_socket : t -> #Eio.Net.datagram_socket Handler.actions -> unit
+  val on_datagram_socket : t -> <Eio.Net.datagram_socket; Eio.Flow.close; ..> Handler.actions -> unit
   (** [on_datagram_socket t actions] configures how to create datagram sockets. *)
 
   val listening_socket : string -> listening_socket

--- a/lib_eio/mock/net.ml
+++ b/lib_eio/mock/net.ml
@@ -3,8 +3,8 @@ open Eio.Std
 type t = <
   Eio.Net.t;
   on_listen : Eio.Net.listening_socket Handler.t;
-  on_connect : Eio.Net.stream_socket Handler.t;
-  on_datagram_socket : Eio.Net.datagram_socket Handler.t;
+  on_connect : <Eio.Net.stream_socket; Eio.Flow.close> Handler.t;
+  on_datagram_socket : <Eio.Net.datagram_socket; Eio.Flow.close> Handler.t;
 >
 
 let make label =
@@ -38,15 +38,15 @@ let make label =
   end
 
 let on_connect (t:t) actions =
-  let as_socket x = (x :> Eio.Net.stream_socket) in
+  let as_socket x = (x :> <Eio.Net.stream_socket; Eio.Flow.close>) in
   Handler.seq t#on_connect (List.map (Action.map as_socket) actions)
 
 let on_listen (t:t) actions =
-  let as_socket x = (x :> Eio.Net.listening_socket) in
+  let as_socket x = (x :> <Eio.Net.listening_socket; Eio.Flow.close>) in
   Handler.seq t#on_listen (List.map (Action.map as_socket) actions)
 
 let on_datagram_socket (t:t) actions =
-  let as_socket x = (x :> Eio.Net.datagram_socket) in
+  let as_socket x = (x :> <Eio.Net.datagram_socket; Eio.Flow.close>) in
   Handler.seq t#on_datagram_socket (List.map (Action.map as_socket) actions)
 
 type listening_socket = <
@@ -65,7 +65,7 @@ let listening_socket label =
       let socket, addr = Handler.run on_accept in
       Flow.attach_to_switch socket sw;
       traceln "%s: accepted connection from %a" label Eio.Net.Sockaddr.pp addr;
-      (socket :> Eio.Net.stream_socket), addr
+      (socket :> <Eio.Net.stream_socket; Eio.Flow.close>), addr
 
     method close =
       traceln "%s: closed" label


### PR DESCRIPTION
`accept_fork` closes the socket when the function returns. Prevent the function from trying to close the socket itself. This removes the `close` method from the socket type, which matches the situation with flows. Alternatively, we could just ignore multiple close attempts.

Fixes #244.