### PR TITLE
Mark getaddrinfo tests as non-deterministic

### DIFF
--- a/tests/network.md
+++ b/tests/network.md
@@ -488,6 +488,7 @@ EPIPE:
 
 ## Getaddrinfo
 
+<!-- $MDX non-deterministic=output -->
 ```ocaml
 # Eio_main.run @@ fun env ->
   Eio.Net.getaddrinfo env#net "127.0.0.1";;
@@ -495,6 +496,7 @@ EPIPE:
 [`Tcp ("\127\000\000\001", 0); `Udp ("\127\000\000\001", 0)]
 ```
 
+<!-- $MDX non-deterministic=output -->
 ```ocaml
 # Eio_main.run @@ fun env ->
   Eio.Net.getaddrinfo env#net "127.0.0.1" ~service:"80";;


### PR DESCRIPTION
On macOS Catalina these tests return the same list only with the `` `UDP`` entry _before_ thee `` `TCP`` entry, so either they should be marked as non-deterministic (as in this PR) or we need a stable way to sort the list before returning it.