### PR TITLE
eio-linux: fix IPv6 support

### DIFF
--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1019,11 +1019,18 @@ let listening_socket fd = object
     flow, client_addr
 end
 
+let socket_domain_of = function
+  | `Unix _ -> Unix.PF_UNIX
+  | `Tcp (host, _) ->
+    Eio.Net.Ipaddr.fold host
+      ~v4:(fun _ -> Unix.PF_INET)
+      ~v6:(fun _ -> Unix.PF_INET6)
+
 let net = object
   inherit Eio.Net.t
 
   method listen ~reuse_addr ~reuse_port  ~backlog ~sw listen_addr =
-    let socket_domain, socket_type, addr =
+    let socket_type, addr =
       match listen_addr with
       | `Unix path         ->
         if reuse_addr then (
@@ -1032,12 +1039,12 @@ let net = object
           | _ -> ()
           | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
         );
-        Unix.PF_UNIX, Unix.SOCK_STREAM, Unix.ADDR_UNIX path
+        Unix.SOCK_STREAM, Unix.ADDR_UNIX path
       | `Tcp (host, port)  ->
         let host = Eio_unix.Ipaddr.to_unix host in
-        Unix.PF_INET, Unix.SOCK_STREAM, Unix.ADDR_INET (host, port)
+        Unix.SOCK_STREAM, Unix.ADDR_INET (host, port)
     in
-    let sock_unix = Unix.socket socket_domain socket_type 0 in
+    let sock_unix = Unix.socket (socket_domain_of listen_addr) socket_type 0 in
     (* For Unix domain sockets, remove the path when done (except for abstract sockets). *)
     begin match listen_addr with
       | `Unix path ->
@@ -1054,15 +1061,15 @@ let net = object
     Unix.listen sock_unix backlog;
     listening_socket sock
 
-  method connect ~sw addr =
-    let socket_domain, socket_type, addr =
-      match addr with
-      | `Unix path         -> Unix.PF_UNIX, Unix.SOCK_STREAM, Unix.ADDR_UNIX path
+  method connect ~sw connect_addr =
+    let socket_type, addr =
+      match connect_addr with
+      | `Unix path         -> Unix.SOCK_STREAM, Unix.ADDR_UNIX path
       | `Tcp (host, port)  ->
         let host = Eio_unix.Ipaddr.to_unix host in
-        Unix.PF_INET, Unix.SOCK_STREAM, Unix.ADDR_INET (host, port)
+        Unix.SOCK_STREAM, Unix.ADDR_INET (host, port)
     in
-    let sock_unix = Unix.socket socket_domain socket_type 0 in
+    let sock_unix = Unix.socket (socket_domain_of connect_addr) socket_type 0 in
     let sock = FD.of_unix ~sw ~seekable:false ~close_unix:true sock_unix in
     Low_level.connect sock addr;
     (flow sock :> <Eio.Flow.two_way; Eio.Flow.close>)

--- a/tests/network.md
+++ b/tests/network.md
@@ -14,6 +14,7 @@ let run (fn : net:Eio.Net.t -> Switch.t -> unit) =
   Switch.run (fn ~net)
 
 let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, 8081)
+let addr6 = `Tcp (Eio.Net.Ipaddr.V6.loopback, 8081)
 
 let read_all flow =
   let b = Buffer.create 100 in
@@ -95,6 +96,18 @@ Handling one connection on an abstract Unix domain socket (this only works on Li
 <!-- $MDX non-deterministic=command -->
 ```ocaml
 # run (test_address (`Unix "\x00/tmp/eio-test.sock"));;
++Connecting to server...
++Server accepted connection from client
++Server received: "Hello from client"
++Client received: "Bye"
++Client finished - cancelling server
+Exception: Graceful_shutdown.
+```
+
+Handling one connection using IPv6:
+
+```ocaml
+# run (test_address addr6);;
 +Connecting to server...
 +Server accepted connection from client
 +Server received: "Hello from client"


### PR DESCRIPTION
Use `PF_INET6` for IPv6 addresses, not `PF_INET`.

Reported by @haesbaert.