### PR TITLE
Add Time.Mono for monotonic clocks

### DIFF
--- a/lib_eio/dune
+++ b/lib_eio/dune
@@ -2,4 +2,4 @@
   (name eio)
   (public_name eio)
   (flags (:standard -open Eio__core -open Eio__core.Private))
-  (libraries eio__core cstruct lwt-dllist fmt bigstringaf optint))
+  (libraries eio__core cstruct lwt-dllist fmt bigstringaf optint mtime))

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -37,6 +37,7 @@ module Stdenv = struct
     net : Net.t;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
+    mono_clock : Time.Mono.t;
     fs : Fs.dir Path.t;
     cwd : Fs.dir Path.t;
     secure_random : Flow.source;
@@ -49,6 +50,7 @@ module Stdenv = struct
   let net (t : <net : #Net.t; ..>) = t#net
   let domain_mgr (t : <domain_mgr : #Domain_manager.t; ..>) = t#domain_mgr
   let clock (t : <clock : #Time.clock; ..>) = t#clock
+  let mono_clock (t : <mono_clock : #Time.Mono.t; ..>) = t#mono_clock
   let secure_random (t: <secure_random : #Flow.source; ..>) = t#secure_random
   let fs (t : <fs : #Fs.dir Path.t; ..>) = t#fs
   let cwd (t : <cwd : #Fs.dir Path.t; ..>) = t#cwd

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -179,6 +179,7 @@ module Stdenv : sig
     net : Net.t;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
+    mono_clock : Time.Mono.t;
     fs : Fs.dir Path.t;
     cwd : Fs.dir Path.t;
     secure_random : Flow.source;
@@ -232,7 +233,10 @@ module Stdenv : sig
   *)
 
   val clock : <clock : #Time.clock as 'a; ..> -> 'a
-  (** [clock t] is the system clock. *)
+  (** [clock t] is the system clock (used to get the current time and date). *)
+
+  val mono_clock : <mono_clock : #Time.Mono.t as 'a; ..> -> 'a
+  (** [mono_clock t] is a monotonic clock (used for measuring intervals). *)
 
   (** {1 Randomness} *)
 

--- a/lib_eio/mock/clock.ml
+++ b/lib_eio/mock/clock.ml
@@ -1,67 +1,111 @@
 open Eio.Std
 
-type t = <
-  Eio.Time.clock;
-  advance : unit;
-  set_time : float -> unit;
->
+module type S = sig
+  type time
 
-module Key = struct
-  type t = < >
-  let compare = compare
+  type t = <
+    time Eio.Time.clock_base;
+    advance : unit;
+    set_time : time -> unit;
+  >
+
+  val make : unit -> t
+  val advance : t -> unit
+  val set_time : t -> time -> unit
 end
 
-module Job = struct
-  type t = {
-    time : float;
-    resolver : unit Promise.u;
-  }
-
-  let compare a b = Float.compare a.time b.time
+module type TIME = sig
+  type t
+  val zero : t
+  val compare : t -> t -> int
+  val pp : t Fmt.t
 end
 
-module Q = Psq.Make(Key)(Job)
+module Make(T : TIME) : S with type time := T.t = struct
+  type t = <
+    T.t Eio.Time.clock_base;
+    advance : unit;
+    set_time : T.t -> unit;
+  >
 
-let make () =
-  object (self)
-    inherit Eio.Time.clock
-
-    val mutable now = 0.0
-    val mutable q = Q.empty
-
-    method now = now
-
-    method sleep_until time =
-      if time <= now then Fiber.yield ()
-      else (
-        let p, r = Promise.create () in
-        let k = object end in
-        q <- Q.add k { time; resolver = r } q;
-        try
-          Promise.await p
-        with Eio.Cancel.Cancelled _ as ex ->
-          q <- Q.remove k q;
-          raise ex
-      )
-
-    method set_time time =
-      let rec drain () =
-        match Q.min q with
-        | Some (_, v) when v.time <= time ->
-          Promise.resolve v.resolver ();
-          q <- Option.get (Q.rest q);
-          drain ()
-        | _ -> ()
-      in
-      drain ();
-      now <- time;
-      traceln "mock time is now %g" now
-
-    method advance =
-      match Q.min q with
-      | None -> invalid_arg "No further events scheduled on mock clock"
-      | Some (_, v) -> self#set_time v.time
+  module Key = struct
+    type t = < >
+    let compare = compare
   end
 
-let set_time (t:t) time = t#set_time time
-let advance (t:t) = t#advance
+  module Job = struct
+    type t = {
+      time : T.t;
+      resolver : unit Promise.u;
+    }
+
+    let compare a b = T.compare a.time b.time
+  end
+
+  module Q = Psq.Make(Key)(Job)
+
+  let make () =
+    object (self)
+      inherit [T.t] Eio.Time.clock_base
+
+      val mutable now = T.zero
+      val mutable q = Q.empty
+
+      method now = now
+
+      method sleep_until time =
+        if T.compare time now <= 0 then Fiber.yield ()
+        else (
+          let p, r = Promise.create () in
+          let k = object end in
+          q <- Q.add k { time; resolver = r } q;
+          try
+            Promise.await p
+          with Eio.Cancel.Cancelled _ as ex ->
+            q <- Q.remove k q;
+            raise ex
+        )
+
+      method set_time time =
+        let rec drain () =
+          match Q.min q with
+          | Some (_, v) when T.compare v.time time <= 0 ->
+            Promise.resolve v.resolver ();
+            q <- Option.get (Q.rest q);
+            drain ()
+          | _ -> ()
+        in
+        drain ();
+        now <- time;
+        traceln "mock time is now %a" T.pp now
+
+      method advance =
+        match Q.min q with
+        | None -> invalid_arg "No further events scheduled on mock clock"
+        | Some (_, v) -> self#set_time v.time
+    end
+
+    let set_time (t:t) time = t#set_time time
+    let advance (t:t) = t#advance
+end
+
+module Old_time = struct
+  type t = float
+  let compare = Float.compare
+  let pp f x = Fmt.pf f "%g" x
+  let zero = 0.0
+end
+
+module Mono_time = struct
+  type t = Mtime.t
+  let compare = Mtime.compare
+  let zero = Mtime.of_uint64_ns 0L
+
+  let pp f t =
+    let s = Int64.to_float (Mtime.to_uint64_ns t) /. 1e9 in
+    Fmt.pf f "%g" s
+end
+
+module Mono = Make(Mono_time)
+
+include Make(Old_time)

--- a/lib_eio/mock/clock.mli
+++ b/lib_eio/mock/clock.mli
@@ -1,17 +1,25 @@
-type t = <
-  Eio.Time.clock;
-  advance : unit;
-  set_time : float -> unit;
->
+module type S = sig
+  type time
 
-val make : unit -> t
-(** [make ()] is a new clock.
+  type t = <
+    time Eio.Time.clock_base;
+    advance : unit;
+    set_time : time -> unit;
+  >
 
-    The time is initially set to 0.0 and doesn't change except when you call {!advance} or {!set_time}. *)
+  val make : unit -> t
+  (** [make ()] is a new clock.
 
-val advance : t -> unit
-(** [advance t] sets the time to the next scheduled event (adding any due fibers to the run queue).
-    @raise Invalid_argument if nothing is scheduled. *)
+      The time is initially set to 0.0 and doesn't change except when you call {!advance} or {!set_time}. *)
 
-val set_time : t -> float -> unit
-(** [set_time t time] sets the time to [time] (adding any due fibers to the run queue). *)
+  val advance : t -> unit
+  (** [advance t] sets the time to the next scheduled event (adding any due fibers to the run queue).
+      @raise Invalid_argument if nothing is scheduled. *)
+
+  val set_time : t -> time -> unit
+  (** [set_time t time] sets the time to [time] (adding any due fibers to the run queue). *)
+end
+
+include S with type time := float
+
+module Mono : S with type time := Mtime.t

--- a/lib_eio/time.ml
+++ b/lib_eio/time.ml
@@ -1,46 +1,95 @@
 exception Timeout
 
-class virtual clock = object
-  method virtual now : float
-  method virtual sleep_until : float -> unit
+class virtual ['a] clock_base = object
+  method virtual now : 'a
+  method virtual sleep_until : 'a -> unit
 end
 
-let now (t : #clock) = t#now
+class virtual clock = object
+  inherit [float] clock_base
+end
 
-let sleep_until (t : #clock) time = t#sleep_until time
+let now (t : _ #clock_base) = t#now
+
+let sleep_until (t : _ #clock_base) time = t#sleep_until time
 
 let sleep t d = sleep_until t (now t +. d)
+
+module Mono = struct
+  class virtual t = object
+    inherit [Mtime.t] clock_base
+  end
+
+  let now = now
+  let sleep_until = sleep_until
+
+  let sleep_span t span =
+    match Mtime.add_span (now t) span with
+    | Some time -> sleep_until t time
+    | None -> Fiber.await_cancel ()
+
+  (* Converting floats via int64 is tricky when things overflow or go negative.
+     Since we don't need to wait for more than 100 years, limit it to this: *)
+  let too_many_ns = 0x8000000000000000.
+
+  let span_of_s s =
+    if s >= 0.0 then (
+      let ns = s *. 1e9 in
+      if ns >= too_many_ns then Mtime.Span.max_span
+      else Mtime.Span.of_uint64_ns (Int64.of_float ns)
+    ) else Mtime.Span.zero      (* Also happens for NaN and negative infinity *)
+
+  let sleep (t : #t) s =
+    sleep_span t (span_of_s s)
+end
 
 let with_timeout t d = Fiber.first (fun () -> sleep t d; Error `Timeout)
 let with_timeout_exn t d = Fiber.first (fun () -> sleep t d; raise Timeout)
 
 module Timeout = struct
   type t =
-    | Timeout of clock * float
+    | Timeout of Mono.t * Mtime.Span.t
+    | Deprecated of clock * float
     | Unlimited
 
   let none = Unlimited
-  let of_s clock time = Timeout ((clock :> clock), time)
+  let v clock time = Timeout ((clock :> Mono.t), time)
+
+  let seconds clock time =
+    v clock (Mono.span_of_s time)
+
+  let of_s clock time =
+    Deprecated ((clock :> clock), time)
 
   let run t fn =
     match t with
     | Unlimited -> fn ()
     | Timeout (clock, d) ->
+      Fiber.first (fun () -> Mono.sleep_span clock d; Error `Timeout) fn
+    | Deprecated (clock, d) ->
       Fiber.first (fun () -> sleep clock d; Error `Timeout) fn
 
   let run_exn t fn =
     match t with
     | Unlimited -> fn ()
     | Timeout (clock, d) ->
+      Fiber.first (fun () -> Mono.sleep_span clock d; raise Timeout) fn
+    | Deprecated (clock, d) ->
       Fiber.first (fun () -> sleep clock d; raise Timeout) fn
+
+  let pp_duration f d =
+    if d >= 0.001 && d < 0.1 then
+      Fmt.pf f "%.2gms" (d *. 1000.)
+    else if d < 120. then
+      Fmt.pf f "%.2gs" d
+    else
+      Fmt.pf f "%.2gm" (d /. 60.)
 
   let pp f = function
     | Unlimited -> Fmt.string f "(no timeout)"
     | Timeout (_clock, d) ->
-      if d >= 0.001 && d < 0.1 then
-        Fmt.pf f "%.2gms" (d *. 1000.)
-      else if d < 120. then
-        Fmt.pf f "%.2gs" d
-      else
-        Fmt.pf f "%.2gm" (d /. 60.)
+      let d = Mtime.Span.to_s d in
+      pp_duration f d
+    | Deprecated (_clock, d) ->
+      pp_duration f d
 end

--- a/lib_eio/time.mli
+++ b/lib_eio/time.mli
@@ -57,7 +57,7 @@ module Timeout : sig
   type t
 
   val of_s : #clock -> float -> t
-  (** [of_s clock duration] is a timeout of [duration] seconds, as measured by [clock]. *)
+  [@@deprecated "Use [seconds] instead, with a monotonic clock"]
 
   val v : #Mono.t -> Mtime.Span.t -> t
   (** [v clock duration] is a timeout of [duration], as measured by [clock].

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -14,7 +14,7 @@ module Private = struct
   type _ Effect.t += 
     | Await_readable : Unix.file_descr -> unit Effect.t
     | Await_writable : Unix.file_descr -> unit Effect.t
-    | Get_system_clock : Eio.Time.clock Effect.t
+    | Get_monotonic_clock : Eio.Time.Mono.t Effect.t
     | Socket_of_fd : Eio.Switch.t * bool * Unix.file_descr -> socket Effect.t
     | Socketpair : Eio.Switch.t * Unix.socket_domain * Unix.socket_type * int -> (socket * socket) Effect.t
     | Pipe : Eio.Switch.t -> (<Eio.Flow.source; Eio.Flow.close; unix_fd> * <Eio.Flow.sink; Eio.Flow.close; unix_fd>) Effect.t
@@ -24,7 +24,7 @@ let await_readable fd = Effect.perform (Private.Await_readable fd)
 let await_writable fd = Effect.perform (Private.Await_writable fd)
 
 let sleep d =
-  Eio.Time.sleep (Effect.perform Private.Get_system_clock) d
+  Eio.Time.Mono.sleep (Effect.perform Private.Get_monotonic_clock) d
 
 let run_in_systhread fn =
   let f fiber enqueue =

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -59,7 +59,7 @@ end
 val sleep : float -> unit
 (** [sleep d] sleeps for [d] seconds, allowing other fibers to run.
     This is can be useful for debugging (e.g. to introduce delays to trigger a race condition)
-    without having to plumb {!Eio.Stdenv.clock} through your code.
+    without having to plumb {!Eio.Stdenv.mono_clock} through your code.
     It can also be used in programs that don't care about tracking determinism. *)
 
 val run_in_systhread : (unit -> 'a) -> 'a
@@ -90,7 +90,7 @@ module Private : sig
   type _ Effect.t += 
     | Await_readable : Unix.file_descr -> unit Effect.t      (** See {!await_readable} *)
     | Await_writable : Unix.file_descr -> unit Effect.t      (** See {!await_writable} *)
-    | Get_system_clock : Eio.Time.clock Effect.t             (** See {!sleep} *)
+    | Get_monotonic_clock : Eio.Time.Mono.t Effect.t
     | Socket_of_fd : Switch.t * bool * Unix.file_descr ->
         socket Effect.t                                      (** See {!FD.as_socket} *)
     | Socketpair : Eio.Switch.t * Unix.socket_domain * Unix.socket_type * int ->

--- a/lib_eio/utils/zzz.ml
+++ b/lib_eio/utils/zzz.ml
@@ -5,11 +5,11 @@ end
 
 module Job = struct
   type t = {
-    time : float;
+    time : Mtime.t;
     thread : unit Suspended.t;
   }
 
-  let compare a b = Float.compare a.time b.time
+  let compare a b = Mtime.compare a.time b.time
 end
 
 module Q = Psq.Make(Key)(Job)

--- a/lib_eio/utils/zzz.mli
+++ b/lib_eio/utils/zzz.mli
@@ -11,7 +11,7 @@ type t
 val create : unit -> t
 (** [create ()] is a fresh empty queue. *)
 
-val add : t -> float -> unit Suspended.t -> Key.t
+val add : t -> Mtime.t -> unit Suspended.t -> Key.t
 (** [add t time thread] adds a new event, due at [time], and returns its ID.
     You must use {!Eio.Private.Fiber_context.set_cancel_fn} on [thread] before
     calling {!pop}.
@@ -20,7 +20,7 @@ val add : t -> float -> unit Suspended.t -> Key.t
 val remove : t -> Key.t -> unit
 (** [remove t key] removes an event previously added with [add]. *)
 
-val pop : t -> now:float -> [`Due of unit Suspended.t | `Wait_until of float | `Nothing]
+val pop : t -> now:Mtime.t -> [`Due of unit Suspended.t | `Wait_until of Mtime.t | `Nothing]
 (** [pop ~now t] removes and returns the earliest thread due by [now].
     It also clears the thread's cancel function.
     If no thread is due yet, it returns the time the earliest thread becomes due. *)

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -65,6 +65,7 @@ type stdenv = <
   net : Eio.Net.t;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
+  mono_clock : Eio.Time.Mono.t;
   fs : Eio.Fs.dir Eio.Path.t;
   cwd : Eio.Fs.dir Eio.Path.t;
   secure_random : Eio.Flow.source;
@@ -107,7 +108,7 @@ module Low_level : sig
 
   (** {1 Time functions} *)
 
-  val sleep_until : float -> unit
+  val sleep_until : Mtime.t -> unit
   (** [sleep_until time] blocks until the current time is [time]. *)
 
   (** {1 Fixed-buffer memory allocation functions}

--- a/lib_eio_linux/tests/basic_eio_linux.ml
+++ b/lib_eio_linux/tests/basic_eio_linux.ml
@@ -24,7 +24,7 @@ let () =
   let buf = alloc_fixed_or_wait () in
   let _ = read_exactly fd buf 5 in
   Logs.debug (fun l -> l "sleeping at %f" (Unix.gettimeofday ()));
-  sleep_until (Unix.gettimeofday () +. 1.0);
+  sleep_until (Mtime.add_span (Mtime_clock.now ()) Mtime.Span.s |> Option.get);
   print_endline (Uring.Region.to_string ~len:5 buf);
   let _ = read_exactly fd ~file_offset:(Int63.of_int 3) buf 3 in
   print_endline (Uring.Region.to_string ~len:3 buf);

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -132,6 +132,7 @@ type stdenv = <
   net : Eio.Net.t;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
+  mono_clock : Eio.Time.Mono.t;
   fs : Eio.Fs.dir Eio.Path.t;
   cwd : Eio.Fs.dir Eio.Path.t;
   secure_random : Eio.Flow.source;

--- a/tests/network.md
+++ b/tests/network.md
@@ -685,8 +685,8 @@ First attempt times out:
 
 ```ocaml
 # Eio_mock.Backend.run @@ fun () ->
-  let clock = Eio_mock.Clock.make () in
-  let timeout = Eio.Time.Timeout.of_s clock 10. in
+  let clock = Eio_mock.Clock.Mono.make () in
+  let timeout = Eio.Time.Timeout.seconds clock 10. in
   Eio_mock.Net.on_getaddrinfo net [`Return [addr1; addr2]];
   let mock_flow = Eio_mock.Flow.make "flow" in
   Eio_mock.Net.on_connect net [`Run Fiber.await_cancel; `Return mock_flow];
@@ -698,7 +698,7 @@ First attempt times out:
        )
     )
     (fun () ->
-       Eio_mock.Clock.advance clock
+       Eio_mock.Clock.Mono.advance clock
      );;
 +mock-net: getaddrinfo ~service:http www.example.com
 +mock-net: connect to tcp:127.0.0.1:80
@@ -715,8 +715,8 @@ Both attempts time out:
 
 ```ocaml
 # Eio_mock.Backend.run @@ fun () ->
-  let clock = Eio_mock.Clock.make () in
-  let timeout = Eio.Time.Timeout.of_s clock 10. in
+  let clock = Eio_mock.Clock.Mono.make () in
+  let timeout = Eio.Time.Timeout.seconds clock 10. in
   Eio_mock.Net.on_getaddrinfo net [`Return [addr1; addr2]];
   Eio_mock.Net.on_connect net [`Run Fiber.await_cancel; `Run Fiber.await_cancel];
   Fiber.both
@@ -726,10 +726,10 @@ Both attempts time out:
        )
     )
     (fun () ->
-       Eio_mock.Clock.advance clock;
+       Eio_mock.Clock.Mono.advance clock;
        Fiber.yield ();
        Fiber.yield ();
-       Eio_mock.Clock.advance clock
+       Eio_mock.Clock.Mono.advance clock
      );;
 +mock-net: getaddrinfo ~service:http www.example.com
 +mock-net: connect to tcp:127.0.0.1:80

--- a/tests/time.md
+++ b/tests/time.md
@@ -113,17 +113,19 @@ let rec loop () =
 ### Timeouts
 
 ```ocaml
-# run @@ fun ~clock ->
+# Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.mono_clock env in
   Eio.Time.Timeout.(run_exn none) (fun () -> ());
-  let t = Eio.Time.Timeout.of_s clock 0.0001 in
+  let t = Eio.Time.Timeout.seconds clock 0.0001 in
   Eio.Time.Timeout.run_exn t (fun () -> Fiber.await_cancel ());;
 Exception: Eio__Time.Timeout.
 ```
 
 ```ocaml
-# run @@ fun ~clock ->
+# Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.mono_clock env in
   let show d =
-    let t = Eio.Time.Timeout.of_s clock d in
+    let t = Eio.Time.Timeout.seconds clock d in
     traceln "%g -> %a" d Eio.Time.Timeout.pp t
   in
   show 0.000000001;


### PR DESCRIPTION
Based on PR #308 by @bikallem. I didn't add Ptime here, but it can be added using the same pattern later.

It differs from #308 in a few ways:
- This change is mostly backwards-compatible. We can deprecate the old float functions in a later release, once people have moved over.
- The `add_seconds` and `to_seconds` operations on clocks are gone. Instead, it provides a separate submodule for Mtime. This allows the API to work directly with Mtime types instead of converting via floats.
- `Time.Timeout` now works on monotonic clocks (only). It's not useful to use a real-time clock for a timeout, so I think it's fine to skip support for that.