### PR TITLE
Report use of closed FDs better

### DIFF
--- a/tests/test_fs.md
+++ b/tests/test_fs.md
@@ -309,3 +309,15 @@ In that case, `with_open_in` will no longer close it on exit:
 +Read 0 bytes from null device
 - : unit = ()
 ```
+
+# Use after close
+
+```ocaml
+# run @@ fun env ->
+  let closed = Switch.run (fun sw -> Eio.Dir.open_dir ~sw env#cwd ".") in
+  try
+    failwith (Eio.Dir.read_dir closed "." |> String.concat ",")
+  with Invalid_argument _ -> traceln "Got Invalid_argument for closed FD";;
++Got Invalid_argument for closed FD
+- : unit = ()
+```


### PR DESCRIPTION
Previously, attempting to use a closed FD would raise an exception in the scheduler context, causing the whole event loop to exit. Now it's just reported back to the caller as an error. This means you get a stack trace, a chance to clean up or recover, and you get to see some output from MDX.