### PR TITLE
Add monotonic clock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,12 +832,12 @@ The standard environment provides a [clock][Eio.Time] with the usual POSIX time:
 
 ```ocaml
 # Eio_main.run @@ fun env ->
-  let clock = Eio.Stdenv.clock env in
-  traceln "The time is now %f" (Eio.Time.now clock);
+  let clock = Eio.Stdenv.real_clock env in
+  traceln "The time is now %a" Ptime.pp (Eio.Time.now clock);
   Eio.Time.sleep clock 1.0;
-  traceln "The time is now %f" (Eio.Time.now clock);;
-+The time is now 1623940778.270336
-+The time is now 1623940779.270336
+  traceln "The time is now %a" Ptime.pp (Eio.Time.now clock);;
++The time is now 2021-06-17 14:39:38 +00:00
++The time is now 2021-06-17 14:39:39 +00:00
 - : unit = ()
 ```
 

--- a/bench/bench_cancel.ml
+++ b/bench/bench_cancel.ml
@@ -37,8 +37,8 @@ let run_bench ?domain_mgr ~clock () =
       )
   with Exit ->
     let t1 = Eio.Time.now clock in
-    let time_total = t1 -. t0 in
-    let time_per_iter = time_total /. float n_iters in
+    let time_total = Mtime.span t1 t0 in
+    let time_per_iter = Mtime.Span.to_s time_total /. float n_iters in
     let _minor1, prom1, _major1 = Gc.counters () in
     let prom = prom1 -. prom0 in
     Printf.printf "%11b, %7.2f, %13.4f\n%!" (domain_mgr <> None) (1e9 *. time_per_iter) (prom /. float n_iters)
@@ -52,4 +52,4 @@ let () =
   Eio_main.run @@ fun env ->
   main
     ~domain_mgr:(Eio.Stdenv.domain_mgr env)
-    ~clock:(Eio.Stdenv.clock env)
+    ~clock:(Eio.Stdenv.mono_clock env)

--- a/bench/bench_mutex.ml
+++ b/bench/bench_mutex.ml
@@ -32,9 +32,9 @@ let run_bench ~domain_mgr ~clock ~use_domains ~iters_per_thread ~threads =
     );
   assert (!v = 0);
   let t1 = Eio.Time.now clock in
-  let time_total = t1 -. t0 in
+  let time_total = Mtime.span t1 t0 in
   let n_iters = iters_per_thread * threads in
-  let time_per_iter = time_total /. float n_iters in
+  let time_per_iter = Mtime.Span.to_s time_total /. float n_iters in
   let _minor1, prom1, _major1 = Gc.counters () in
   let prom = prom1 -. prom0 in
   Printf.printf "%11b, %12d, %8d, %8.2f, %13.4f\n%!" use_domains n_iters threads (1e9 *. time_per_iter) (prom /. float n_iters)
@@ -55,4 +55,4 @@ let () =
   Eio_main.run @@ fun env ->
   main
     ~domain_mgr:(Eio.Stdenv.domain_mgr env)
-    ~clock:(Eio.Stdenv.clock env)
+    ~clock:(Eio.Stdenv.mono_clock env)

--- a/bench/bench_promise.ml
+++ b/bench/bench_promise.ml
@@ -46,7 +46,8 @@ let bench_resolved ~clock ~n_iters =
     t := !t + Promise.await p;
   done;
   let t1 = Eio.Time.now clock in
-  Printf.printf "Reading a resolved promise: %.3f ns\n%!" (1e9 *. (t1 -. t0) /. float n_iters);
+  let total_time = Mtime.span t1 t0 in
+  Printf.printf "Reading a resolved promise: %.3f ns\n%!" (1e9 *. (Mtime.Span.to_s total_time) /. float n_iters);
   assert (!t = n_iters)
 
 let run_bench ~domain_mgr ~clock ~use_domains ~n_iters =
@@ -67,8 +68,8 @@ let run_bench ~domain_mgr ~clock ~use_domains ~n_iters =
        run_client ~n_iters ~i:0 init_p
     );
   let t1 = Eio.Time.now clock in
