### PR TITLE
Expose File.stat and improve Path.load

### DIFF
--- a/lib_eio/fs.ml
+++ b/lib_eio/fs.ml
@@ -1,23 +1,21 @@
 (** Defines types used by file-systems. *)
 
 (** Tranditional Unix permissions. *)
-module Unix_perm = struct
-  type t = int
-  (** This is the same as {!Unix.file_perm}, but avoids a dependency on [Unix]. *)
-end
+module Unix_perm = File.Unix_perm [@@deprecated "Moved to File.Unix_perm"]
 
 type path = string
 
 exception Already_exists of path * exn
 exception Not_found of path * exn
 exception Permission_denied of path * exn
+exception File_too_large of path * exn
 
 (** When to create a new file. *)
 type create = [
-  | `Never                            (** fail if the named file doesn't exist *)
-  | `If_missing of Unix_perm.t        (** create if file doesn't already exist *)
-  | `Or_truncate of Unix_perm.t       (** any existing file is truncated to zero length *)
-  | `Exclusive of Unix_perm.t         (** always create; fail if the file already exists *)
+  | `Never                                 (** fail if the named file doesn't exist *)
+  | `If_missing of File.Unix_perm.t        (** create if file doesn't already exist *)
+  | `Or_truncate of File.Unix_perm.t       (** any existing file is truncated to zero length *)
+  | `Exclusive of File.Unix_perm.t         (** always create; fail if the file already exists *)
 ]
 (** If a new file is created, the given permissions are used for it. *)
 
@@ -30,7 +28,7 @@ class virtual dir = object (_ : #Generic.t)
     append:bool ->
     create:create ->
     path -> <File.rw; Flow.close>
-  method virtual mkdir : perm:Unix_perm.t -> path -> unit
+  method virtual mkdir : perm:File.Unix_perm.t -> path -> unit
   method virtual open_dir : sw:Switch.t -> path -> dir_with_close
   method virtual read_dir : path -> string list
   method virtual unlink : path -> unit

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -88,7 +88,7 @@ val with_open_out :
 
 (** {1 Directories} *)
 
-val mkdir : perm:Unix_perm.t -> _ t -> unit
+val mkdir : perm:File.Unix_perm.t -> _ t -> unit
 (** [mkdir ~perm t] creates a new directory [t] with permissions [perm]. *)
 
 val open_dir : sw:Switch.t -> _ t -> <dir; Flow.close> t

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -203,8 +203,8 @@ module Low_level : sig
   val await_writable : FD.t -> unit
   (** [await_writable fd] blocks until [fd] is writable (or has an error). *)
 
-  val fstat : FD.t -> Unix.stats
-  (** Like {!Unix.fstat}. *)
+  val fstat : FD.t -> Eio.File.Stat.t
+  (** Like {!Unix.LargeFile.fstat}. *)
 
   val read_dir : FD.t -> string list
   (** [read_dir dir] reads all directory entries from [dir].

--- a/lib_eio_linux/tests/eurcp_lib.ml
+++ b/lib_eio_linux/tests/eurcp_lib.ml
@@ -31,7 +31,7 @@ let run_cp block_size queue_depth infile outfile () =
   let open Unix in
   let infd = U.openfile ~sw infile [O_RDONLY] 0 in
   let outfd = U.openfile ~sw outfile [O_WRONLY; O_CREAT; O_TRUNC] 0o644 in
-  let insize = U.fstat infd |> fun {st_size; _} -> Int63.of_int st_size in
+  let insize = (U.fstat infd).size in
   Logs.debug (fun l -> l "eurcp: %s -> %s size %a queue %d bs %d"
                  infile
                  outfile

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -55,6 +55,9 @@ module Low_level : sig
         This allows unsafe access to the FD.
         @raise Invalid_arg if [t] is closed. *)
 
+    val fstat : t -> Luv.File.Stat.t or_error
+    (** [fstat fd] returns the stat of [fd]. *)
+
     val open_ :
       sw:Switch.t ->
       ?mode:Luv.File.Mode.t list ->

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -64,6 +64,10 @@ let try_rmdir path =
 let chdir path =
   traceln "chdir %S" path;
   Unix.chdir path
+
+let assert_kind path kind =
+  Path.with_open_in path @@ fun file ->
+  assert ((Eio.File.stat file).kind = kind)
 ```
 
 # Basic test cases
@@ -493,5 +497,19 @@ Unconfined:
 +rename <dir:bar> to <fs:foo> -> ok
 +read <fs:foo> -> "FOO"
 +rename <fs:../foo> to <fs:foo> -> ok
+- : unit = ()
+```
+
+# Stat
+```ocaml
+# run @@ fun env ->
+  let cwd = Eio.Stdenv.cwd env in
+  Switch.run @@ fun sw ->
+  try_mkdir (cwd / "stat_subdir");
+  assert_kind (cwd / "stat_subdir") `Directory;
+  try_write_file (cwd / "stat_reg") "kingbula" ~create:(`Exclusive 0o600);
+  assert_kind (cwd / "stat_reg") `Regular_file;;
++mkdir <cwd:stat_subdir> -> ok
++write <cwd:stat_reg> -> ok
 - : unit = ()
 ```


### PR DESCRIPTION
Path.load was doubling the buffer and trying to fit enough until it saw an EOF. This would cause many unecessary large allocations and my poor 16GB ram laptop couldn't even load a 5GB file without getting OOMed.

This diff makes load create an initial buffer of the size of the file and load exactly that amount of bytes in it.

Also, using take_all here isn't a good idea since it will resize even if initial_size (capacity) is adequate, that's because it does:
  ensure t.len(0) (0+1), which ends up allocating another bigarray.