### PR TITLE
direct implementation of Flow.source_string

### DIFF
--- a/lib_eio/flow.ml
+++ b/lib_eio/flow.ml
@@ -55,7 +55,20 @@ let cstruct_source data : source =
       avail
   end
 
-let string_source s = cstruct_source [Cstruct.of_string s]
+let string_source s : source =
+  object
+    val mutable offset = 0
+
+    inherit source
+
+    method read_into dst =
+      if offset = String.length s then raise End_of_file;
+
+      let len = min (Cstruct.length dst) (String.length s - offset) in
+      Cstruct.blit_from_string s offset dst 0 len;
+      offset <- offset + len;
+      len
+  end
 
 class virtual sink = object (_ : <Generic.t; ..>)
   method probe _ = None

--- a/tests/flow.md
+++ b/tests/flow.md
@@ -68,7 +68,7 @@ Exception: End_of_file.
 - : unit = ()
 ```
 
-Copying from src using a plain buffer (the default):
+Copying from a string src:
 
 ```ocaml
 # run @@ fun () ->
@@ -80,11 +80,25 @@ Copying from src using a plain buffer (the default):
 +dst: wrote "bar"
 - : unit = ()
 ```
+
+Copying from src using a plain buffer (the default):
+
+```ocaml
+# run @@ fun () ->
+  let src = Eio.Flow.cstruct_source [Cstruct.of_string "foobar"] in
+  let dst = Eio_mock.Flow.make "dst" in
+  Eio_mock.Flow.on_copy_bytes dst [`Return 3; `Return 5];
+  Eio.Flow.copy src dst;;
++dst: wrote "foo"
++dst: wrote "bar"
+- : unit = ()
+```
+
 Copying from src using `Read_source_buffer`:
 
 ```ocaml
 # run @@ fun () ->
-  let src = Eio.Flow.string_source "foobar" in
+  let src = Eio.Flow.cstruct_source [Cstruct.of_string "foobar"] in
   let dst = Eio_mock.Flow.make "dst" in
   Eio_mock.Flow.set_copy_method dst `Read_source_buffer;
   Eio_mock.Flow.on_copy_bytes dst [`Return 3; `Return 5];


### PR DESCRIPTION
this loses the `Read_source_buffer` read method, but removes the intermediate allocation + copy of a cstruct.