-  let time_total = t1 -. t0 in
-  let time_per_iter = time_total /. float n_iters in
+  let time_total = Mtime.span t1 t0 in
+  let time_per_iter = Mtime.Span.to_s time_total /. float n_iters in
   let _minor1, prom1, _major1 = Gc.counters () in
   let prom = prom1 -. prom0 in
   Printf.printf "%11b, %8d, %8.2f, %13.4f\n%!" use_domains n_iters (1e9 *. time_per_iter) (prom /. float n_iters)
@@ -86,4 +87,4 @@ let () =
   Eio_main.run @@ fun env ->
   main
     ~domain_mgr:(Eio.Stdenv.domain_mgr env)
-    ~clock:(Eio.Stdenv.clock env)
+    ~clock:(Eio.Stdenv.mono_clock env)

--- a/bench/bench_semaphore.ml
+++ b/bench/bench_semaphore.ml
@@ -30,8 +30,8 @@ let run_bench ~domain_mgr ~clock ~use_domains ~n_iters ~batch_size =
        done
     );
   let t1 = Eio.Time.now clock in
-  let time_total = t1 -. t0 in
-  let time_per_iter = time_total /. float n_iters in
+  let time_total = Mtime.span t1 t0 in
+  let time_per_iter = Mtime.Span.to_s time_total /. float n_iters in
   let _minor1, prom1, _major1 = Gc.counters () in
   let prom = prom1 -. prom0 in
   Printf.printf "%11b, %8d, %3d, %8.2f, %13.4f\n%!" use_domains n_iters batch_size (1e9 *. time_per_iter) (prom /. float n_iters)
@@ -52,4 +52,4 @@ let () =
   Eio_main.run @@ fun env ->
   main
     ~domain_mgr:(Eio.Stdenv.domain_mgr env)
-    ~clock:(Eio.Stdenv.clock env)
+    ~clock:(Eio.Stdenv.mono_clock env)

--- a/bench/bench_stream.ml
+++ b/bench/bench_stream.ml
@@ -26,8 +26,8 @@ let run_bench ~domain_mgr ~clock ~use_domains ~n_iters ~capacity =
          done
       );
     let t1 = Eio.Time.now clock in
-    let time_total = t1 -. t0 in
-    let time_per_iter = time_total /. float n_iters in
+    let time_total = Mtime.span t1 t0 in
+    let time_per_iter = Mtime.Span.to_s time_total /. float n_iters in
     let _minor1, prom1, _major1 = Gc.counters () in
     let prom = prom1 -. prom0 in
     Printf.printf "%11b, %8d, %8d, %7.2f, %13.4f\n%!" use_domains n_iters capacity (1e9 *. time_per_iter) (prom /. float n_iters)
@@ -46,4 +46,4 @@ let () =
   Eio_main.run @@ fun env ->
   main
     ~domain_mgr:(Eio.Stdenv.domain_mgr env)
-    ~clock:(Eio.Stdenv.clock env)
+    ~clock:(Eio.Stdenv.mono_clock env)

--- a/bench/bench_yield.ml
+++ b/bench/bench_yield.ml
@@ -19,9 +19,9 @@ let main ~clock =
           done
         );
       let t1 = Eio.Time.now clock in
-      let time_total = t1 -. t0 in
+      let time_total = Mtime.span t1 t0 in
       let n_total = n_fibers * n_iters in
-      let time_per_iter = time_total /. float n_total in
+      let time_per_iter = Mtime.Span.to_s time_total /. float n_total in
       let _minor1, prom1, _major1 = Gc.counters () in
       let prom = prom1 -. prom0 in
       Printf.printf "%8d, % 7.2f, % 13.4f\n%!" n_fibers (1e9 *. time_per_iter) (prom /. float n_total)
@@ -29,4 +29,4 @@ let main ~clock =
 
 let () =
   Eio_main.run @@ fun env ->
-  main ~clock:(Eio.Stdenv.clock env)
+  main ~clock:(Eio.Stdenv.mono_clock env)

--- a/doc/dune
+++ b/doc/dune
@@ -1,4 +1,4 @@
 (mdx
   (package eio_main)
-  (packages eio_main)
+  (packages eio_main ptime)
   (files multicore.md))

