### PR TITLE
Buf_read: Add take_while1 and skip_while1

### DIFF
--- a/lib_eio/buf_read.ml
+++ b/lib_eio/buf_read.ml
@@ -215,6 +215,14 @@ let take_while p t =
   consume t len;
   data
 
+let take_while1 p t =
+  let len = count_while p t in
+  if len < 1 then Fmt.failwith "take_while1"
+  else
+    let data = Cstruct.to_string (Cstruct.of_bigarray t.buf ~off:t.pos ~len) in
+    consume t len;
+    data
+
 let skip_while p t =
   let rec aux i =
     if i < t.len then (

--- a/lib_eio/buf_read.ml
+++ b/lib_eio/buf_read.ml
@@ -237,6 +237,11 @@ let skip_while p t =
   try aux 0
   with End_of_file -> ()
 
+let skip_while1 p t =
+  let len = count_while p t in
+  if len < 1 then Fmt.failwith "skip_while1"
+  else consume t len
+
 let rec skip n t =
   if n <= t.len then (
     consume t n

--- a/lib_eio/buf_read.mli
+++ b/lib_eio/buf_read.mli
@@ -127,6 +127,10 @@ val take_while : (char -> bool) -> string parser
     It will return the empty string if there are no matching characters
     (and therefore never raises [End_of_file]). *)
 
+val take_while1 : (char -> bool) -> string parser
+(** [take_while1 p] is like [take_while]. However, the parser fails with "take_while1"
+    if at least one character of input hasn't been consumed by the parser. *)
+
 val skip_while : (char -> bool) -> unit parser
 (** [skip_while p] skips zero or more bytes for which [p] is [true].
 

--- a/lib_eio/buf_read.mli
+++ b/lib_eio/buf_read.mli
@@ -137,6 +137,10 @@ val skip_while : (char -> bool) -> unit parser
     [skip_while p t] does the same thing as [ignore (take_while p t)],
     except that it is not limited by the buffer size. *)
 
+val skip_while1 : (char -> bool) -> unit parser
+(** [skip_while1 p] is like [skip_while]. However, the parser fails with "skip_while1" if
+    at least one character of input hasn't been skipped. *)
+
 val skip : int -> unit parser
 (** [skip n] discards the next [n] bytes.
 

--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -360,6 +360,23 @@ val i : R.t = <abstr>
 +mock_flow returning 1 bytes
 +mock_flow returning Eof
 - : string = "fg"
+
+# let is_a = function
+  | 'a' -> true
+  | _ -> false;;
+val is_a : char -> bool = <fun>
+
+# test ["aaabc"] (R.take_while1 is_a);;
++mock_flow returning 5 bytes
+- : string = "aaa"
+
+# test ["aaabc"] (R.take_while1 (Fun.negate is_a));;
++mock_flow returning 5 bytes
+Exception: Failure "take_while1".
+
+# test ["abc"] (R.take_while1 is_a);;
++mock_flow returning 3 bytes
+- : string = "a"
 ```
 
 ## Take all

--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -377,6 +377,20 @@ Exception: Failure "take_while1".
 # test ["abc"] (R.take_while1 is_a);;
 +mock_flow returning 3 bytes
 - : string = "a"
+
+# test ["aaaaabc"] (R.skip_while1 is_a *> R.take_all);;
++mock_flow returning 7 bytes
++mock_flow returning Eof
+- : string = "bc"
+
+# test ["bbbccc"] (R.skip_while1 is_a *> R.take_all);;
++mock_flow returning 6 bytes
+Exception: Failure "skip_while1".
+
+# test ["abbbccc"] (R.skip_while1 is_a *> R.take_all);;
++mock_flow returning 7 bytes
++mock_flow returning Eof
+- : string = "bbbccc"
 ```
 
 ## Take all


### PR DESCRIPTION
This PR adds support for `take_while1` and `skip_while1` parsers. 

The parsers are equivalent of `take_while` and `skip_while` respectively. However, they fail if at least one token is not consumed by the parser. The parsers implement an equivalent of "at least one or more" token parsing needs.