### PR TITLE
Implement Flow.write and write_from

### DIFF
--- a/lib_eio/flow.ml
+++ b/lib_eio/flow.ml
@@ -70,10 +70,13 @@ let string_source s : source =
       len
   end
 
-class virtual sink = object (_ : <Generic.t; ..>)
+class virtual sink = object (self : <Generic.t; ..>)
   method probe _ = None
   method virtual copy : 'a. (#source as 'a) -> unit
+  method write bufs = self#copy (cstruct_source bufs)
 end
+
+let write (t : #sink) (bufs : Cstruct.t list) = t#write bufs
 
 let copy (src : #source) (dst : #sink) = dst#copy src
 
@@ -91,10 +94,13 @@ let buffer_sink b =
           Buffer.add_string b (Cstruct.to_string ~len:got buf)
         done
       with End_of_file -> ()
+
+    method! write bufs =
+      List.iter (fun buf -> Buffer.add_bytes b (Cstruct.to_bytes buf)) bufs
   end
 
 class virtual two_way = object (_ : <source; sink; ..>)
-  method probe _ = None
+  inherit sink
   method read_methods = []
 
   method virtual shutdown : shutdown_command -> unit

--- a/lib_eio/flow.mli
+++ b/lib_eio/flow.mli
@@ -62,7 +62,16 @@ type read_method += Read_source_buffer of ((Cstruct.t list -> int) -> unit)
 class virtual sink : object
   inherit Generic.t
   method virtual copy : 'a. (#source as 'a) -> unit
+
+  method write : Cstruct.t list -> unit
+  (** The default implementation is [copy (cstruct_source ...)], but it can be overridden for speed. *)
 end
+
+val write : #sink -> Cstruct.t list -> unit
+(** [write dst bufs] writes all bytes from [bufs].
+
+    This is a low level API, consider using {!copy} if possible as it
+    may allow optimizations. *)
 
 val copy : #source -> #sink -> unit
 (** [copy src dst] copies data from [src] to [dst] until end-of-file. *)

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1044,6 +1044,8 @@ let flow fd =
 
     method read_methods = []
 
+    method write bufs = Low_level.writev fd bufs
+
     method copy src =
       match get_fd_opt src with
       | Some src -> fast_copy_try_splice src fd

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -597,6 +597,10 @@ let flow fd = object (_ : <source; sink; ..>)
 
   method read_methods = []
 
+  method write bufs =
+    let bufs = List.map Cstruct.to_bigarray bufs in
+    File.write fd bufs |> or_raise
+
   method copy src =
     let buf = Luv.Buffer.create 4096 in
     try
@@ -623,6 +627,10 @@ let socket sock = object
   method read_into buf =
     let buf = Cstruct.to_bigarray buf in
     Stream.read_into sock buf
+
+  method! write bufs =
+    let bufs = List.map Cstruct.to_bigarray bufs in
+    Stream.write sock bufs
 
   method copy src =
     let buf = Luv.Buffer.create 4096 in

--- a/tests/flow.md
+++ b/tests/flow.md
@@ -107,3 +107,14 @@ Copying from src using `Read_source_buffer`:
 +dst: wrote (rsb) ["bar"]
 - : unit = ()
 ```
+
+## write
+
+```ocaml
+# run @@ fun () ->
+  let dst = Eio_mock.Flow.make "dst" in
+  Eio_mock.Flow.on_copy_bytes dst [`Return 6];
+  Eio.Flow.write dst [Cstruct.of_string "foobar"];;
++dst: wrote "foobar"
+- : unit = ()
+```


### PR DESCRIPTION
These are the corollary from Flow.read and read_into.

-- 

Not super sure about `write_from` naming, but it's the closest to the opposite of `read_into` I can think of.