### PR TITLE
Add subprocess support

### DIFF
--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -36,7 +36,7 @@ module Stdenv = struct
     stdout : Flow.sink;
     stderr : Flow.sink;
     net : Net.t;
-    process : Process.t;
+    process : Process.mgr;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
     fs : Fs.dir Path.t;
@@ -49,7 +49,7 @@ module Stdenv = struct
   let stdout (t : <stdout : #Flow.sink;   ..>) = t#stdout
   let stderr (t : <stderr : #Flow.sink;   ..>) = t#stderr
   let net (t : <net : #Net.t; ..>) = t#net
-  let process (t : <process : #Process.t; ..>) = t#process
+  let process (t : <process : #Process.mgr; ..>) = t#process
   let domain_mgr (t : <domain_mgr : #Domain_manager.t; ..>) = t#domain_mgr
   let clock (t : <clock : #Time.clock; ..>) = t#clock
   let secure_random (t: <secure_random : #Flow.source; ..>) = t#secure_random

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -23,6 +23,7 @@ module Flow = Flow
 module Buf_read = Buf_read
 module Buf_write = Buf_write
 module Net = Net
+module Process = Process
 module Domain_manager = Domain_manager
 module Time = Time
 module File = File
@@ -35,6 +36,7 @@ module Stdenv = struct
     stdout : Flow.sink;
     stderr : Flow.sink;
     net : Net.t;
+    process : Process.t;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
     fs : Fs.dir Path.t;
@@ -47,6 +49,7 @@ module Stdenv = struct
   let stdout (t : <stdout : #Flow.sink;   ..>) = t#stdout
   let stderr (t : <stderr : #Flow.sink;   ..>) = t#stderr
   let net (t : <net : #Net.t; ..>) = t#net
+  let process (t : <process : #Process.t; ..>) = t#process
   let domain_mgr (t : <domain_mgr : #Domain_manager.t; ..>) = t#domain_mgr
   let clock (t : <clock : #Time.clock; ..>) = t#clock
   let secure_random (t: <secure_random : #Flow.source; ..>) = t#secure_random

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -36,7 +36,7 @@ module Stdenv = struct
     stdout : Flow.sink;
     stderr : Flow.sink;
     net : Net.t;
-    process : Process.mgr;
+    process_mgr : Process.mgr;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
     fs : Fs.dir Path.t;
@@ -49,7 +49,7 @@ module Stdenv = struct
   let stdout (t : <stdout : #Flow.sink;   ..>) = t#stdout
   let stderr (t : <stderr : #Flow.sink;   ..>) = t#stderr
   let net (t : <net : #Net.t; ..>) = t#net
-  let process (t : <process : #Process.mgr; ..>) = t#process
+  let process_mgr (t : <process_mgr : #Process.mgr; ..>) = t#process_mgr
   let domain_mgr (t : <domain_mgr : #Domain_manager.t; ..>) = t#domain_mgr
   let clock (t : <clock : #Time.clock; ..>) = t#clock
   let secure_random (t: <secure_random : #Flow.source; ..>) = t#secure_random

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -180,7 +180,7 @@ module Stdenv : sig
     stdout : Flow.sink;
     stderr : Flow.sink;
     net : Net.t;
-    process : Process.t;
+    process : Process.mgr;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
     fs : Fs.dir Path.t;
@@ -227,7 +227,9 @@ module Stdenv : sig
       To use this, see {!Domain_manager}.
   *)
 
-  val process : <process : #Process.t as 'a; ..> -> 'a
+  val process : <process : #Process.mgr as 'a; ..> -> 'a
+  (** [process t] allows spawning subprocesses. This is a powerful capability
+      and should be used with care. *)
 
   val domain_mgr : <domain_mgr : #Domain_manager.t as 'a; ..> -> 'a
   (** [domain_mgr t] allows running code on other cores. *)

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -84,6 +84,9 @@ module Buf_write = Buf_write
 (** Networking. *)
 module Net = Net
 
+(** Subprocesses *)
+module Process = Process
+
 (** Parallel computation across multiple CPU cores. *)
 module Domain_manager : sig
   class virtual t : object
@@ -177,6 +180,7 @@ module Stdenv : sig
     stdout : Flow.sink;
     stderr : Flow.sink;
     net : Net.t;
+    process : Process.t;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
     fs : Fs.dir Path.t;
@@ -222,6 +226,8 @@ module Stdenv : sig
 
       To use this, see {!Domain_manager}.
   *)
+
+  val process : <process : #Process.t as 'a; ..> -> 'a
 
   val domain_mgr : <domain_mgr : #Domain_manager.t as 'a; ..> -> 'a
   (** [domain_mgr t] allows running code on other cores. *)

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -228,8 +228,7 @@ module Stdenv : sig
   *)
 
   val process : <process : #Process.mgr as 'a; ..> -> 'a
-  (** [process t] allows spawning subprocesses. This is a powerful capability
-      and should be used with care. *)
+  (** [process t] allows spawning subprocesses. *)
 
   val domain_mgr : <domain_mgr : #Domain_manager.t as 'a; ..> -> 'a
   (** [domain_mgr t] allows running code on other cores. *)

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -180,7 +180,7 @@ module Stdenv : sig
     stdout : Flow.sink;
     stderr : Flow.sink;
     net : Net.t;
-    process : Process.mgr;
+    process_mgr : Process.mgr;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
     fs : Fs.dir Path.t;
@@ -227,8 +227,8 @@ module Stdenv : sig
       To use this, see {!Domain_manager}.
   *)
 
-  val process : <process : #Process.mgr as 'a; ..> -> 'a
-  (** [process t] allows spawning subprocesses. *)
+  val process_mgr : <process_mgr : #Process.mgr as 'a; ..> -> 'a
+  (** [process_mgr t] allows spawning subprocesses. *)
 
   val domain_mgr : <domain_mgr : #Domain_manager.t as 'a; ..> -> 'a
   (** [domain_mgr t] allows running code on other cores. *)

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -18,8 +18,8 @@ let stop proc = proc#stop
 
 class virtual mgr = object (_ : #Generic.t)
   method probe _ = None
-  method virtual spawn : sw:Switch.t -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
-  method virtual spawn_detached : ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
+  method virtual spawn : sw:Switch.t -> ?cwd:Fs.dir Path.t -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
+  method virtual spawn_detached : ?cwd:Fs.dir Path.t -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
 end
 
 let spawn ~sw t ?cwd ?stderr ?stdout ?stdin cmd args = t#spawn ~sw ?cwd ?stderr ?stdout ?stdin  cmd args

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -1,0 +1,26 @@
+type status = Exited of int | Signaled of int | Stopped of int
+
+let pp_status ppf = function
+  | Exited i -> Format.fprintf ppf "Exited %i" i
+  | Signaled i -> Format.fprintf ppf "Signalled %i" i
+  | Stopped i -> Format.fprintf ppf "Stopped %i" i
+
+class virtual process = object (_ : #Generic.t)
+  method probe _ = None
+  method virtual pid : int
+  method virtual status : status
+  method virtual stop : unit
+end
+
+let pid proc = proc#pid
+let status proc = proc#status
+let stop proc = proc#stop
+
+class virtual t = object (_ : #Generic.t)
+  method probe _ = None
+  method virtual spawn : sw:Switch.t -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> process
+  method virtual spawn_detached : ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> process
+end
+
+let spawn ~sw t ?cwd ?stderr ?stdout ?stdin cmd args = t#spawn ~sw ?cwd ?stderr ?stdout ?stdin  cmd args
+let spawn_detached t ?cwd ?stderr ?stdout ?stdin cmd args = t#spawn_detached ?cwd ?stderr ?stdout ?stdin cmd args

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -18,9 +18,9 @@ let stop proc = proc#stop
 
 class virtual mgr = object (_ : #Generic.t)
   method probe _ = None
-  method virtual spawn : sw:Switch.t -> ?cwd:Fs.dir Path.t -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
-  method virtual spawn_detached : ?cwd:Fs.dir Path.t -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
+  method virtual spawn : sw:Switch.t -> ?cwd:Fs.dir Path.t -> stdin:Flow.source -> stdout:Flow.sink -> stderr:Flow.sink -> string -> string list -> t
+  method virtual spawn_detached : ?cwd:Fs.dir Path.t -> stdin:Flow.source -> stdout:Flow.sink -> stderr:Flow.sink -> string -> string list -> t
 end
 
-let spawn ~sw t ?cwd ?stderr ?stdout ?stdin cmd args = t#spawn ~sw ?cwd ?stderr ?stdout ?stdin  cmd args
-let spawn_detached t ?cwd ?stderr ?stdout ?stdin cmd args = t#spawn_detached ?cwd ?stderr ?stdout ?stdin cmd args
+let spawn ~sw t ?cwd ~stdin ~stdout ~stderr cmd args = t#spawn ~sw ?cwd ~stdin ~stdout ~stderr cmd args
+let spawn_detached t ?cwd ~stdin ~stdout ~stderr cmd args = t#spawn_detached ?cwd ~stdin ~stdout ~stderr cmd args

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -8,7 +8,7 @@ let pp_status ppf = function
 class virtual t = object (_ : #Generic.t)
   method probe _ = None
   method virtual pid : int
-  method virtual status : status
+  method virtual status : status Promise.t
   method virtual stop : unit
 end
 

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -5,7 +5,7 @@ let pp_status ppf = function
   | Signaled i -> Format.fprintf ppf "Signalled %i" i
   | Stopped i -> Format.fprintf ppf "Stopped %i" i
 
-class virtual process = object (_ : #Generic.t)
+class virtual t = object (_ : #Generic.t)
   method probe _ = None
   method virtual pid : int
   method virtual status : status
@@ -16,10 +16,10 @@ let pid proc = proc#pid
 let status proc = proc#status
 let stop proc = proc#stop
 
-class virtual t = object (_ : #Generic.t)
+class virtual mgr = object (_ : #Generic.t)
   method probe _ = None
-  method virtual spawn : sw:Switch.t -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> process
-  method virtual spawn_detached : ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> process
+  method virtual spawn : sw:Switch.t -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
+  method virtual spawn_detached : ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
 end
 
 let spawn ~sw t ?cwd ?stderr ?stdout ?stdin cmd args = t#spawn ~sw ?cwd ?stderr ?stdout ?stdin  cmd args

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -8,12 +8,12 @@ let pp_status ppf = function
 class virtual t = object (_ : #Generic.t)
   method probe _ = None
   method virtual pid : int
-  method virtual status : status Promise.t
+  method virtual await_exit : status
   method virtual stop : unit
 end
 
 let pid proc = proc#pid
-let status proc = proc#status
+let await_exit proc = proc#await_exit
 let stop proc = proc#stop
 
 class virtual mgr = object (_ : #Generic.t)

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -2,24 +2,24 @@ type status = Exited of int | Signaled of int | Stopped of int
 
 val pp_status : Format.formatter -> status -> unit
 
-class virtual process : object
+class virtual t : object
     inherit Generic.t
     method virtual pid : int
     method virtual status : status
     method virtual stop : unit
 end
 
-val pid : #process -> int
+val pid : #t -> int
 (** The process ID *)
 
-val status : #process -> status
+val status : #t -> status
 (** Checks the status of the subprocess, this will block waiting for the subprocess
     to terminate or be stopped by a signal. *)
 
-val stop : #process -> unit
+val stop : #t -> unit
 (** Stop a running subprocess *)
 
-class virtual t : object
+class virtual mgr : object
     inherit Generic.t
     method virtual spawn : 
         sw:Switch.t -> 
@@ -29,7 +29,7 @@ class virtual t : object
         ?stdin:Flow.source ->
         string ->
         string list ->
-        process
+        t
     
     method virtual spawn_detached :
         ?cwd:string ->
@@ -38,13 +38,14 @@ class virtual t : object
         ?stdin:Flow.source ->
         string ->
         string list ->
-        process
+        t
 end
+(** A process manager capable of spawning new processes. *)
 
-val spawn : sw:Switch.t -> #t -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> process
+val spawn : sw:Switch.t -> #mgr -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
 (** [spawn ~sw t cmd] creates a new subprocess that is connected to the
     switch [sw]. The standard input and outputs redirect to nothing by default. *)
 
-val spawn_detached : #t -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> process
+val spawn_detached : #mgr -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
 (** [spawn_detached t cmd] is like {! spawn} but the new subprocess is not
     attached to any switch. *)

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -1,0 +1,50 @@
+type status = Exited of int | Signaled of int | Stopped of int
+
+val pp_status : Format.formatter -> status -> unit
+
+class virtual process : object
+    inherit Generic.t
+    method virtual pid : int
+    method virtual status : status
+    method virtual stop : unit
+end
+
+val pid : #process -> int
+(** The process ID *)
+
+val status : #process -> status
+(** Checks the status of the subprocess, this will block waiting for the subprocess
+    to terminate or be stopped by a signal. *)
+
+val stop : #process -> unit
+(** Stop a running subprocess *)
+
+class virtual t : object
+    inherit Generic.t
+    method virtual spawn : 
+        sw:Switch.t -> 
+        ?cwd:string ->
+        ?stderr:Flow.sink ->
+        ?stdout:Flow.sink -> 
+        ?stdin:Flow.source ->
+        string ->
+        string list ->
+        process
+    
+    method virtual spawn_detached :
+        ?cwd:string ->
+        ?stderr:Flow.sink ->
+        ?stdout:Flow.sink -> 
+        ?stdin:Flow.source ->
+        string ->
+        string list ->
+        process
+end
+
+val spawn : sw:Switch.t -> #t -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> process
+(** [spawn ~sw t cmd] creates a new subprocess that is connected to the
+    switch [sw]. The standard input and outputs redirect to nothing by default. *)
+
+val spawn_detached : #t -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> process
+(** [spawn_detached t cmd] is like {! spawn} but the new subprocess is not
+    attached to any switch. *)

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -24,28 +24,28 @@ class virtual mgr : object
     method virtual spawn : 
         sw:Switch.t -> 
         ?cwd:Fs.dir Path.t ->
-        ?stderr:Flow.sink ->
-        ?stdout:Flow.sink -> 
-        ?stdin:Flow.source ->
+        stdin:Flow.source ->
+        stdout:Flow.sink -> 
+        stderr:Flow.sink ->
         string ->
         string list ->
         t
     
     method virtual spawn_detached :
         ?cwd:Fs.dir Path.t ->
-        ?stderr:Flow.sink ->
-        ?stdout:Flow.sink -> 
-        ?stdin:Flow.source ->
+        stdin:Flow.source ->
+        stdout:Flow.sink -> 
+        stderr:Flow.sink ->
         string ->
         string list ->
         t
 end
 (** A process manager capable of spawning new processes. *)
 
-val spawn : sw:Switch.t -> #mgr -> ?cwd:Fs.dir Path.t -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
+val spawn : sw:Switch.t -> #mgr -> ?cwd:Fs.dir Path.t -> stdin:Flow.source -> stdout:Flow.sink -> stderr:Flow.sink -> string -> string list -> t
 (** [spawn ~sw t cmd] creates a new subprocess that is connected to the
     switch [sw]. The standard input and outputs redirect to nothing by default. *)
 
-val spawn_detached : #mgr -> ?cwd:Fs.dir Path.t -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
+val spawn_detached : #mgr -> ?cwd:Fs.dir Path.t -> stdin:Flow.source -> stdout:Flow.sink -> stderr:Flow.sink -> string -> string list -> t
 (** [spawn_detached t cmd] is like {! spawn} but the new subprocess is not
     attached to any switch. *)

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -23,7 +23,7 @@ class virtual mgr : object
     inherit Generic.t
     method virtual spawn : 
         sw:Switch.t -> 
-        ?cwd:string ->
+        ?cwd:Fs.dir Path.t ->
         ?stderr:Flow.sink ->
         ?stdout:Flow.sink -> 
         ?stdin:Flow.source ->
@@ -32,7 +32,7 @@ class virtual mgr : object
         t
     
     method virtual spawn_detached :
-        ?cwd:string ->
+        ?cwd:Fs.dir Path.t ->
         ?stderr:Flow.sink ->
         ?stdout:Flow.sink -> 
         ?stdin:Flow.source ->
@@ -42,10 +42,10 @@ class virtual mgr : object
 end
 (** A process manager capable of spawning new processes. *)
 
-val spawn : sw:Switch.t -> #mgr -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
+val spawn : sw:Switch.t -> #mgr -> ?cwd:Fs.dir Path.t -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
 (** [spawn ~sw t cmd] creates a new subprocess that is connected to the
     switch [sw]. The standard input and outputs redirect to nothing by default. *)
 
-val spawn_detached : #mgr -> ?cwd:string -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
+val spawn_detached : #mgr -> ?cwd:Fs.dir Path.t -> ?stderr:Flow.sink -> ?stdout:Flow.sink -> ?stdin:Flow.source -> string -> string list -> t
 (** [spawn_detached t cmd] is like {! spawn} but the new subprocess is not
     attached to any switch. *)

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -5,14 +5,14 @@ val pp_status : Format.formatter -> status -> unit
 class virtual t : object
     inherit Generic.t
     method virtual pid : int
-    method virtual status : status
+    method virtual status : status Promise.t
     method virtual stop : unit
 end
 
 val pid : #t -> int
 (** The process ID *)
 
-val status : #t -> status
+val status : #t -> status Promise.t
 (** Checks the status of the subprocess, this will block waiting for the subprocess
     to terminate or be stopped by a signal. *)
 

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -43,9 +43,12 @@ end
 (** A process manager capable of spawning new processes. *)
 
 val spawn : sw:Switch.t -> #mgr -> ?cwd:Fs.dir Path.t -> stdin:Flow.source -> stdout:Flow.sink -> stderr:Flow.sink -> string -> string list -> t
-(** [spawn ~sw t cmd] creates a new subprocess that is connected to the
-    switch [sw]. The standard input and outputs redirect to nothing by default. *)
+(** [spawn ~sw mgr ?cwd ~stdin ~stdout ~stderr cmd args] creates a new subprocess that is connected to the
+    switch [sw]. A process will be stopped when the switch is released.
+    
+    You must provide a standard input and outputs that are backed by file descriptors and
+    [cwd] will optionally change the current working directory of the process.*)
 
 val spawn_detached : #mgr -> ?cwd:Fs.dir Path.t -> stdin:Flow.source -> stdout:Flow.sink -> stderr:Flow.sink -> string -> string list -> t
-(** [spawn_detached t cmd] is like {! spawn} but the new subprocess is not
+(** [spawn_detached  mgr ?cwd ~stdin ~stdout ~stderr cmd args] is like {! spawn} but the new subprocess is not
     attached to any switch. *)

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -5,14 +5,14 @@ val pp_status : Format.formatter -> status -> unit
 class virtual t : object
     inherit Generic.t
     method virtual pid : int
-    method virtual status : status Promise.t
+    method virtual await_exit : status
     method virtual stop : unit
 end
 
 val pid : #t -> int
 (** The process ID *)
 
-val status : #t -> status Promise.t
+val await_exit : #t -> status
 (** Checks the status of the subprocess, this will block waiting for the subprocess
     to terminate or be stopped by a signal. *)
 

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -41,6 +41,7 @@ module FD = struct
   let take x = x#unix_fd `Take
 
   let peek_opt x = Eio.Generic.probe x (Private.Unix_file_descr `Peek)
+
   let take_opt x = Eio.Generic.probe x (Private.Unix_file_descr `Take)
 
   let as_socket ~sw ~close_unix fd = Effect.perform (Private.Socket_of_fd (sw, close_unix, fd))

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1208,9 +1208,11 @@ let process = object
     let process = pid_to_process close pid in
     let cleanup () =
       try 
-        ignore (wait_for_process [] pid);
+        process#stop;
         close ()
-      with Unix.Unix_error (ECHILD, _, _) -> ()
+      with Unix.Unix_error (Unix.ESRCH, _, _) -> 
+      (* Process is already finished when trying to stop it. *)
+      ()
     in
     Switch.on_release sw cleanup;
     process

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1203,6 +1203,7 @@ let process = object
     let stdin = source_or_std (Lazy.force dev_null_in) stdin |> get_fd_or_err in
     let stdout = sink_or_std (Lazy.force dev_null_out) stdout |> get_fd_or_err in
     let stderr = sink_or_std (Lazy.force dev_null_out) stderr |> get_fd_or_err in
+    let cwd = Option.map snd cwd in
     let pid =
       Option.iter Sys.chdir cwd;
       Unix.create_process cmd
@@ -1226,6 +1227,7 @@ let process = object
     
 
   method spawn_detached ?cwd ?stderr ?stdout ?stdin cmd args = 
+    let cwd = Option.map snd cwd in
     let pid =
       Option.iter Sys.chdir cwd;
       Unix.create_process cmd 

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1163,7 +1163,7 @@ let net = object
 end
 
 let pid_to_process close pid = object
-  inherit Eio.Process.process
+  inherit Eio.Process.t
   method pid = pid
   method status = 
     match Eio_unix.run_in_systhread @@ fun () -> let v = Unix.waitpid [] pid in close (); v with
@@ -1196,7 +1196,7 @@ let dev_null_in = open_null [ Unix.O_RDONLY; Unix.O_CLOEXEC ]
 let dev_null_out = open_null [ Unix.O_WRONLY; Unix.O_CLOEXEC ]
 
 let process = object
-  inherit Eio.Process.t
+  inherit Eio.Process.mgr
 
   (* TODO: Is Sys.chdir cwd domain-safe, ? *)
   method spawn ~sw ?cwd ?stderr ?stdout ?stdin cmd args =
@@ -1242,7 +1242,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
-  process : Eio.Process.t;
+  process : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1197,7 +1197,7 @@ let get_fd_or_err flow =
     Unix.dup ~cloexec:false (FD.to_unix `Peek fd)
   | None -> failwith "Currently only flows backed by file descriptors are supported!"
 
-let process = object
+let process_mgr = object
   inherit Eio.Process.mgr
 
   (* TODO: Is Sys.chdir cwd domain-safe, ? *)
@@ -1245,7 +1245,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
-  process : Eio.Process.mgr;
+  process_mgr : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;
@@ -1359,7 +1359,7 @@ let stdenv ~run_event_loop =
     method stdout = Lazy.force stdout
     method stderr = Lazy.force stderr
     method net = net
-    method process = process
+    method process_mgr = process_mgr
     method domain_mgr = domain_mgr ~run_event_loop
     method clock = clock
     method fs = (fs :> Eio.Fs.dir Eio.Path.t)

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1162,11 +1162,87 @@ let net = object
   method getnameinfo = Eio_unix.getnameinfo
 end
 
+let pid_to_process close pid = object
+  inherit Eio.Process.process
+  method pid = pid
+  method status = 
+    match Eio_unix.run_in_systhread @@ fun () -> let v = Unix.waitpid [] pid in close (); v with
+    | _, WEXITED i -> Exited i
+    | _, WSIGNALED i -> Signaled i
+    | _, WSTOPPED i -> Stopped i
+  
+  method stop = 
+    Unix.kill pid Sys.sigkill
+end
+
+let source_or_std fd = function
+  | Some flow -> flow
+  | None -> (source (FD.of_unix_no_hook ~seekable:(FD.is_seekable fd) ~close_unix:true fd) :> Eio.Flow.source)
+
+let sink_or_std fd = function
+  | Some flow -> flow
+  | None -> (sink (FD.of_unix_no_hook ~seekable:(FD.is_seekable fd) ~close_unix:true fd) :> Eio.Flow.sink)
+
+let get_fd_or_err flow =
+  match get_fd_opt flow with
+  | Some fd -> 
+    Unix.dup ~cloexec:false (FD.to_unix `Peek fd)
+  | None -> failwith "Currently only flows backed by file descriptors are supported!"
+
+let open_null flags = lazy (Unix.openfile "/dev/null" flags 0o666)
+
+let dev_null_in = open_null [ Unix.O_RDONLY; Unix.O_CLOEXEC ]
+
+let dev_null_out = open_null [ Unix.O_WRONLY; Unix.O_CLOEXEC ]
+
+let process = object
+  inherit Eio.Process.t
+
+  (* TODO: Is Sys.chdir cwd domain-safe, ? *)
+  method spawn ~sw ?cwd ?stderr ?stdout ?stdin cmd args =
+    let stdin = source_or_std (Lazy.force dev_null_in) stdin |> get_fd_or_err in
+    let stdout = sink_or_std (Lazy.force dev_null_out) stdout |> get_fd_or_err in
+    let stderr = sink_or_std (Lazy.force dev_null_out) stderr |> get_fd_or_err in
+    let pid =
+      Option.iter Sys.chdir cwd;
+      Unix.create_process cmd
+        (Array.of_list args) 
+        stdin stdout stderr
+    in
+    let close () =
+      Unix.close stdin;
+      Unix.close stdout;
+      Unix.close stderr
+    in
+    let process = pid_to_process close pid in
+    let cleanup () =
+      try 
+        ignore (Unix.waitpid [] pid);
+        close ()
+      with Unix.Unix_error (ECHILD, _, _) -> ()
+    in
+    Switch.on_release sw cleanup;
+    process
+    
+
+  method spawn_detached ?cwd ?stderr ?stdout ?stdin cmd args = 
+    let pid =
+      Option.iter Sys.chdir cwd;
+      Unix.create_process cmd 
+        (Array.of_list args) 
+        (get_fd_or_err (source_or_std (Lazy.force dev_null_in) stdin))
+        (get_fd_or_err (sink_or_std (Lazy.force dev_null_out) stdout))
+        (get_fd_or_err (sink_or_std (Lazy.force dev_null_out) stderr))
+    in
+    pid_to_process (fun () -> ()) pid
+end
+
 type stdenv = <
   stdin  : source;
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
+  process : Eio.Process.t;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;
@@ -1280,6 +1356,7 @@ let stdenv ~run_event_loop =
     method stdout = Lazy.force stdout
     method stderr = Lazy.force stderr
     method net = net
+    method process = process
     method domain_mgr = domain_mgr ~run_event_loop
     method clock = clock
     method fs = (fs :> Eio.Fs.dir Eio.Path.t)

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -63,6 +63,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
+  process : Eio.Process.t;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -63,7 +63,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
-  process : Eio.Process.t;
+  process : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -63,7 +63,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
-  process : Eio.Process.mgr;
+  process_mgr : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;

--- a/lib_eio_linux/eio_stubs.c
+++ b/lib_eio_linux/eio_stubs.c
@@ -99,3 +99,10 @@ CAMLprim value caml_eio_getdents(value v_fd) {
 
   CAMLreturn(result);
 }
+
+CAMLextern int caml_convert_signal_number(int);
+
+CAMLprim value caml_signal_to_posix_signal(value v_signo)
+{
+  return Val_int(caml_convert_signal_number(Int_val(v_signo)));
+}

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -843,7 +843,7 @@ let net = object
 end
 
 let process_of_handle status_promise handle = object
-   inherit Eio.Process.process
+   inherit Eio.Process.t
    method stop = Luv.Process.kill handle Luv.Signal.sigkill |> or_raise
    method pid = Luv.Process.pid handle
    method status = Promise.await status_promise
@@ -856,7 +856,7 @@ let get_fd_or_err flow =
   | None -> failwith "Currently only flows backed by file descriptors are supported!"
 
 let process = object
-  inherit Eio.Process.t
+  inherit Eio.Process.mgr
 
   method spawn ~sw ?cwd ?stderr:stderr_flow ?stdout:stdout_flow ?stdin:stdin_flow cmd args =
     let promise, resolve = Promise.create () in
@@ -911,7 +911,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
-  process : Eio.Process.t;
+  process : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -846,7 +846,7 @@ let process_of_handle status_promise handle = object
    inherit Eio.Process.t
    method stop = Luv.Process.kill handle Luv.Signal.sigkill |> or_raise
    method pid = Luv.Process.pid handle
-   method status = Promise.await status_promise
+   method status = status_promise
 end
 
 let get_fd_or_err flow =

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -880,6 +880,7 @@ let process = object
        Option.map (fun fd -> inherit_fd ~fd:Luv.Process.stdin ~from_parent_fd:(fd |> Obj.magic) ()) stdin_fd
     ] |> List.filter_map Fun.id
     in
+    let cwd = Option.map snd cwd in
     Switch.on_release sw (fun () -> ignore (Promise.await promise));
     Luv.Process.spawn ~loop:(get_loop ()) ?working_directory:cwd ~redirect ~on_exit cmd args |> or_raise |> process_of_handle promise
 
@@ -893,6 +894,7 @@ let process = object
       in
         Promise.resolve resolve status
     in
+    let cwd = Option.map snd cwd in
     Luv.Process.spawn ?working_directory:cwd ~on_exit cmd args |> or_raise |> process_of_handle promise
 end
 

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -880,7 +880,7 @@ let spawn_process ?cwd ~stdin:stdin_flow ~stdout:stdout_flow ~stderr:stderr_flow
   let cwd = Option.map snd cwd in
   promise, Luv.Process.spawn ~loop:(get_loop ()) ?working_directory:cwd ~redirect ~on_exit cmd args |> or_raise
 
-let process = object
+let process_mgr = object
   inherit Eio.Process.mgr
 
   method spawn ~sw ?cwd ~stdin:stdin_flow ~stdout:stdout_flow ~stderr:stderr_flow cmd args =
@@ -908,7 +908,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
-  process : Eio.Process.mgr;
+  process_mgr : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;
@@ -1091,7 +1091,7 @@ let stdenv ~run_event_loop =
     method stdout = Lazy.force stdout
     method stderr = Lazy.force stderr
     method net = net
-    method process = process
+    method process_mgr = process_mgr
     method domain_mgr = domain_mgr ~run_event_loop
     method clock = clock
     method fs = (fs :> Eio.Fs.dir), "."

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -846,7 +846,7 @@ let process_of_handle status_promise handle = object
    inherit Eio.Process.t
    method stop = Luv.Process.kill handle Luv.Signal.sigkill |> or_raise
    method pid = Luv.Process.pid handle
-   method status = status_promise
+   method await_exit = Promise.await status_promise
 end
 
 let get_fd_or_err flow =

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -127,6 +127,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
+  process : Eio.Process.t;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -127,7 +127,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
-  process : Eio.Process.t;
+  process : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -127,7 +127,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
-  process : Eio.Process.mgr;
+  process_mgr : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   fs : Eio.Fs.dir Eio.Path.t;

--- a/tests/process.md
+++ b/tests/process.md
@@ -31,7 +31,7 @@ Running a program as a subprocess
 # run @@ fun spawn env ->
   Switch.run @@ fun sw ->
   let t = spawn ~sw "echo" [ "echo"; "hello world" ] in
-  Eio.Process.status t;;
+  Promise.await (Process.status t);;
 hello world
 - : Process.status = Eio.Process.Exited 0
 ```
@@ -42,9 +42,9 @@ Stopping a subprocess works and checking the status waits and reports correctly
 # run @@ fun spawn _env ->
   Switch.run @@ fun sw ->
   let t = spawn ~sw "sleep" [ "sleep"; "10" ] in
-  Eio.Process.stop t;
-  Eio.Process.status t;;
-- : Process.status = Eio.Process.Signaled (-7)
+  Process.stop t;
+  Promise.await (Process.status t);;
+- : Process.status = Eio.Process.Signaled 9
 ```
 
 A switch will wait for a subprocess to finished when spawned.
@@ -71,7 +71,7 @@ Passing in flows allows you to redirect the child process' stdout.
     let stdout = (stdout :> Eio.Flow.sink) in
     Switch.run @@ fun sw ->
     let t = Eio.Process.spawn ~sw ~stdout ~stdin:env#stdin ~stderr:env#stderr process "echo" [ "echo"; "Hello" ] in
-    Eio.Process.status t
+    Promise.await (Process.status t)
   in
   match run () with
     | Exited 0 ->
@@ -106,7 +106,7 @@ val with_pipe_from_child :
   let t =
     Eio.Process.spawn ~sw ~stdout:(w :> Flow.sink) ~stdin:env#stdin ~stderr:env#stderr env#process "echo" [ "echo"; "Hello" ] 
   in
-  let status = Eio.Process.status t in
+  let status = Promise.await (Process.status t) in
   Eio.traceln "%a" Eio.Process.pp_status status;
   Flow.close w;
   let buff = Buffer.create 10 in
@@ -129,7 +129,7 @@ Spawning subprocesses in new domains works normally
   Eio.Domain_manager.run mgr @@ fun () ->
   Switch.run @@ fun sw ->
   let t = spawn ~sw "echo" [ "echo"; "Hello from another domain" ] in
-  Eio.Process.status t;;
+  Promise.await (Process.status t);;
 Hello from another domain
 - : Process.status = Eio.Process.Exited 0
 ```

--- a/tests/process.md
+++ b/tests/process.md
@@ -11,10 +11,10 @@ open Eio
 open Eio.Std
 
 let spawn ~env ~sw ?cwd cmd args =
-  Process.spawn ~sw ?cwd ~stdout:env#stdout ~stdin:env#stdin ~stderr:env#stderr env#process cmd args
+  Process.spawn ~sw ?cwd ~stdout:env#stdout ~stdin:env#stdin ~stderr:env#stderr env#process_mgr cmd args
 
 let spawn_detached ~env ?cwd cmd args =
-  Process.spawn_detached ?cwd ~stdout:env#stdout ~stdin:env#stdin ~stderr:env#stderr env#process cmd args
+  Process.spawn_detached ?cwd ~stdout:env#stdout ~stdin:env#stdin ~stderr:env#stderr env#process_mgr cmd args
 
 let run fn =
   Eio_main.run @@ fun env ->
@@ -66,7 +66,7 @@ Passing in flows allows you to redirect the child process' stdout.
 
 ```ocaml
 # run @@ fun _spawn env ->
-  let process = Eio.Stdenv.process env in
+  let process = Eio.Stdenv.process_mgr env in
   let fs = Eio.Stdenv.fs env in
   let filename = "process-test.txt" in
   let run () =
@@ -107,7 +107,7 @@ val with_pipe_from_child :
 # let pread env =
   with_pipe_from_child @@ fun ~sw ~r ~w ->
   let t =
-    Eio.Process.spawn ~sw ~stdout:(w :> Flow.sink) ~stdin:env#stdin ~stderr:env#stderr env#process "echo" [ "echo"; "Hello" ] 
+    Eio.Process.spawn ~sw ~stdout:(w :> Flow.sink) ~stdin:env#stdin ~stderr:env#stderr env#process_mgr "echo" [ "echo"; "Hello" ] 
   in
   let status = Promise.await (Process.status t) in
   Eio.traceln "%a" Eio.Process.pp_status status;
@@ -116,7 +116,7 @@ val with_pipe_from_child :
   Flow.copy r (Flow.buffer_sink buff);
   Buffer.contents buff;;
 val pread :
-  < process : #Process.mgr; stderr : Flow.sink; stdin : Flow.source; .. > ->
+  < process_mgr : #Process.mgr; stderr : Flow.sink; stdin : Flow.source; .. > ->
   string = <fun>
 # run @@ fun _spawn env ->
   pread env;;

--- a/tests/process.md
+++ b/tests/process.md
@@ -10,7 +10,7 @@ Creating some useful helper functions
 open Eio
 open Eio.Std
 
-let run (fn : Eio.Process.t -> 'a) =
+let run fn =
   Eio_main.run @@ fun env ->
   fn (Eio.Stdenv.process env) env
 
@@ -106,7 +106,7 @@ val with_pipe_from_child :
   let buff = Buffer.create 10 in
   Flow.copy r (Flow.buffer_sink buff);
   Buffer.contents buff;;
-val pread : process:#Process.t -> unit -> string = <fun>
+val pread : process:#Process.mgr -> unit -> string = <fun>
 # run @@ fun process _env ->
   pread ~process ();;
 +Exited 0

--- a/tests/process.md
+++ b/tests/process.md
@@ -1,0 +1,128 @@
+# Setting up the environment
+
+```ocaml
+# #require "eio_main";;
+```
+
+Creating some useful helper functions
+
+```ocaml
+open Eio
+open Eio.Std
+
+let run (fn : Eio.Process.t -> 'a) =
+  Eio_main.run @@ fun env ->
+  fn (Eio.Stdenv.process env) env
+
+let run_env (fn : Eio.Stdenv.t -> 'a) =
+  Eio_main.run @@ fun env ->
+  fn env
+```
+
+Running a program as a subprocess
+
+```ocaml
+# run @@ fun process env ->
+  Switch.run @@ fun sw ->
+  let t = Eio.Process.spawn ~sw ~stdout:(env#stdout) process "echo" [ "echo"; "hello world" ] in
+  Eio.Process.status t;;
+hello world
+- : Process.status = Eio.Process.Exited 0
+```
+
+Stopping a subprocess works and checking the status waits and reports correctly
+
+```ocaml
+# run @@ fun process _env ->
+  Switch.run @@ fun sw ->
+  let t = Eio.Process.spawn ~sw process "sleep" [ "sleep"; "10" ] in
+  Eio.Process.stop t;
+  Eio.Process.status t;;
+- : Process.status = Eio.Process.Signaled 9
+```
+
+A switch will wait for a subprocess to finished when spawned.
+<!-- Need a better test of this... -->
+
+```ocaml
+# run @@ fun process env ->
+  Switch.run @@ fun sw ->
+  let _t = Eio.Process.spawn ~sw ~stdout:(env#stdout) process "echo" [ "echo"; "Waited..." ] in
+  ();;
+Waited...
+- : unit = ()
+```
+
+Passing in flows allows you to redirect the child process' stdout.
+
+```ocaml
+# run_env @@ fun env ->
+  let process = Eio.Stdenv.process env in
+  let fs = Eio.Stdenv.fs env in
+  let filename = "process-test.txt" in
+  let run () =
+    Eio.Path.(with_open_out ~create:(`Exclusive 0o600) (fs / filename)) @@ fun stdout ->
+    let stdout = (stdout :> Eio.Flow.sink) in
+    Switch.run @@ fun sw ->
+    let t = Eio.Process.spawn ~sw ~stdout process "echo" [ "echo"; "Hello" ] in
+    Eio.Process.status t
+  in
+  match run () with
+    | Exited 0 ->
+      Eio.Path.(with_open_in (fs / filename)) @@ fun flow ->
+      let buff = Buffer.create 128 in
+      Eio.Flow.copy flow (Eio.Flow.buffer_sink buff);
+      Buffer.contents buff
+    | _ -> failwith "Subprocess didn't exit cleanly!";;
+- : string = "Hello\n"
+```
+
+Pipes
+
+```ocaml
+# let with_pipe_from_child fn =
+  Switch.run @@ fun sw ->
+  let r, w = Eio_unix.pipe sw in
+  fn ~sw ~r ~w;;
+val with_pipe_from_child :
+  (sw:Switch.t ->
+   r:< close : unit; probe : 'a. 'a Generic.ty -> 'a option;
+       read_into : Cstruct.t -> int; read_methods : Flow.read_method list;
+       unix_fd : [ `Peek | `Take ] -> Unix.file_descr > ->
+   w:< close : unit; copy : 'b. (#Flow.source as 'b) -> unit;
+       probe : 'a. 'a Generic.ty -> 'a option;
+       unix_fd : [ `Peek | `Take ] -> Unix.file_descr;
+       write : Cstruct.t list -> unit > ->
+   'c) ->
+  'c = <fun>
+# let pread ~process () =
+  with_pipe_from_child @@ fun ~sw ~r ~w ->
+  let t =
+    Eio.Process.spawn ~sw ~stdout:(w :> Flow.sink) process "echo" [ "echo"; "Hello" ] 
+  in
+  let status = Eio.Process.status t in
+  Eio.traceln "%a" Eio.Process.pp_status status;
+  Flow.close w;
+  let buff = Buffer.create 10 in
+  Flow.copy r (Flow.buffer_sink buff);
+  Buffer.contents buff;;
+val pread : process:#Process.t -> unit -> string = <fun>
+# run @@ fun process _env ->
+  pread ~process ();;
++Exited 0
+- : string = "Hello\n"
+```
+
+Spawning subprocesses in new domains works normally
+
+```ocaml
+# run_env @@ fun env ->
+  let process = Eio.Stdenv.process env in
+  let mgr = Eio.Stdenv.domain_mgr env in
+  Eio.Domain_manager.run mgr @@ fun () ->
+  Switch.run @@ fun sw ->
+  let t = Eio.Process.spawn ~sw ~stdout:(env#stdout) process "echo" [ "echo"; "Hello from another domain" ] in
+  Eio.Process.status t;;
+Hello from another domain
+- : Process.status = Eio.Process.Exited 0
+```

--- a/tests/process.md
+++ b/tests/process.md
@@ -47,16 +47,19 @@ Stopping a subprocess works and checking the status waits and reports correctly
 - : Process.status = Eio.Process.Signaled 9
 ```
 
-A switch will wait for a subprocess to finished when spawned.
+A switch will stop a process when it is released.
 <!-- Need a better test of this... -->
 
 ```ocaml
-# run_detached @@ fun spawn env ->
-  Switch.run @@ fun sw ->
-  let _t = spawn ~sw "echo" [ "echo"; "Waited..." ] in
-  ();;
-Waited...
-- : unit = ()
+# run @@ fun spawn env ->
+  let proc = ref None in 
+  let run () =
+    Switch.run @@ fun sw ->
+    proc := Some (spawn ~sw "sleep" [ "sleep"; "10" ])
+  in
+  run ();
+  Promise.await @@ Process.status (Option.get !proc);;
+- : Process.status = Eio.Process.Signaled 9
 ```
 
 Passing in flows allows you to redirect the child process' stdout.

--- a/tests/process.md
+++ b/tests/process.md
@@ -13,8 +13,8 @@ open Eio.Std
 let spawn ~env ~sw ?cwd cmd args =
   Process.spawn ~sw ?cwd ~stdout:env#stdout ~stdin:env#stdin ~stderr:env#stderr env#process cmd args
 
-let spawn_detached ~env ~sw ?cwd cmd args =
-  Process.spawn ~sw ?cwd ~stdout:env#stdout ~stdin:env#stdin ~stderr:env#stderr env#process cmd args
+let spawn_detached ~env ?cwd cmd args =
+  Process.spawn_detached ?cwd ~stdout:env#stdout ~stdin:env#stdin ~stderr:env#stderr env#process cmd args
 
 let run fn =
   Eio_main.run @@ fun env ->
@@ -134,5 +134,15 @@ Spawning subprocesses in new domains works normally
   let t = spawn ~sw "echo" [ "echo"; "Hello from another domain" ] in
   Promise.await (Process.status t);;
 Hello from another domain
+- : Process.status = Eio.Process.Exited 0
+```
+
+The `spawn_detached` function will spawn a process without needing to provide a switch.
+
+```ocaml
+# run_detached @@ fun spawn env ->
+  let t = spawn "echo" [ "echo"; "hello world" ] in
+  Promise.await (Process.status t);;
+hello world
 - : Process.status = Eio.Process.Exited 0
 ```


### PR DESCRIPTION
This PR is primarily for generating a discussion around how best to support spawning subprocesses in Eio. In particular for issue #126. The current implementation makes the following decisions.

 - Child I/O by default is mapped to `/dev/null`
 - There's a lot of file-descriptor mangling related to child I/O which definitely needs double-checked.

One unfortunate side-effect is that adding subprocesses bypasses all capability-style security iiuc as someone could easily `cd ..` out of the current working directory of the process. Perhaps processes should live in a separate package?

Note: if it ever lands, it would probably be good to use `io-uring-spawn`: https://www.phoronix.com/news/Linux-LPC2022-io_uring_spawn