### PR TITLE
Add API for seekable read/writes

### DIFF
--- a/lib_eio/dune
+++ b/lib_eio/dune
@@ -2,4 +2,4 @@
   (name eio)
   (public_name eio)
   (flags (:standard -open Eio__core -open Eio__core.Private))
-  (libraries eio__core cstruct lwt-dllist fmt bigstringaf))
+  (libraries eio__core cstruct lwt-dllist fmt bigstringaf optint))

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -25,6 +25,7 @@ module Buf_write = Buf_write
 module Net = Net
 module Domain_manager = Domain_manager
 module Time = Time
+module File = File
 module Fs = Fs
 module Path = Path
 

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -134,6 +134,9 @@ module Time : sig
       raising exception [Timeout]. *)
 end
 
+(** Operations on open files. *)
+module File = File
+
 (** File-system types. *)
 module Fs = Fs
 

--- a/lib_eio/file.ml
+++ b/lib_eio/file.ml
@@ -1,0 +1,52 @@
+(** A file opened for reading. *)
+class virtual ro = object (_ : <Generic.t; Flow.source; ..>)
+  method probe _ = None
+  method read_methods = []
+  method virtual pread : file_offset:Optint.Int63.t -> Cstruct.t list -> int
+end
+
+(** A file opened for reading and writing. *)
+class virtual rw = object (_ : <Generic.t; Flow.source; Flow.sink; ..>)
+  inherit ro
+  method virtual pwrite : file_offset:Optint.Int63.t -> Cstruct.t list -> int
+end
+
+(** [pread t ~file_offset bufs] performs a single read of [t] at [file_offset] into [bufs].
+
+    It returns the number of bytes read, which may be less than the space in [bufs],
+    even if more bytes are available. Use {!pread_exact} instead if you require
+    the buffer to be filled.
+
+    To read at the current offset, use {!Flow.read} instead. *)
+let pread (t : #ro) ~file_offset bufs =
+  let got = t#pread ~file_offset bufs in
+  assert (got > 0 && got <= Cstruct.lenv bufs);
+  got
+
+(** [pread_exact t ~file_offset bufs] reads from [t] into [bufs] until [bufs] is full.
+
+    @raise End_of_file if the buffer could not be filled. *)
+let rec pread_exact (t : #ro) ~file_offset bufs =
+  if Cstruct.lenv bufs > 0 then (
+    let got = t#pread ~file_offset bufs in
+    let file_offset = Optint.Int63.add file_offset (Optint.Int63.of_int got) in
+    pread_exact t ~file_offset (Cstruct.shiftv bufs got)
+  )
+
+(** [pwrite_single t ~file_offset bufs] performs a single write operation, writing
+    data from [bufs] to location [file_offset] in [t].
+
+    It returns the number of bytes written, which may be less than the length of [bufs].
+    In most cases, you will want to use {!pwrite_all} instead. *)
+let pwrite_single (t : #rw) ~file_offset bufs =
+  let got = t#pwrite ~file_offset bufs in
+  assert (got > 0 && got <= Cstruct.lenv bufs);
+  got
+
+(** [pwrite_all t ~file_offset bufs] writes all the data in [bufs] to location [file_offset] in [t]. *)
+let rec pwrite_all (t : #rw) ~file_offset bufs =
+  if Cstruct.lenv bufs > 0 then (
+    let got = t#pwrite ~file_offset bufs in
+    let file_offset = Optint.Int63.add file_offset (Optint.Int63.of_int got) in
+    pwrite_all t ~file_offset (Cstruct.shiftv bufs got)
+  )

--- a/lib_eio/fs.ml
+++ b/lib_eio/fs.ml
@@ -12,7 +12,13 @@ exception Already_exists of path * exn
 exception Not_found of path * exn
 exception Permission_denied of path * exn
 
+class virtual ro = object (_ : <Generic.t; Flow.source; ..>)
+  method virtual pread : file_offset:Optint.Int63.t -> Cstruct.t list -> int
+end
+
 class virtual rw = object (_ : <Generic.t; Flow.source; Flow.sink; ..>)
+  inherit ro
+  method virtual pwrite : file_offset:Optint.Int63.t -> Cstruct.t list -> int
   method probe _ = None
   method read_methods = []
 end
@@ -29,7 +35,7 @@ type create = [
 (** Note: use the functions in {!Path} to access directories. *)
 class virtual dir = object (_ : #Generic.t)
   method probe _ = None
-  method virtual open_in : sw:Switch.t -> path -> <Flow.source; Flow.close>
+  method virtual open_in : sw:Switch.t -> path -> <ro; Flow.close>
   method virtual open_out :
     sw:Switch.t ->
     append:bool ->
@@ -48,3 +54,27 @@ and virtual dir_with_close = object
   inherit dir
   method virtual close : unit
 end
+
+let pread (t : #ro) ~file_offset bufs =
+  let got = t#pread ~file_offset bufs in
+  assert (got > 0 && got <= Cstruct.lenv bufs);
+  got
+
+let rec pread_exact (t : #ro) ~file_offset bufs =
+  if Cstruct.lenv bufs > 0 then (
+    let got = t#pread ~file_offset bufs in
+    let file_offset = Optint.Int63.add file_offset (Optint.Int63.of_int got) in
+    pread_exact t ~file_offset (Cstruct.shiftv bufs got)
+  )
+
+let pwrite (t : #rw) ~file_offset bufs =
+  let got = t#pwrite ~file_offset bufs in
+  assert (got > 0 && got <= Cstruct.lenv bufs);
+  got
+
+let rec pwrite_exact (t : #rw) ~file_offset bufs =
+  if Cstruct.lenv bufs > 0 then (
+    let got = t#pwrite ~file_offset bufs in
+    let file_offset = Optint.Int63.add file_offset (Optint.Int63.of_int got) in
+    pwrite_exact t ~file_offset (Cstruct.shiftv bufs got)
+  )

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -47,12 +47,12 @@ val load : _ t -> string
 
     This is a convenience wrapper around {!with_open_in}. *)
 
-val open_in : sw:Switch.t -> _ t -> <Flow.source; Flow.close>
+val open_in : sw:Switch.t -> _ t -> <ro; Flow.close>
 (** [open_in ~sw t] opens [t] for reading.
 
     Note: files are always opened in binary mode. *)
 
-val with_open_in : _ t -> (<Flow.source; Flow.close> -> 'a) -> 'a
+val with_open_in : _ t -> (<ro; Flow.close> -> 'a) -> 'a
 (** [with_open_in] is like [open_in], but calls [fn flow] with the new flow and closes
     it automatically when [fn] returns (if it hasn't already been closed by then). *)
 

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -47,12 +47,12 @@ val load : _ t -> string
 
     This is a convenience wrapper around {!with_open_in}. *)
 
-val open_in : sw:Switch.t -> _ t -> <ro; Flow.close>
+val open_in : sw:Switch.t -> _ t -> <File.ro; Flow.close>
 (** [open_in ~sw t] opens [t] for reading.
 
     Note: files are always opened in binary mode. *)
 
-val with_open_in : _ t -> (<ro; Flow.close> -> 'a) -> 'a
+val with_open_in : _ t -> (<File.ro; Flow.close> -> 'a) -> 'a
 (** [with_open_in] is like [open_in], but calls [fn flow] with the new flow and closes
     it automatically when [fn] returns (if it hasn't already been closed by then). *)
 
@@ -72,7 +72,7 @@ val open_out :
   sw:Switch.t ->
   ?append:bool ->
   create:create ->
-  _ t -> <rw; Flow.close>
+  _ t -> <File.rw; Flow.close>
 (** [open_out ~sw t] opens [t] for reading and writing.
 
     Note: files are always opened in binary mode.
@@ -82,7 +82,7 @@ val open_out :
 val with_open_out :
   ?append:bool ->
   create:create ->
-  _ t -> (<rw; Flow.close> -> 'a) -> 'a
+  _ t -> (<File.rw; Flow.close> -> 'a) -> 'a
 (** [with_open_out] is like [open_out], but calls [fn flow] with the new flow and closes
     it automatically when [fn] returns (if it hasn't already been closed by then). *)
 

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1210,7 +1210,7 @@ class dir ~label (fd : dir_fd) = object
         ~flags:Uring.Open_flags.cloexec
         ~perm:0
     in
-    (flow fd :> <Eio.Fs.ro; Eio.Flow.close>)
+    (flow fd :> <Eio.File.ro; Eio.Flow.close>)
 
   method open_out ~sw ~append ~create path =
     let perm, flags =
@@ -1226,7 +1226,7 @@ class dir ~label (fd : dir_fd) = object
         ~flags:Uring.Open_flags.(cloexec + flags)
         ~perm
     in
-    (flow fd :> <Eio.Fs.rw; Eio.Flow.close>)
+    (flow fd :> <Eio.File.rw; Eio.Flow.close>)
 
   method open_dir ~sw path =
     let fd = Low_level.openat ~sw ~seekable:false fd path

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -562,9 +562,7 @@ let flow fd = object (_ : <source; sink; ..>)
   method pwrite ~file_offset bufs =
     let bufs = List.map Cstruct.to_bigarray bufs in
     let file_offset = Optint.Int63.to_int64 file_offset in
-    match File.write_single ~file_offset fd bufs |> or_raise |> Unsigned.Size_t.to_int with
-    | 0 -> raise End_of_file
-    | got -> got
+    File.write_single ~file_offset fd bufs |> or_raise |> Unsigned.Size_t.to_int
 
   method read_methods = []
 
@@ -897,7 +895,7 @@ class dir ~label (dir_path : string) = object (self)
 
   method open_in ~sw path =
     let fd = File.open_ ~sw (self#resolve path) [`NOFOLLOW; `RDONLY] |> or_raise_path path in
-    (flow fd :> <Eio.Fs.ro; Eio.Flow.close>)
+    (flow fd :> <Eio.File.ro; Eio.Flow.close>)
 
   method open_out ~sw ~append ~create path =
     let mode, flags =
@@ -914,7 +912,7 @@ class dir ~label (dir_path : string) = object (self)
       else self#resolve_new path
     in
     let fd = File.open_ ~sw real_path flags ~mode:[`NUMERIC mode] |> or_raise_path path in
-    (flow fd :> <Eio.Fs.rw; Eio.Flow.close>)
+    (flow fd :> <Eio.File.rw; Eio.Flow.close>)
 
   method open_dir ~sw path =
     Switch.check sw;

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -61,7 +61,7 @@ module Low_level : sig
       string -> Luv.File.Open_flag.t list -> t or_error
     (** Wraps {!Luv.File.open_} *)
 
-    val read : t -> Luv.Buffer.t list -> Unsigned.Size_t.t or_error
+    val read : ?file_offset:int64 -> t -> Luv.Buffer.t list -> Unsigned.Size_t.t or_error
     (** Wraps {!Luv.File.read} *)
 
     val write : t -> Luv.Buffer.t list -> unit

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -64,8 +64,12 @@ module Low_level : sig
     val read : ?file_offset:int64 -> t -> Luv.Buffer.t list -> Unsigned.Size_t.t or_error
     (** Wraps {!Luv.File.read} *)
 
-    val write : t -> Luv.Buffer.t list -> unit
-    (** [write t bufs] writes all the data in [bufs] (which may take several calls to {!Luv.File.write}). *)
+    val write_single : ?file_offset:int64 -> t -> Luv.Buffer.t list -> Unsigned.Size_t.t or_error
+    (** [write_single t bufs] performs a single write call and returns the number of bytes written,
+        which may be less than the amount of data provided in [bufs]. *)
+
+    val write : t -> Luv.Buffer.t list -> unit or_error
+    (** [write t bufs] writes all the data in [bufs] (which may take several calls to {!write_single}). *)
 
     val realpath : string -> string or_error
     (** Wraps {!Luv.File.realpath} *)


### PR DESCRIPTION
This partly addresses #305. Currently just a draft, meant for discussing the API.

The PR adds a method `#read_at_offset` to the object returned by `open_in` and `with_open_in` allowing to do a read at a given offset. The new method is exposed as `Eio.Fs.read_at_offset` and a helper function is added as well `Eio.Fs.read_exact_at_offset`. Not sure if this is the right level at which to expose this functionality.

I'm just getting started with this library and am not sure I have yet grokked the full picture, so all feedback is welcome!