### PR TITLE
Fix getrandom(2)

### DIFF
--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -237,8 +237,8 @@ module Low_level : sig
 
   (** {1 Randomness} *)
 
-  val getrandom : Cstruct.t -> int
-  (**[ getrandom buf] reads some random bytes into [buf] and returns the number of bytes written.
+  val getrandom : Cstruct.t -> unit
+  (**[getrandom buf] fills [buf] with random bytes.
 
      It uses Linux's [getrandom] call, which is like reading from /dev/urandom
      except that it will block (the whole domain) if used at early boot

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -847,9 +847,9 @@ let secure_random =
     inherit Eio.Flow.source
 
     method read_into buf =
-      let ba = cstruct_to_luv_truncate buf in
-      Random.fill ba;
-      Bigarray.Array1.dim ba
+      List.fold_left
+        (fun dim ba -> Random.fill ba; dim + Bigarray.Array1.dim ba)
+        0 (cstructv_to_luv [ buf ])
   end
 
 type stdenv = <


### PR DESCRIPTION
Fix some mistakes and bad practices:



- The Uring backend getrandom(2) was broken in commit 6f6b2eee, there is no
  guarantee getrandom(2) will fill the whole buffer in one go.
- Make sure we either get all the requested bytes or fail hard. I've checked
  libuv and it already does the right thing (tm).
- Fail as hard and as soon possible, don't let users think of catching an
  exception, don't propagate anything. If we can't get entropy, nothing should
  run. This is one of the only cases where a library _should_ kill a program.
- Don't truncate a buffer in Luv if it would overflow, fail hard (this could be
  improved to get in chunks).
- While here, sanitize the includes.

I didn't know much about getrandom(2), and I'm surprised it was designed allowing short counts even though they based it off getentropy(2), which always does the right thing.

"""
The behavior when a call to getrandom() that is blocked while reading from the urandom source is interrupted by a signal handler depends on the initialization state of the entropy buffer and on the request size, buflen.  If the entropy is not yet initialized, then the call fails with the EINTR error.  If the entropy pool has been initialized and the request size is large (buflen > 256), the call either succeeds, returning a partially filled buffer, or fails with the error EINTR.  If the entropy pool has been initialized and the quest size is small (buflen <= 256), then getrandom() will not fail with EINTR.  Instead, it will return all of the bytes that have been requested.
 """