### PR TITLE
Expose `Eio.Fiber.Not_first`

### DIFF
--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -173,6 +173,10 @@ end
 
 (** @canonical Eio.Fiber *)
 module Fiber : sig
+  exception Not_first
+  (** Exception attached to [Cancel.Cancelled] when an operation is cancelled
+      in one of the racing functions described below. *)
+
   (** Within a domain, only one fiber can be running at a time.
       A fiber runs until it performs an IO operation (directly or indirectly).
       At that point, it may be suspended and the next fiber on the run queue runs. *)


### PR DESCRIPTION
Useful to match against in e.g.:

```ocaml
Fiber.first
 (fun () ->
   try 
     `Ok (operation_that_can_switch_fibers)
   with
   | Eio.Cancel.Cancelled Fiber.Not_first (* right now need to use `Eio__core__Fiber.Not_first` *) ->
     `Canceled)
 (fun () ->
    Promise.await some_promise;
   `Ok ())

```