### PR TITLE
Qualify `Effect.Unhandled`

### DIFF
--- a/lib_eio/core/debug.ml
+++ b/lib_eio/core/debug.ml
@@ -29,7 +29,7 @@ let traceln ?__POS__ fmt =
     match Fiber.get traceln_key with
     | Some { traceln } -> traceln
     | None
-    | exception Unhandled -> default_traceln
+    | exception (Effect.Unhandled _) -> default_traceln
   in
   traceln ?__POS__ fmt
 


### PR DESCRIPTION
https://github.com/ocaml/ocaml/pull/11423 is landing in the next pre-release of OCaml 5, which moves the `Unhandled` exception to the `Effect` module.