### PR TITLE
net: add Net.with_tcp_connect

### DIFF
--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -12,7 +12,6 @@
 *)
 
 exception Connection_reset of exn
-exception Unix_error of string * string * string
 exception Connection_failure of exn
 
 (** IP addresses. *)
@@ -117,31 +116,31 @@ val connect : sw:Switch.t -> #t -> Sockaddr.stream -> <stream_socket; Flow.close
 
     The new socket will be closed when [sw] finishes, unless closed manually first.
 
-    @raise Unix_error if connection couldn't be established. *)
-
-type 'a timeout = (#Time.clock as 'a) * float
+    @raise Connection_failure if connection couldn't be established. *)
 
 val with_tcp_connect :
-  ?timeout:'a timeout ->
+  ?timeout:Time.Timeout.t ->
   host:string ->
   service:string ->
   #t ->
   (<stream_socket; Flow.close> -> 'b) ->
   'b
 (** [with_tcp_connect ~host ~service t f] creates a tcp connection [conn] to [host] and [service] and executes 
-    [f conn]. IPv6 connection is preferred over IPv4 addresses if [host] provides them. If a connection
-    can't be established for any of the addresses defined for [host], then [Connection_failure] exception is raised.
+    [f conn].
 
-    [conn] is closed after [f] returns if it isn't already closed.
+    [conn] is closed after [f] returns (if it isn't already closed by then).
 
     [host] is either an IP address or a domain name, eg. "www.example.org", "www.ocaml.org" or "127.0.0.1".
 
     [service] is an IANA recognized service name or port number, eg. "http", "ftp", "8080" etc.
     See https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml.
 
-    [timeout] specifies the amount of seconds to wait for establishing the connection to host per host ip address.
+    Addresses are tried in the order they are returned by {!getaddrinfo}, until one succeeds.
 
-    @raise Connection_failure. *)
+    @param timeout Limits how long to wait for each connection attempt before moving on to the next.
+                   By default there is no timeout (beyond what the underlying network does).
+
+    @raise Connection_failure A connection couldn't be established for any of the addresses defined for [host]. *)
 
 (** {2 Incoming Connections} *)
 

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -747,7 +747,8 @@ module Low_level = struct
     let res = enter (enqueue_connect fd addr) in
     Log.debug (fun l -> l "connect returned");
     if res < 0 then (
-      raise (Unix.Unix_error (Uring.error_of_errno res, "connect", ""))
+      let err = Uring.error_of_errno res |> Unix.error_message in
+      raise (Eio.Net.Unix_error (err, "connect", ""))
     )
 
   let send_msg fd ?(fds=[]) ?dst buf =

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -747,8 +747,8 @@ module Low_level = struct
     let res = enter (enqueue_connect fd addr) in
     Log.debug (fun l -> l "connect returned");
     if res < 0 then (
-      let err = Uring.error_of_errno res |> Unix.error_message in
-      raise (Eio.Net.Unix_error (err, "connect", ""))
+      let ex = Unix.Unix_error (Uring.error_of_errno res, "connect", "") in
+      raise (Eio.Net.Connection_failure ex)
     )
 
   let send_msg fd ?(fds=[]) ?dst buf =

--- a/tests/network.md
+++ b/tests/network.md
@@ -546,3 +546,42 @@ EPIPE:
   Eio.Net.getnameinfo env#net sockaddr;;
 - : string * string = ("localhost", "http")
 ```
+
+## with_tcp_connet
+
+<!-- $MDX non-deterministic=command -->
+```ocaml
+# Eio_main.run @@ fun env ->
+  Eio.Net.with_tcp_connect ~host:"www.example.com" ~service:"http" env#net (fun conn ->
+    let req = "GET / HTTP/1.1\r\nHost:www.example.com:80\r\n\r\n" in
+    Eio.Flow.copy_string req conn;
+    let cs = Cstruct.create 25 in
+    Eio.Flow.read_exact conn cs;
+    Eio.Flow.close conn;
+    Eio.traceln "%S" (Cstruct.to_string cs));;
++"HTTP/1.1 200 OK\r\nAge: 372"
+- : unit = ()
+
+# Eio_main.run @@ fun env ->
+  Eio.Net.with_tcp_connect ~timeout:(env#clock, 0.1) ~host:"www.example.com" ~service:"http" env#net (fun conn ->
+    let req = "GET / HTTP/1.1\r\nHost:www.example.com:80\r\n\r\n" in
+    Eio.Flow.copy_string req conn;
+    let cs = Cstruct.create 25 in
+    Eio.Flow.read_exact conn cs;
+    Eio.Flow.close conn;
+    Eio.traceln "%S" (Cstruct.to_string cs));;
++"HTTP/1.1 200 OK\r\nAge: 296"
+- : unit = ()
+
+# Eio_main.run @@ fun env ->
+  Eio.Net.with_tcp_connect ~timeout:(env#clock, 0.01) ~host:"www.example.com" ~service:"http" env#net (fun conn ->
+    let req = "GET / HTTP/1.1\r\nHost:www.example.com:80\r\n\r\n" in
+    Eio.Flow.copy_string req conn;
+    let cs = Cstruct.create 25 in
+    Eio.Flow.read_exact conn cs;
+    Eio.Flow.close conn;
+    Eio.traceln "%S" (Cstruct.to_string cs));;
+Exception:
+Eio__Net.Connection_failure
+ (Failure "Unable to connect to host:www.example.com, service:http").
+```


### PR DESCRIPTION
`Net.with_tcp_connect` takes a domain-name/port/service and attempts to
establish connection to it. IP addresses for the host are tried one
after the other while preferring/trying IPv6 protocol addresses first
if available.

We also introduce two new exceptions:
1. Connection_failure - raised when a connection couldn't be established
  for any of the addresses defined for a given host/port/service.
2. Unix_error - introduced to mimic Unix.Unix_error without depending
  on "unix" library in the "lib_eio" which is (should?) be free from "unix" lib dependency if I understand the design/architecture of "eio". 

**Open Issues**
Ideally, `Eio.Net.Unix_error` is an implementation level exception which could be hidden from lib `eio` users. Question to maintainers - should this exn be hidden? At the moment there is `net.mli` file which prevents this from being hidden at the `eio` level.