### PR TITLE
Clarify OCaml version constraint

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -12,7 +12,7 @@
  (synopsis "Effect-based direct-style IO API for OCaml")
  (description "An effect-based IO API for multicore OCaml with fibers.")
  (depends
-  (ocaml (>= 5.0.0~alpha0))
+  (ocaml (>= 5.0.0))
   (bigstringaf (>= 0.9.0))
   (cstruct (>= 6.0.1))
   lwt-dllist

--- a/eio.opam
+++ b/eio.opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "5.0.0~alpha0"}
+  "ocaml" {>= "5.0.0"}
   "bigstringaf" {>= "0.9.0"}
   "cstruct" {>= "6.0.1"}
   "lwt-dllist"


### PR DESCRIPTION
`ocaml-base-compiler` is version `5.0.0~alpha1` but `ocaml` itself is just `5.0.0`.

(spotted by @kit-ty-kate in https://github.com/ocaml/opam-repository/pull/21935)