### PR TITLE
Add Eio_mock.Clock

### DIFF
--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -109,55 +109,7 @@ module Domain_manager : sig
 end
 
 (** Clocks, time, sleeping and timeouts. *)
-module Time : sig
-  class virtual clock : object
-    method virtual now : float
-    method virtual sleep_until : float -> unit
-  end
-
-  val now : #clock -> float
-  (** [now t] is the current time according to [t]. *)
-
-  val sleep_until : #clock -> float -> unit
-  (** [sleep_until t time] waits until the given time is reached. *)
-
-  val sleep : #clock -> float -> unit
-  (** [sleep t d] waits for [d] seconds. *)
-
-  (** {2 Timeouts} *)
-
-  exception Timeout
-
-  val with_timeout : #clock -> float -> (unit -> ('a, 'e) result) -> ('a, [> `Timeout] as 'e) result
-  (** [with_timeout clock d fn] runs [fn ()] but cancels it after [d] seconds. *)
-
-  val with_timeout_exn : #clock -> float -> (unit -> 'a) -> 'a
-  (** [with_timeout_exn clock d fn] runs [fn ()] but cancels it after [d] seconds,
-      raising exception {!exception-Timeout}. *)
-
-  (** Timeout values. *)
-  module Timeout : sig
-    type t
-
-    val of_s : #clock -> float -> t
-    (** [of_s clock duration] is a timeout of [duration] seconds, as measured by [clock].
-        Internally, this is just the tuple [(clock, duration)]. *)
-
-    val none : t
-    (** [none] is an infinite timeout. *)
-
-    val run : t -> (unit -> ('a, 'e) result) -> ('a, [> `Timeout] as 'e) result
-    (** [run t fn] runs [fn ()] but cancels it if it takes longer than allowed by timeout [t]. *)
-
-    val run_exn : t -> (unit -> 'a) -> 'a
-    (** [run_exn t fn] runs [fn ()] but cancels it if it takes longer than allowed by timeout [t],
-        raising exception {!exception-Timeout}. *)
-
-    val pp : t Fmt.t
-    (** [pp] formats a timeout as a duration (e.g. "5s").
-        This is intended for use in error messages and logging and is rounded. *)
-  end
-end
+module Time = Time
 
 (** Operations on open files. *)
 module File = File

--- a/lib_eio/mock/clock.ml
+++ b/lib_eio/mock/clock.ml
@@ -1,0 +1,67 @@
+open Eio.Std
+
+type t = <
+  Eio.Time.clock;
+  advance : unit;
+  set_time : float -> unit;
+>
+
+module Key = struct
+  type t = < >
+  let compare = compare
+end
+
+module Job = struct
+  type t = {
+    time : float;
+    resolver : unit Promise.u;
+  }
+
+  let compare a b = Float.compare a.time b.time
+end
+
+module Q = Psq.Make(Key)(Job)
+
+let make () =
+  object (self)
+    inherit Eio.Time.clock
+
+    val mutable now = 0.0
+    val mutable q = Q.empty
+
+    method now = now
+
+    method sleep_until time =
+      if time <= now then Fiber.yield ()
+      else (
+        let p, r = Promise.create () in
+        let k = object end in
+        q <- Q.add k { time; resolver = r } q;
+        try
+          Promise.await p
+        with Eio.Cancel.Cancelled _ as ex ->
+          q <- Q.remove k q;
+          raise ex
+      )
+
+    method set_time time =
+      let rec drain () =
+        match Q.min q with
+        | Some (_, v) when v.time <= time ->
+          Promise.resolve v.resolver ();
+          q <- Option.get (Q.rest q);
+          drain ()
+        | _ -> ()
+      in
+      drain ();
+      now <- time;
+      traceln "mock time is now %g" now
+
+    method advance =
+      match Q.min q with
+      | None -> invalid_arg "No further events scheduled on mock clock"
+      | Some (_, v) -> self#set_time v.time
+  end
+
+let set_time (t:t) time = t#set_time time
+let advance (t:t) = t#advance

--- a/lib_eio/mock/clock.mli
+++ b/lib_eio/mock/clock.mli
@@ -1,0 +1,17 @@
+type t = <
+  Eio.Time.clock;
+  advance : unit;
+  set_time : float -> unit;
+>
+
+val make : unit -> t
+(** [make ()] is a new clock.
+
+    The time is initially set to 0.0 and doesn't change except when you call {!advance} or {!set_time}. *)
+
+val advance : t -> unit
+(** [advance t] sets the time to the next scheduled event (adding any due fibers to the run queue).
+    @raise Invalid_argument if nothing is scheduled. *)
+
+val set_time : t -> float -> unit
+(** [set_time t time] sets the time to [time] (adding any due fibers to the run queue). *)

--- a/lib_eio/mock/eio_mock.ml
+++ b/lib_eio/mock/eio_mock.ml
@@ -2,4 +2,5 @@ module Action = Action
 module Handler = Handler
 module Flow = Flow
 module Net = Net
+module Clock = Clock
 module Backend = Backend

--- a/lib_eio/mock/eio_mock.mli
+++ b/lib_eio/mock/eio_mock.mli
@@ -156,6 +156,9 @@ module Net : sig
   (** [on_accept socket actions] configures how to respond when the server calls "accept". *)
 end
 
+(** A mock {!Eio.Time} clock for testing timeouts. *)
+module Clock = Clock
+
 (** {2 Backend for mocks}
 
     The mocks can be used with any backend, but if you don't need any IO then you can use this one

--- a/lib_eio/time.mli
+++ b/lib_eio/time.mli
@@ -1,0 +1,47 @@
+class virtual clock : object
+  method virtual now : float
+  method virtual sleep_until : float -> unit
+end
+
+val now : #clock -> float
+(** [now t] is the current time according to [t]. *)
+
+val sleep_until : #clock -> float -> unit
+(** [sleep_until t time] waits until the given time is reached. *)
+
+val sleep : #clock -> float -> unit
+(** [sleep t d] waits for [d] seconds. *)
+
+(** {2 Timeouts} *)
+
+exception Timeout
+
+val with_timeout : #clock -> float -> (unit -> ('a, 'e) result) -> ('a, [> `Timeout] as 'e) result
+(** [with_timeout clock d fn] runs [fn ()] but cancels it after [d] seconds. *)
+
+val with_timeout_exn : #clock -> float -> (unit -> 'a) -> 'a
+(** [with_timeout_exn clock d fn] runs [fn ()] but cancels it after [d] seconds,
+    raising exception {!exception-Timeout}. *)
+
+(** Timeout values. *)
+module Timeout : sig
+  type t
+
+  val of_s : #clock -> float -> t
+  (** [of_s clock duration] is a timeout of [duration] seconds, as measured by [clock].
+      Internally, this is just the tuple [(clock, duration)]. *)
+
+  val none : t
+  (** [none] is an infinite timeout. *)
+
+  val run : t -> (unit -> ('a, 'e) result) -> ('a, [> `Timeout] as 'e) result
+  (** [run t fn] runs [fn ()] but cancels it if it takes longer than allowed by timeout [t]. *)
+
+  val run_exn : t -> (unit -> 'a) -> 'a
+  (** [run_exn t fn] runs [fn ()] but cancels it if it takes longer than allowed by timeout [t],
+      raising exception {!exception-Timeout}. *)
+
+  val pp : t Fmt.t
+  (** [pp] formats a timeout as a duration (e.g. "5s").
+      This is intended for use in error messages and logging and is rounded. *)
+end


### PR DESCRIPTION
This adds a mock clock that can be used for testing time-related functions, such as the timeout handling in #302 (see https://github.com/talex5/eio/pull/new/with_connect for a draft updated version of that).

I also moved the signature for Time from eio.mli to time.mli, so that other Eio modules can refer to the type in future.

/cc @bikallem