### PR TITLE
io-uring needs kernel version >= 5.10, not 5.11

### DIFF
--- a/lib_main/eio_main.linux.ml
+++ b/lib_main/eio_main.linux.ml
@@ -1,6 +1,6 @@
 let has_working_uring v =
   match String.split_on_char '.' v with
-  | "5" :: minor :: _ -> int_of_string minor >= 11
+  | "5" :: minor :: _ -> int_of_string minor >= 10
   | major :: _ -> int_of_string major > 5
   | [] -> false
 


### PR DESCRIPTION
Fixes #304 