### PR TITLE
Disable tests in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 # Add the alpha repository with some required preview versions of dependencies:
 RUN opam remote add alpha git+https://github.com/kit-ty-kate/opam-alpha-repository.git
 # Install utop for interactive use:
-RUN opam install utop
+RUN opam install utop fmt
 # Install Eio's dependencies (adding just the opam files first to help with caching):
 RUN mkdir eio
 WORKDIR eio
 COPY *.opam ./
-RUN opam install --deps-only -t .
-# Build and test Eio:
+RUN opam install --deps-only .
+# Build Eio:
 COPY . ./
-RUN opam install -t .
+RUN opam install .


### PR DESCRIPTION
Can't run tests as `docker bulild` doesn't provide an IPv6 loopback address, so disable that for now.

Also, install `fmt` earlier to avoid recompiling stuff later.