### PR TITLE
Some fixes for cancellation

### DIFF
--- a/lib_eio/core/cancel.ml
+++ b/lib_eio/core/cancel.ml
@@ -137,7 +137,7 @@ let rec cancel_internal t ex acc_fns =
   | On ->
     let bt = Printexc.get_raw_backtrace () in
     t.state <- Cancelling (ex, bt);
-    let acc_fns = Lwt_dllist.fold_l collect_cancel_fn t.fibers acc_fns in
+    let acc_fns = Lwt_dllist.fold_r collect_cancel_fn t.fibers acc_fns in
     Lwt_dllist.fold_r (cancel_child ex) t.children acc_fns
 and cancel_child ex t acc =
   if t.protected then acc

--- a/tests/test_switch.md
+++ b/tests/test_switch.md
@@ -392,9 +392,9 @@ Exception:
 Multiple exceptions:
 Stdlib.Exit
 and
-Failure("cancel2 failed")
-and
 Failure("cancel1 failed")
+and
+Failure("cancel2 failed")
 ```
 
 # Errors during cleanup are reported during cancellation


### PR DESCRIPTION
- Run cancel functions in the order in which the fibers were added, for simplicity.

- `Cancel.cancel` collects the cancel functions for all the fibers at once, and then calls them in series. This means that a job may have completed and been freed by the time its cancel function is called. Just ignore the cancellation in that case.

- If an eio_linux job succeeds, report the success even if it was also cancelled. This allows e.g. closing an allocated FD.