### PR TITLE
Account for stack differences in the socketpair test (issue #312)

### DIFF
--- a/tests/network.md
+++ b/tests/network.md
@@ -450,7 +450,7 @@ ECONNRESET:
   try
     ignore (Eio.Flow.read a (Cstruct.create 1) : int);
     assert false
-  with Eio.Net.Connection_reset _ -> traceln "Connection failed (good)";;
+  with Eio.Net.Connection_reset _ | End_of_file -> traceln "Connection failed (good)";;
 +Connection failed (good)
 - : unit = ()
 ```


### PR DESCRIPTION
Linux returns ECONNRESET while every other stack tested returns EOF on this test.

I did not dig into the especification but Linux appears to be on the weird side.

In order to get a ECONNRESET, the write needs to hit the socket _after_ the close, but our program does:

WRITE(A)
CLOSE(B)
READ(A)

Linux never gives "A" side a chance to see a proper EOF, while the others do:

Linux        -> ECONNRESET
FreeBSD 12   -> EOF
OpenBSD 7.2  -> EOF
macos 12.5.1 -> EOF

We can fix this by properly draining B side of things before the close, but we can't reliably test ECONNRESET so turn this into an EOF test for now.