--- a/dune-project
+++ b/dune-project
@@ -22,6 +22,7 @@
   (hmap (>= 0.8.1))
   (astring (and (>= 0.8.5) :with-test))
   (crowbar (and (>= 0.2) :with-test))
+  (ptime (>= 1.0.0))
   (mtime (>= 1.2.0))
   (alcotest (and (>= 1.4.0) :with-test))))
 (package

--- a/eio.opam
+++ b/eio.opam
@@ -20,6 +20,7 @@ depends: [
   "hmap" {>= "0.8.1"}
   "astring" {>= "0.8.5" & with-test}
   "crowbar" {>= "0.2" & with-test}
+  "ptime" {>= "1.0.0"}
   "mtime" {>= "1.2.0"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}

--- a/lib_eio/dune
+++ b/lib_eio/dune
@@ -1,5 +1,6 @@
 (library
-  (name eio)
-  (public_name eio)
-  (flags (:standard -open Eio__core -open Eio__core.Private))
-  (libraries eio__core cstruct lwt-dllist fmt bigstringaf optint))
+ (name eio)
+ (public_name eio)
+ (flags
+  (:standard -open Eio__core -open Eio__core.Private))
+ (libraries eio__core cstruct lwt-dllist fmt bigstringaf optint ptime mtime))

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -36,7 +36,8 @@ module Stdenv = struct
     stderr : Flow.sink;
     net : Net.t;
     domain_mgr : Domain_manager.t;
-    clock : Time.clock;
+    real_clock : Ptime.t Time.clock;
+    mono_clock : Mtime.t Time.clock;
     fs : Fs.dir Path.t;
     cwd : Fs.dir Path.t;
     secure_random : Flow.source;
@@ -48,7 +49,8 @@ module Stdenv = struct
   let stderr (t : <stderr : #Flow.sink;   ..>) = t#stderr
   let net (t : <net : #Net.t; ..>) = t#net
   let domain_mgr (t : <domain_mgr : #Domain_manager.t; ..>) = t#domain_mgr
-  let clock (t : <clock : #Time.clock; ..>) = t#clock
+  let real_clock (t : <real_clock : Ptime.t #Time.clock; ..>) = t#real_clock
+  let mono_clock (t : <mono_clock : Mtime.t #Time.clock; ..>) = t#mono_clock
   let secure_random (t: <secure_random : #Flow.source; ..>) = t#secure_random
   let fs (t : <fs : #Fs.dir Path.t; ..>) = t#fs
   let cwd (t : <cwd : #Fs.dir Path.t; ..>) = t#cwd

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -178,7 +178,8 @@ module Stdenv : sig
     stderr : Flow.sink;
     net : Net.t;
     domain_mgr : Domain_manager.t;
-    clock : Time.clock;
+    real_clock : Ptime.t Time.clock;
+    mono_clock : Mtime.t Time.clock;
     fs : Fs.dir Path.t;
     cwd : Fs.dir Path.t;
     secure_random : Flow.source;
@@ -231,8 +232,11 @@ module Stdenv : sig
       To use this, see {!Time}.
   *)
 
-  val clock : <clock : #Time.clock as 'a; ..> -> 'a
-  (** [clock t] is the system clock. *)
+  val real_clock : <real_clock : Ptime.t #Time.clock as 'a; ..> -> 'a
+  (** [real_clock t] is the realtime OS clock. *)
+
+  val mono_clock : <mono_clock : Mtime.t #Time.clock as 'a; ..> -> 'a
+  (** [mono_clock t] is the monotonic OS clock. *)
 
   (** {1 Randomness} *)
 

--- a/lib_eio/mock/clock.ml
+++ b/lib_eio/mock/clock.ml
@@ -1,7 +1,7 @@
 open Eio.Std
 
 type t = <
-  Eio.Time.clock;
+  float Eio.Time.clock;
   advance : unit;
   set_time : float -> unit;
 >
@@ -24,12 +24,15 @@ module Q = Psq.Make(Key)(Job)
 
 let make () =
   object (self)
-    inherit Eio.Time.clock
+    inherit [float] Eio.Time.clock
 
     val mutable now = 0.0
     val mutable q = Q.empty
 
     method now = now
+
+    method add_seconds t d = t +. d
+    method to_seconds t = t
 
     method sleep_until time =
       if time <= now then Fiber.yield ()

--- a/lib_eio/mock/clock.mli
+++ b/lib_eio/mock/clock.mli
@@ -1,5 +1,5 @@
 type t = <
-  Eio.Time.clock;
+  float Eio.Time.clock;
   advance : unit;
   set_time : float -> unit;
 >

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -119,7 +119,7 @@ val connect : sw:Switch.t -> #t -> Sockaddr.stream -> <stream_socket; Flow.close
     @raise Connection_failure if connection couldn't be established. *)
 
 val with_tcp_connect :
-  ?timeout:Time.Timeout.t ->
+  ?timeout:'a Time.Timeout.t ->
   host:string ->
   service:string ->
   #t ->

--- a/lib_eio/time.mli
+++ b/lib_eio/time.mli
@@ -1,47 +1,50 @@
-class virtual clock : object
-  method virtual now : float
-  method virtual sleep_until : float -> unit
+class virtual ['a] clock : object
+  method virtual now : 'a
+  method virtual sleep_until : 'a -> unit
+  method virtual add_seconds : 'a -> float -> 'a
+  method virtual to_seconds : 'a -> float
 end
 
-val now : #clock -> float
+val now : 'a #clock -> 'a
 (** [now t] is the current time according to [t]. *)
 
-val sleep_until : #clock -> float -> unit
+val sleep_until : 'a #clock -> 'a -> unit
 (** [sleep_until t time] waits until the given time is reached. *)
 
-val sleep : #clock -> float -> unit
+val sleep : 'a #clock -> float -> unit
 (** [sleep t d] waits for [d] seconds. *)
 
-(** {2 Timeouts} *)
+val to_seconds : 'a #clock -> 'a -> float
+(** [to_seconds clock time] converts [time] to fractional seconds using [clock]. *)
+
+val with_timeout : 'a #clock -> float -> (unit -> ('a, 'e) result) -> ('a, [> `Timeout] as 'e) result
+(** [with_timeout clock d fn] runs [fn ()] but cancels it after [d] seconds. *)
 
 exception Timeout
 
-val with_timeout : #clock -> float -> (unit -> ('a, 'e) result) -> ('a, [> `Timeout] as 'e) result
-(** [with_timeout clock d fn] runs [fn ()] but cancels it after [d] seconds. *)
-
-val with_timeout_exn : #clock -> float -> (unit -> 'a) -> 'a
-(** [with_timeout_exn clock d fn] runs [fn ()] but cancels it after [d] seconds,
+val with_timeout_exn : 'a #clock -> float -> (unit -> 'a) -> 'a
+(** [with_timeout_exn clock d fn] runs [fn ()] but cancels it after [d] seconds, 
     raising exception {!exception-Timeout}. *)
 
 (** Timeout values. *)
 module Timeout : sig
-  type t
+  type 'a t
 
-  val of_s : #clock -> float -> t
+  val of_s : 'a #clock -> float -> 'a t
   (** [of_s clock duration] is a timeout of [duration] seconds, as measured by [clock].
       Internally, this is just the tuple [(clock, duration)]. *)
 
-  val none : t
+  val none : 'a t
   (** [none] is an infinite timeout. *)
 
-  val run : t -> (unit -> ('a, 'e) result) -> ('a, [> `Timeout] as 'e) result
+  val run : 'a t -> (unit -> ('b, 'e) result) -> ('b, [> `Timeout] as 'e) result
   (** [run t fn] runs [fn ()] but cancels it if it takes longer than allowed by timeout [t]. *)
 
-  val run_exn : t -> (unit -> 'a) -> 'a
+  val run_exn : 'a t -> (unit -> 'b) -> 'b
   (** [run_exn t fn] runs [fn ()] but cancels it if it takes longer than allowed by timeout [t],
       raising exception {!exception-Timeout}. *)
 
-  val pp : t Fmt.t
+  val pp : 'a t Fmt.t
   (** [pp] formats a timeout as a duration (e.g. "5s").
       This is intended for use in error messages and logging and is rounded. *)
 end

--- a/lib_eio/unix/dune
+++ b/lib_eio/unix/dune
@@ -1,4 +1,4 @@
 (library
  (name eio_unix)
  (public_name eio.unix)
- (libraries eio unix threads mtime.clock.os))
+ (libraries eio unix threads mtime mtime.clock.os ptime ptime.clock.os))

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -14,6 +14,7 @@ module Private = struct
   type _ Effect.t += 
     | Await_readable : Unix.file_descr -> unit Effect.t
     | Await_writable : Unix.file_descr -> unit Effect.t
+    | Sleep_until : float -> unit Effect.t
     | Socket_of_fd : Eio.Switch.t * bool * Unix.file_descr -> socket Effect.t
     | Socketpair : Eio.Switch.t * Unix.socket_domain * Unix.socket_type * int -> (socket * socket) Effect.t
 end
@@ -25,22 +26,36 @@ let real_clock = object
   inherit [Ptime.t] Eio.Time.clock
 
   method now = Ptime_clock.now ()
-  method sleep_until = failwith "sleep_until not implemented"
+
+  method sleep_until time =
+    let time = Ptime.to_float_s time in
+    Effect.perform (Private.Sleep_until time)
+
   method add_seconds t d =
     let span = Ptime.Span.of_float_s d in
     Option.bind span (Ptime.add_span t)
     |> Option.get
+
+  method to_seconds time = Ptime.to_float_s time
 end
 
 let mono_clock = object
   inherit [Mtime.t] Eio.Time.clock
 
   method now = Mtime_clock.now ()
-  method sleep_until = failwith "sleep_until not implemented"
+
+  method sleep_until time =
+    let time = Mtime.to_uint64_ns time |> Int64.to_float in
+    Effect.perform (Private.Sleep_until (time /. 1e9))
+
   method add_seconds t d =
     let span = (d *. 1e9) |> Int64.of_float |> Mtime.Span.of_uint64_ns in
     Mtime.add_span t span
     |> Option.get
+
+  method to_seconds time =
+    let time = Mtime.to_uint64_ns time |> Int64.to_float in
+    (time /. 1e9)
 end
 
 let sleep d = Eio.Time.sleep mono_clock d

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -60,7 +60,9 @@ val sleep : float -> unit
 (** [sleep d] sleeps for [d] seconds, allowing other fibers to run.
     This is can be useful for debugging (e.g. to introduce delays to trigger a race condition)
     without having to plumb {!Eio.Stdenv.clock} through your code.
-    It can also be used in programs that don't care about tracking determinism. *)
+    It can also be used in programs that don't care about tracking determinism.
+
+    The clock used is the monotonic system clock. See {!val:mono_clock}. *)
 
 val run_in_systhread : (unit -> 'a) -> 'a
 (** [run_in_systhread fn] runs the function [fn] in a newly created system thread (a {! Thread.t}).
@@ -85,7 +87,6 @@ module Private : sig
   type _ Effect.t += 
     | Await_readable : Unix.file_descr -> unit Effect.t      (** See {!await_readable} *)
     | Await_writable : Unix.file_descr -> unit Effect.t      (** See {!await_writable} *)
-    | Get_system_clock : Eio.Time.clock Effect.t             (** See {!sleep} *)
     | Socket_of_fd : Switch.t * bool * Unix.file_descr ->
         socket Effect.t                                      (** See {!FD.as_socket} *)
     | Socketpair : Eio.Switch.t * Unix.socket_domain * Unix.socket_type * int ->
@@ -96,3 +97,9 @@ module Ctf = Ctf_unix
 
 val getnameinfo : Eio.Net.Sockaddr.t -> (string * string)
 (** [getnameinfo sockaddr] returns domain name and service for [sockaddr]. *)
+
+val real_clock : Ptime.t Eio.Time.clock
+(** [real_clock] is the realtime OS clock. *)
+
+val mono_clock : Mtime.t Eio.Time.clock
+(** [mono_clock] is the monotonic OS clock. *)

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -87,6 +87,7 @@ module Private : sig
   type _ Effect.t += 
     | Await_readable : Unix.file_descr -> unit Effect.t      (** See {!await_readable} *)
     | Await_writable : Unix.file_descr -> unit Effect.t      (** See {!await_writable} *)
+    | Sleep_until : float -> unit Effect.t
     | Socket_of_fd : Switch.t * bool * Unix.file_descr ->
         socket Effect.t                                      (** See {!FD.as_socket} *)
     | Socketpair : Eio.Switch.t * Unix.socket_domain * Unix.socket_type * int ->

--- a/lib_eio_linux/dune
+++ b/lib_eio_linux/dune
@@ -6,4 +6,4 @@
   (language c)
   (flags :standard -D_LARGEFILE64_SOURCE)
   (names eio_stubs))
- (libraries eio eio.utils eio.unix uring logs fmt))
+  (libraries eio eio.utils eio.unix uring logs fmt ptime mtime))

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -514,7 +514,7 @@ let rec schedule ({run_q; sleep_q; mem_q; uring; _} as st) : [`Exit_scheduler] =
   | Some Failed_thread (k, ex) -> Suspended.discontinue k ex
   | Some IO -> (* Note: be sure to re-inject the IO task before continuing! *)
     (* This is not a fair scheduler: timers always run before all other IO *)
-    let now = Eio_unix.(mono_clock#now |> mono_clock#to_seconds) in
+    let now = Eio_unix.(real_clock#now |> real_clock#to_seconds) in
     match Zzz.pop ~now sleep_q with
     | `Due k ->
       Lf_queue.push run_q IO;                   (* Re-inject IO job in the run queue *)

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -64,7 +64,8 @@ type stdenv = <
   stderr : sink;
   net : Eio.Net.t;
   domain_mgr : Eio.Domain_manager.t;
-  clock : Eio.Time.clock;
+  real_clock : Ptime.t Eio.Time.clock;
+  mono_clock : Mtime.t Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;
   cwd : Eio.Fs.dir Eio.Path.t;
   secure_random : Eio.Flow.source;

--- a/lib_eio_linux/tests/bench_noop.ml
+++ b/lib_eio_linux/tests/bench_noop.ml
@@ -19,9 +19,9 @@ let main ~clock =
           done
         );
       let t1 = Eio.Time.now clock in
-      let time_total = t1 -. t0 in
+      let time_total = Mtime.span t1 t0 in
       let n_total = n_fibers * n_iters in
-      let time_per_iter = time_total /. float n_total in
+      let time_per_iter = Mtime.Span.to_s time_total /. float n_total in
       let _minor1, prom1, _major1 = Gc.counters () in
       let prom = prom1 -. prom0 in
       Printf.printf "%5d, %.2f, %7.4f\n%!" n_fibers (1e9 *. time_per_iter) (prom /. float n_total)
@@ -29,4 +29,4 @@ let main ~clock =
 
 let () =
   Eio_linux.run @@ fun env ->
-  main ~clock:(Eio.Stdenv.clock env)
+  main ~clock:(Eio.Stdenv.mono_clock env)

--- a/lib_eio_luv/dune
+++ b/lib_eio_luv/dune
@@ -1,4 +1,4 @@
 (library
  (name eio_luv)
  (public_name eio_luv)
- (libraries eio eio.unix luv luv_unix eio.utils logs fmt))
+ (libraries eio eio.unix luv luv_unix eio.utils logs fmt ptime mtime))

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -521,7 +521,7 @@ module Low_level = struct
   module Poll = Poll
 
   let sleep_until due st (k: unit Suspended.t) =
-    let now = Eio_unix.(mono_clock#now |> mono_clock#to_seconds) in
+    let now = Eio_unix.(real_clock#now |> real_clock#to_seconds) in
     let delay = 1000. *. (due -.  now) |> ceil |> truncate |> max 0 in
     let timer = Luv.Timer.init ~loop:st.loop () |> or_raise in
     Fiber_context.set_cancel_fn k.fiber (fun ex ->

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -824,7 +824,8 @@ type stdenv = <
   stderr : sink;
   net : Eio.Net.t;
   domain_mgr : Eio.Domain_manager.t;
-  clock : Eio.Time.clock;
+  real_clock : Ptime.t Eio.Time.clock;
+  mono_clock : Mtime.t Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;
   cwd : Eio.Fs.dir Eio.Path.t;
   secure_random : Eio.Flow.source;
@@ -866,13 +867,6 @@ let domain_mgr ~run_event_loop = object (self)
           );
         Option.get !result
       )
-end
-
-let clock = object
-  inherit Eio.Time.clock
-
-  method now = Unix.gettimeofday ()
-  method sleep_until = sleep_until
 end
 
 type _ Eio.Generic.ty += Dir_resolve_new : (string -> string) Eio.Generic.ty
@@ -1006,7 +1000,8 @@ let stdenv ~run_event_loop =
     method stderr = Lazy.force stderr
     method net = net
     method domain_mgr = domain_mgr ~run_event_loop
-    method clock = clock
+    method real_clock = Eio_unix.real_clock
+    method mono_clock = Eio_unix.mono_clock
     method fs = (fs :> Eio.Fs.dir), "."
     method cwd = (cwd :> Eio.Fs.dir), "."
     method secure_random = secure_random
@@ -1090,7 +1085,6 @@ let rec run : type a. (_ -> a) -> a = fun main ->
               let k = { Suspended.k; fiber } in
               Poll.await_writable st k fd
           )
-        | Eio_unix.Private.Get_system_clock -> Some (fun k -> continue k clock)
         | Eio_unix.Private.Socket_of_fd (sw, close_unix, fd) -> Some (fun k ->
             try
               let fd = Low_level.Stream.of_unix fd in

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -21,11 +21,6 @@ module Low_level : sig
   (** [await_with_cancel ~request fn] converts a function using a luv-style callback to one using effects.
       It sets the fiber's cancel function to cancel [request], and clears it when the operation completes. *)
 
-  (** {1 Time functions} *)
-
-  val sleep_until : float -> unit
-  (** [sleep_until time] blocks until the current time is [time]. *)
-
   (** {1 DNS functions} *)
 
   val getaddrinfo : service:string -> string -> Eio.Net.Sockaddr.t list

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -128,7 +128,8 @@ type stdenv = <
   stderr : sink;
   net : Eio.Net.t;
   domain_mgr : Eio.Domain_manager.t;
-  clock : Eio.Time.clock;
+  real_clock : Ptime.t Eio.Time.clock;
+  mono_clock : Mtime.t Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;
   cwd : Eio.Fs.dir Eio.Path.t;
   secure_random : Eio.Flow.source;

--- a/tests/time.md
+++ b/tests/time.md
@@ -8,9 +8,9 @@
 ```ocaml
 open Eio.Std
 
-let run (fn : clock:Eio.Time.clock -> unit) =
+let run (fn : clock:'a Eio.Time.clock -> unit) =
   Eio_main.run @@ fun env ->
-  let clock = Eio.Stdenv.clock env in
+  let clock = Eio.Stdenv.real_clock env in
   fn ~clock
 ```
 


### PR DESCRIPTION
This PR adds support for monotonic clock to eio. The original `clock` method in `Eio.Stdevn.t` is now renamed to `real_clock` since it is in fact an encapsulation of real-time OS clock. The monotonic clock is `mono_clock`. 

The real_clock is implemented using `Ptime.t` and mono_clock is implemented using `Mtime.t`. There is an open PR to use CLOCK_BOOTTIME as monotonic clock in Mtime (https://github.com/dbuenzli/mtime/pull/44). 

We now use a common `Sleep_until` effect in `Eio_unix.Private` for both luv and uring backend. 

`make bench` now uses `mono_clock` to mark start/end time. I believe this is "more" correct than using `real_clock` for benchmarking purposes.

In addition to `Eio.Time.clock` being polymorhphic, it now also features two functions to make working with time in seconds a bit convenient, `to_seconds` and `add_seconds`. 

Seconds is chosen as default time unit since it seems to be the unit used by OCaml stdlib. Secondly and subjectively it seems to be a convenient unit to be thinking in terms of time when using time related functions in eio. 

Fixes https://github.com/ocaml-multicore/eio/issues/229

/cc @haesbaert 