### PR TITLE
Move list functions into a dedicated submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,7 +991,7 @@ val fetch : string -> string = <fun>
     | page -> traceln "%s -> %s" url page
     | exception ex -> traceln "%s -> %a" url Fmt.exn ex
   in
-  Fiber.iter test [
+  Fiber.List.iter test [
     "http://example.com";
     "http://example.com";
     "http://bad.com";
@@ -1012,7 +1012,7 @@ val fetch : string -> string = <fun>
 - : unit = ()
 ```
 
-`Fiber.iter` is like `List.iter` but doesn't wait for each job to finish before starting the next.
+`Fiber.List.iter` is like `List.iter` but doesn't wait for each job to finish before starting the next.
 Notice that we made four requests, but only started two download operations.
 
 This version of the cache remembers failed lookups too.

--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -265,8 +265,15 @@ module Fiber : sig
       The current task remains runnable, but goes to the back of the queue.
       Automatically calls {!check} just before resuming. *)
 
+  (** Concurrent list operations. *)
   module List : sig
-    (** {2 Concurrent list operations} *)
+    (** These functions behave like the ones in the standard library's [List]
+        module, except that multiple items can be processed concurrently.
+
+        They correspond to Lwt's [Lwt_list.*_p] operations. e.g.
+        [Lwt_list.iter_p] becomes [Fiber.List.iter].
+        For the [Lwt_list.*_s] operations, just use the standard library function.
+        e.g. [Lwt_list.iter_s] can be replaced by a plain [List.iter]. *)
 
     val filter : ?max_fibers:int -> ('a -> bool) -> 'a list -> 'a list
     (** [filter f x] is like [List.filter f x] except that the invocations of [f] are

--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -265,27 +265,41 @@ module Fiber : sig
       The current task remains runnable, but goes to the back of the queue.
       Automatically calls {!check} just before resuming. *)
 
-  (** {2 Concurrent list operations} *)
+  module List : sig
+    (** {2 Concurrent list operations} *)
+
+    val filter : ?max_fibers:int -> ('a -> bool) -> 'a list -> 'a list
+    (** [filter f x] is like [List.filter f x] except that the invocations of [f] are
+        run concurrently in separate fibers.
+        @param max_fibers Maximum number of fibers to run concurrently *)
+
+    val map : ?max_fibers:int -> ('a -> 'b) -> 'a list -> 'b list
+    (** [map f x] is like [List.map f x] except that the invocations of [f] are
+        run concurrently in separate fibers.
+        @param max_fibers Maximum number of fibers to run concurrently *)
+
+    val filter_map : ?max_fibers:int -> ('a -> 'b option) -> 'a list -> 'b list
+    (** [filter_map f x] is like [List.filter_map f x] except that the
+        invocations of [f] are run concurrently in separate fibers.
+        @param max_fibers Maximum number of fibers to run concurrently *)
+
+    val iter : ?max_fibers:int -> ('a -> unit) -> 'a list -> unit
+    (** [iter f x] is like [List.iter f x] except that the invocations of [f] are
+        run concurrently in separate fibers.
+        @param max_fibers Maximum number of fibers to run concurrently *)
+  end
 
   val filter : ?max_fibers:int -> ('a -> bool) -> 'a list -> 'a list
-  (** [filter f x] is like [List.filter f x] except that the invocations of [f] are
-      run concurrently in separate fibers.
-      @param max_fibers Maximum number of fibers to run concurrently *)
+  [@@ocaml.deprecated "Use `Eio.Fiber.List.filter` instead."]
 
   val map : ?max_fibers:int -> ('a -> 'b) -> 'a list -> 'b list
-  (** [map f x] is like [List.map f x] except that the invocations of [f] are
-      run concurrently in separate fibers.
-      @param max_fibers Maximum number of fibers to run concurrently *)
+  [@@ocaml.deprecated "Use `Eio.Fiber.List.map instead."]
 
   val filter_map : ?max_fibers:int -> ('a -> 'b option) -> 'a list -> 'b list
-  (** [filter_map f x] is like [List.filter_map f x] except that the
-      invocations of [f] are run concurrently in separate fibers.
-      @param max_fibers Maximum number of fibers to run concurrently *)
+  [@@ocaml.deprecated "Use `Eio.Fiber.List.filter_map instead."]
 
   val iter : ?max_fibers:int -> ('a -> unit) -> 'a list -> unit
-  (** [iter f x] is like [List.iter f x] except that the invocations of [f] are
-      run concurrently in separate fibers.
-      @param max_fibers Maximum number of fibers to run concurrently *)
+  [@@ocaml.deprecated "Use `Eio.Fiber.List.iter instead."]
 
   (** {2 Fiber-local variables}
 

--- a/lib_eio/core/fiber.ml
+++ b/lib_eio/core/fiber.ml
@@ -163,108 +163,113 @@ let check () =
   Cancel.check ctx.cancel_context
 
 (* Some concurrent list operations *)
+module List = struct
 
-let opt_cons x xs =
-  match x with
-  | None -> xs
-  | Some x -> x :: xs
+  let opt_cons x xs =
+    match x with
+    | None -> xs
+    | Some x -> x :: xs
 
-module Limiter : sig
-  (** This is a bit like using a semaphore, but it assumes that there is only a
-      single fiber using it. e.g. you must not call {!use}, {!fork}, etc from
-      two different fibers. *)
+  module Limiter : sig
+    (** This is a bit like using a semaphore, but it assumes that there is only a
+        single fiber using it. e.g. you must not call {!use}, {!fork}, etc from
+        two different fibers. *)
 
-  type t
+    type t
 
-  val create : sw:Switch.t -> int -> t
-  (** [create ~sw n] is a limiter that allows running up to [n] jobs at once. *)
+    val create : sw:Switch.t -> int -> t
+    (** [create ~sw n] is a limiter that allows running up to [n] jobs at once. *)
 
-  val use : t -> ('a -> 'b) -> 'a -> 'b
-  (** [use t fn x] runs [fn x] in this fiber, counting it as one use of [t]. *)
+    val use : t -> ('a -> 'b) -> 'a -> 'b
+    (** [use t fn x] runs [fn x] in this fiber, counting it as one use of [t]. *)
 
-  val fork : t -> ('a -> unit) -> 'a -> unit
-  (** [fork t fn x] runs [fn x] in a new fibre, once a fiber is free. *)
+    val fork : t -> ('a -> unit) -> 'a -> unit
+    (** [fork t fn x] runs [fn x] in a new fibre, once a fiber is free. *)
 
-  val fork_promise_exn : t -> ('a -> 'b) -> 'a -> 'b Promise.t
-  (** [fork_promise_exn t fn x] runs [fn x] in a new fibre, once a fiber is free,
-      and returns a promise for the result. *)
-end = struct
-  type t = {
-    mutable free_fibers : int;
-    cond : unit Single_waiter.t;
-    sw : Switch.t;
-  }
-
-  let max_fibers_err n =
-    Fmt.failwith "max_fibers must be positive (got %d)" n
-
-  let create ~sw max_fibers =
-    if max_fibers <= 0 then max_fibers_err max_fibers;
-    {
-      free_fibers = max_fibers;
-      cond = Single_waiter.create ();
-      sw;
+    val fork_promise_exn : t -> ('a -> 'b) -> 'a -> 'b Promise.t
+    (** [fork_promise_exn t fn x] runs [fn x] in a new fibre, once a fiber is free,
+        and returns a promise for the result. *)
+  end = struct
+    type t = {
+      mutable free_fibers : int;
+      cond : unit Single_waiter.t;
+      sw : Switch.t;
     }
 
-  let await_free t =
-    if t.free_fibers = 0 then Single_waiter.await t.cond t.sw.id;
-    (* If we got woken up then there was a free fiber then. And since we're the
-       only fiber that uses [t], and we were sleeping, it must still be free. *)
-    assert (t.free_fibers > 0);
-    t.free_fibers <- t.free_fibers - 1
+    let max_fibers_err n =
+      Fmt.failwith "max_fibers must be positive (got %d)" n
 
-  let release t =
-    t.free_fibers <- t.free_fibers + 1;
-    if t.free_fibers = 1 then Single_waiter.wake t.cond (Ok ())
+    let create ~sw max_fibers =
+      if max_fibers <= 0 then max_fibers_err max_fibers;
+      {
+        free_fibers = max_fibers;
+        cond = Single_waiter.create ();
+        sw;
+      }
 
-  let use t fn x =
-    await_free t;
-    let r = fn x in
-    release t;
-    r
+    let await_free t =
+      if t.free_fibers = 0 then Single_waiter.await t.cond t.sw.id;
+      (* If we got woken up then there was a free fiber then. And since we're the
+         only fiber that uses [t], and we were sleeping, it must still be free. *)
+      assert (t.free_fibers > 0);
+      t.free_fibers <- t.free_fibers - 1
 
-  let fork_promise_exn t fn x =
-    await_free t;
-    fork_promise_exn ~sw:t.sw (fun () -> let r = fn x in release t; r)
+    let release t =
+      t.free_fibers <- t.free_fibers + 1;
+      if t.free_fibers = 1 then Single_waiter.wake t.cond (Ok ())
 
-  let fork t fn x =
-    await_free t;
-    fork ~sw:t.sw (fun () -> fn x; release t)
+    let use t fn x =
+      await_free t;
+      let r = fn x in
+      release t;
+      r
+
+    let fork_promise_exn t fn x =
+      await_free t;
+      fork_promise_exn ~sw:t.sw (fun () -> let r = fn x in release t; r)
+
+    let fork t fn x =
+      await_free t;
+      fork ~sw:t.sw (fun () -> fn x; release t)
+  end
+
+  let filter_map ?(max_fibers=max_int) fn items =
+    match items with
+    | [] -> []    (* Avoid creating a switch in the simple case *)
+    | items ->
+      Switch.run @@ fun sw ->
+      let limiter = Limiter.create ~sw max_fibers in
+      let rec aux = function
+        | [] -> []
+        | [x] -> Option.to_list (Limiter.use limiter fn x)
+        | x :: xs ->
+          let x = Limiter.fork_promise_exn limiter fn x in
+          let xs = aux xs in
+          opt_cons (Promise.await x) xs
+      in
+      aux items
+
+  let map ?max_fibers fn = filter_map ?max_fibers (fun x -> Some (fn x))
+  let filter ?max_fibers fn = filter_map ?max_fibers (fun x -> if fn x then Some x else None)
+
+  let iter ?(max_fibers=max_int) fn items =
+    match items with
+    | [] -> ()    (* Avoid creating a switch in the simple case *)
+    | items ->
+      Switch.run @@ fun sw ->
+      let limiter = Limiter.create ~sw max_fibers in
+      let rec aux = function
+        | [] -> ()
+        | [x] -> Limiter.use limiter fn x
+        | x :: xs ->
+          Limiter.fork limiter fn x;
+          aux xs
+      in
+      aux items
+
 end
 
-let filter_map ?(max_fibers=max_int) fn items =
-  match items with
-  | [] -> []    (* Avoid creating a switch in the simple case *)
-  | items ->
-    Switch.run @@ fun sw ->
-    let limiter = Limiter.create ~sw max_fibers in
-    let rec aux = function
-      | [] -> []
-      | [x] -> Option.to_list (Limiter.use limiter fn x)
-      | x :: xs ->
-        let x = Limiter.fork_promise_exn limiter fn x in
-        let xs = aux xs in
-        opt_cons (Promise.await x) xs
-    in
-    aux items
-
-let map ?max_fibers fn = filter_map ?max_fibers (fun x -> Some (fn x))
-let filter ?max_fibers fn = filter_map ?max_fibers (fun x -> if fn x then Some x else None)
-
-let iter ?(max_fibers=max_int) fn items =
-  match items with
-  | [] -> ()    (* Avoid creating a switch in the simple case *)
-  | items ->
-    Switch.run @@ fun sw ->
-    let limiter = Limiter.create ~sw max_fibers in
-    let rec aux = function
-      | [] -> ()
-      | [x] -> Limiter.use limiter fn x
-      | x :: xs ->
-        Limiter.fork limiter fn x;
-        aux xs
-    in
-    aux items
+include List
 
 type 'a key = 'a Hmap.key
 

--- a/tests/fiber.md
+++ b/tests/fiber.md
@@ -340,7 +340,7 @@ let crash_on_three x =
 
 ```ocaml
 # Eio_mock.Backend.run @@ fun () ->
-  Fiber.filter (process is_even) [1; 2; 3; 4]
+  Fiber.List.filter (process is_even) [1; 2; 3; 4]
   |> traceln "%a" Fmt.(Dump.list int);;
 +Start 1
 +Start 2
@@ -356,7 +356,7 @@ let crash_on_three x =
 
 ```ocaml
 # Eio_mock.Backend.run @@ fun () ->
-  Fiber.map (process string_even) [1; 2; 3; 4]
+  Fiber.List.map (process string_even) [1; 2; 3; 4]
   |> traceln "%a" Fmt.Dump.(list (option string));;
 +Start 1
 +Start 2
@@ -372,7 +372,7 @@ let crash_on_three x =
 
 ```ocaml
 # Eio_mock.Backend.run @@ fun () ->
-  Fiber.filter_map (process string_even) [1; 2; 3; 4]
+  Fiber.List.filter_map (process string_even) [1; 2; 3; 4]
   |> traceln "%a" Fmt.Dump.(list string);;
 +Start 1
 +Start 2
@@ -390,7 +390,7 @@ If any fiber raises, everything is cancelled:
 
 ```ocaml
 # Eio_mock.Backend.run @@ fun () ->
-  Fiber.filter_map (process crash_on_three) [1; 2; 3; 4]
+  Fiber.List.filter_map (process crash_on_three) [1; 2; 3; 4]
   |> traceln "%a" Fmt.Dump.(list string);;
 +Start 1
 +Start 2
@@ -410,7 +410,7 @@ The number of concurrent fibers can be limited:
   let finish i = Promise.resolve (snd (ps.(i))) in
   Fiber.both
     (fun () ->
-       Fiber.map ~max_fibers:2 (process await) (List.init 4 Fun.id)
+       Fiber.List.map ~max_fibers:2 (process await) (List.init 4 Fun.id)
        |> traceln "%a" Fmt.(Dump.list string)
     )
     (fun () ->
@@ -443,7 +443,7 @@ Handling exceptions while waiting for a free fiber:
   let finish i = Promise.resolve (snd (ps.(i))) in
   Fiber.both
     (fun () ->
-       Fiber.map ~max_fibers:1 (process await) (List.init 2 Fun.id)
+       Fiber.List.map ~max_fibers:1 (process await) (List.init 2 Fun.id)
        |> traceln "%a" Fmt.(Dump.list string)
     )
     (fun () ->
@@ -463,7 +463,7 @@ Simple iteration:
   let finish i = Promise.resolve (snd (ps.(i))) () in
   Fiber.both
     (fun () ->
-       Fiber.iter ~max_fibers:2 (process await) (List.init 4 Fun.id)
+       Fiber.List.iter ~max_fibers:2 (process await) (List.init 4 Fun.id)
     )
     (fun () ->
        finish 1;


### PR DESCRIPTION
As the title says: this PR introduces a submodule of `Fiber` called `List` to collect the list-related functions.

- The name `Eio.Fiber.map` could suggest mapping fibers.
- Lists are centrals but Seqs are also becoming important so having List functions unqualified in the main namespace may not be the best.
- At some point there'll be contributions to add `rev_map`, `mapi`, `filteri`, etc. and the main namespace would get bloated quickly.