### PR TITLE
Add Eio.Net.getaddrinfo_{stream,datagram}

### DIFF
--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -191,6 +191,20 @@ let datagram_socket ~sw (t:#t) = t#datagram_socket ~sw
 
 let getaddrinfo ?(service="") (t:#t) hostname = t#getaddrinfo ~service hostname
 
+let getaddrinfo_stream ?service t hostname =
+  getaddrinfo ?service t hostname
+  |> List.filter_map (function
+      | #Sockaddr.stream as x -> Some x
+      | _ -> None
+    )
+
+let getaddrinfo_datagram ?service t hostname =
+  getaddrinfo ?service t hostname
+  |> List.filter_map (function
+      | #Sockaddr.datagram as x -> Some x
+      | _ -> None
+    )
+
 let getnameinfo (t:#t) sockaddr = t#getnameinfo sockaddr
 
 let close = Flow.close

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -184,6 +184,12 @@ val getaddrinfo: ?service:string -> #t -> string -> Sockaddr.t list
 
     For a more thorough treatment, @see <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html> getaddrinfo *)
 
+val getaddrinfo_stream: ?service:string -> #t -> string -> Sockaddr.stream list
+(** [getaddrinfo_stream] is like {!getaddrinfo}, but filters out non-stream protocols. *)
+
+val getaddrinfo_datagram: ?service:string -> #t -> string -> Sockaddr.datagram list
+(** [getaddrinfo_datagram] is like {!getaddrinfo}, but filters out non-datagram protocols. *)
+
 val getnameinfo : #t -> Sockaddr.t -> (string * string)
 (** [getnameinfo t sockaddr] is [(hostname, service)] corresponding to [sockaddr]. [hostname] is the
     registered domain name represented by [sockaddr]. [service] is the IANA specified textual name of the

--- a/tests/network.md
+++ b/tests/network.md
@@ -490,16 +490,26 @@ EPIPE:
 
 ```ocaml
 # Eio_main.run @@ fun env ->
-  Eio.Net.getaddrinfo env#net "127.0.0.1";;
-- : Eio.Net.Sockaddr.t list =
-[`Tcp ("\127\000\000\001", 0); `Udp ("\127\000\000\001", 0)]
+  Eio.Net.getaddrinfo_stream env#net "127.0.0.1";;
+- : Eio.Net.Sockaddr.stream list = [`Tcp ("\127\000\000\001", 0)]
 ```
 
 ```ocaml
 # Eio_main.run @@ fun env ->
-  Eio.Net.getaddrinfo env#net "127.0.0.1" ~service:"80";;
-- : Eio.Net.Sockaddr.t list =
-[`Tcp ("\127\000\000\001", 80); `Udp ("\127\000\000\001", 80)]
+  Eio.Net.getaddrinfo_stream env#net "127.0.0.1" ~service:"80";;
+- : Eio.Net.Sockaddr.stream list = [`Tcp ("\127\000\000\001", 80)]
+```
+
+```ocaml
+# Eio_main.run @@ fun env ->
+  Eio.Net.getaddrinfo_datagram env#net "127.0.0.1";;
+- : Eio.Net.Sockaddr.datagram list = [`Udp ("\127\000\000\001", 0)]
+```
+
+```ocaml
+# Eio_main.run @@ fun env ->
+  Eio.Net.getaddrinfo_datagram env#net "127.0.0.1" ~service:"80";;
+- : Eio.Net.Sockaddr.datagram list = [`Udp ("\127\000\000\001", 80)]
 ```
 
 <!-- $MDX non-deterministic=output -->


### PR DESCRIPTION
These filter the results of `getaddrinfo` to ensure you get something of the correct type. This makes it possible to use the result directly with e.g. `connect`.

This is also used in the tests to avoid non-deterministic ordering of TCP vs UDP results, which fixes #285.

/cc @bikallem 