### PR TITLE
Allow sharing of libuv poll handles

### DIFF
--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -435,7 +435,7 @@ module Low_level = struct
 
     let await_readable t (k:unit Suspended.t) fd =
       match Fd_map.find_opt fd t.fd_map with
-      | Some ({ read; _ } as events) when not (Lwt_dllist.is_empty read) -> 
+      | Some ({ read; _ } as events) when not (Lwt_dllist.is_empty read) ->
         let node = Lwt_dllist.add_l k read in
         set_fiber_cancel ~t ~events ~node k fd
       | v ->
@@ -465,7 +465,7 @@ module Low_level = struct
       | Some ({ write; _ } as events) when not (Lwt_dllist.is_empty write) ->
         let node = Lwt_dllist.add_l k write in
         set_fiber_cancel ~t ~events ~node k fd
-      | v -> 
+      | v ->
         (* Either we haven't created a handle yet, or [write] is empty which either
            means all awaiting continuations have finished or we haven't yet started
            the [`WRITABLE] callback. This can happen if [await_readable] was called

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -90,6 +90,7 @@ module Low_level : sig
 
   module Handle : sig
     type 'a t
+      constraint 'a = [< `Poll | `Stream of [< `Pipe | `TCP | `TTY ] | `UDP ]
 
     val is_open : 'a t -> bool
     (** [is_open t] is [true] if {!close} hasn't been called yet. *)

--- a/lib_eio_luv/tests/poll.md
+++ b/lib_eio_luv/tests/poll.md
@@ -103,3 +103,13 @@ Cancelling a fiber removes a fiber but does not stop polling if others are still
 - : unit = ()
 ```
 
+Closing a file descriptor with an actively waiting poll fails the fiber that is waiting.
+
+```ocaml
+# with_sockets @@ fun ~sw ((src, src_fd), (_dst, _dst_fd)) ->
+  Eio.Fiber.both
+      (fun () -> Eio_unix.await_readable src_fd)
+      (fun () -> Eio.Flow.close src);;
+Exception: Failure "Closed file descriptor whilst polling".
+```
+

--- a/lib_eio_luv/tests/poll.md
+++ b/lib_eio_luv/tests/poll.md
@@ -56,15 +56,28 @@ Waiting for reading and writing on the same file descriptor.
   Eio.Fiber.both
     (fun () -> 
       Eio_unix.await_writable src_fd;
-      Eio_unix.await_readable src_fd; 
+      Eio_unix.await_readable src_fd;
       Eio.Flow.copy src (Flow.buffer_sink buffer))
     (fun () -> 
-      Eio_unix.await_writable dst_fd; 
+      Eio_unix.await_writable dst_fd;
       Eio.Flow.copy_string message dst;
       Eio.Flow.close dst
     );
   Buffer.contents buffer;;
 - : string = "hello"
+```
+
+Waiting for reading and writing on the same file descriptor, at the same time.
+
+```ocaml
+# with_sockets @@ fun ~sw ((src, src_fd), (dst, dst_fd)) ->
+  Eio.Fiber.both
+    (fun () -> 
+      Eio_unix.await_readable src_fd)
+    (fun () -> 
+      Eio_unix.await_writable src_fd;
+      Eio.Flow.close dst);;
+- : unit = ()
 ```
 
 Cancelling a fiber removes a fiber but does not stop polling if others are still waiting.

--- a/lib_eio_luv/tests/poll.md
+++ b/lib_eio_luv/tests/poll.md
@@ -1,0 +1,92 @@
+# Set up the test environment
+
+```ocaml
+# #require "eio_luv";;
+# open Eio.Std;;
+# open Eio;;
+```
+
+A helper function to create two sockets and pass their FDs to a function:
+
+```ocaml
+let with_sockets fn =
+  Eio_luv.run @@ fun _env ->
+  Switch.run @@ fun sw ->
+  let src, dst = Eio_unix.socketpair ~sw () in
+  let src_fd = Option.get @@ Eio_unix.FD.peek_opt src in
+  let dst_fd = Option.get @@ Eio_unix.FD.peek_opt dst in
+  fn ~sw ((src, src_fd), (dst, dst_fd))
+```
+
+Waiting for the same file descriptor to become writable does not raise `EEXIST`.
+
+```ocaml
+# with_sockets @@ fun ~sw ((src, src_fd), (dst, dst_fd)) ->
+  Eio.Fiber.both
+    (fun () -> Eio_unix.await_writable src_fd)
+    (fun () -> Eio_unix.await_writable src_fd);;
+- : unit = ()
+```
+
+An example of reading and writing with different file descriptors.
+
+```ocaml
+# with_sockets @@ fun ~sw ((src, src_fd), (dst, dst_fd)) ->
+  let message = "hello" in
+  let buffer = Buffer.create (String.length message) in
+  Eio.Fiber.both
+    (fun () -> 
+      Eio_unix.await_readable src_fd; 
+      Eio.Flow.copy src (Flow.buffer_sink buffer))
+    (fun () -> 
+      Eio_unix.await_writable dst_fd; 
+      Eio.Flow.copy_string message dst; 
+      Eio.Flow.close dst
+    );
+  Buffer.contents buffer;;
+- : string = "hello"
+```
+
+Waiting for reading and writing on the same file descriptor.
+
+```ocaml
+# with_sockets @@ fun ~sw ((src, src_fd), (dst, dst_fd)) ->
+  let message = "hello" in
+  let buffer = Buffer.create (String.length message) in
+  Eio.Fiber.both
+    (fun () -> 
+      Eio_unix.await_writable src_fd;
+      Eio_unix.await_readable src_fd; 
+      Eio.Flow.copy src (Flow.buffer_sink buffer))
+    (fun () -> 
+      Eio_unix.await_writable dst_fd; 
+      Eio.Flow.copy_string message dst;
+      Eio.Flow.close dst
+    );
+  Buffer.contents buffer;;
+- : string = "hello"
+```
+
+Cancelling a fiber removes a fiber but does not stop polling if others are still waiting.
+
+```ocaml
+# with_sockets @@ fun ~sw ((src, src_fd), (dst, _dst_fd)) ->
+  let buffer = Buffer.create 5 in
+  Fiber.fork ~sw (fun () -> 
+    Eio_unix.await_readable src_fd; 
+    Eio.Flow.copy src (Flow.buffer_sink buffer);
+    traceln "Still received: %s" (Buffer.contents buffer)
+  );
+  (try 
+    Eio.Fiber.both
+      (fun () -> Eio_unix.await_readable src_fd)
+      (fun () -> raise (Failure "Simulate a cancel"))
+  with
+    exn -> traceln "%s" (Printexc.to_string exn));
+  Flow.copy_string "Hello" dst;
+  Flow.close dst;;
++Failure("Simulate a cancel")
++Still received: Hello
+- : unit = ()
+```
+

--- a/lib_eio_luv/tests/poll.md
+++ b/lib_eio_luv/tests/poll.md
@@ -112,4 +112,3 @@ Closing a file descriptor with an actively waiting poll fails the fiber that is 
       (fun () -> Eio.Flow.close src);;
 Exception: Failure "Closed file descriptor whilst polling".
 ```
-


### PR DESCRIPTION
Multiple poll handles for the same file descriptor are not allowed by libuv as @talex5 noted in https://github.com/ocaml-multicore/lwt_eio/issues/11

> http://docs.libuv.org/en/v1.x/poll.html says:
>
>> It is not okay to have multiple active poll handles for the same socket, this can cause libuv to busyloop or otherwise ? malfunction.

This can happen seemingly quite easily, for example:

```ocaml
let () =
  Eio_luv.run @@ fun _env ->
  Eio.Switch.run @@ fun sw ->
  let src, _dst = Eio_unix.socketpair ~sw () in
  let fd = Option.get @@ Eio_unix.FD.peek_opt src in
  Eio.Fiber.both
    (fun () -> Eio_unix.await_writable fd)
    (fun () -> Eio_unix.await_writable fd)
(* Eio_luv.Luv_error(EEXIST) (* file already exists *) *)
```

This PR makes it so we keep track of the various fibers that are waiting on read and write events and we enqueue them accordingly based on the events that the polling callback receives. This means the same handle must register for both kinds of events and then we decided how to handle them rather than having a dedicated `READABLE` and a dedicated `WRITABLE` poll handle.

So far this PR fixes both the simple example and the origin Irmin example that caused me to find this ([code here](https://github.com/ocaml-multicore/lwt_eio/issues/11#issue-1337047305)), however I haven't tried:

 - [ ] Awaiting across multiple domains
 - [ ] I believe the logic for when to stop a handle is currently incorrect, a fiber could be cancelled but this doesn't remove it from the `Lf_queue` and I'm using the `Lf_queue` size to check whether there are any fibers waiting on the handle -- perhaps an integer that we decrement/increment would suffice here?