### PR TITLE
Remove odoc-parser pin

### DIFF
--- a/eio.opam
+++ b/eio.opam
@@ -40,6 +40,3 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
-pin-depends: [
-  ["odoc-parser.1.0.0.1~alpha-repo" "git+https://github.com/ocaml-doc/odoc-parser.git#d573aadbdefcfc1830676ed3ccd91c84774331c4"]
-]

--- a/eio.opam.template
+++ b/eio.opam.template
@@ -1,3 +1,0 @@
-pin-depends: [
-  ["odoc-parser.1.0.0.1~alpha-repo" "git+https://github.com/ocaml-doc/odoc-parser.git#d573aadbdefcfc1830676ed3ccd91c84774331c4"]
-]


### PR DESCRIPTION
odoc-parser 1.0.1 has now been released with OCaml 5.0 support.