### PR TITLE
Add pipe to eio_unix

### DIFF
--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -17,6 +17,7 @@ module Private = struct
     | Get_system_clock : Eio.Time.clock Effect.t
     | Socket_of_fd : Eio.Switch.t * bool * Unix.file_descr -> socket Effect.t
     | Socketpair : Eio.Switch.t * Unix.socket_domain * Unix.socket_type * int -> (socket * socket) Effect.t
+    | Pipe : Eio.Switch.t -> (<Eio.Flow.source; Eio.Flow.close; unix_fd> * <Eio.Flow.sink; Eio.Flow.close; unix_fd>) Effect.t
 end
 
 let await_readable fd = Effect.perform (Private.Await_readable fd)
@@ -47,6 +48,8 @@ end
 
 let socketpair ~sw ?(domain=Unix.PF_UNIX) ?(ty=Unix.SOCK_STREAM) ?(protocol=0) () =
   Effect.perform (Private.Socketpair (sw, domain, ty, protocol))
+
+let pipe sw = Effect.perform (Private.Pipe sw)
 
 module Ipaddr = struct
   let to_unix : _ Eio.Net.Ipaddr.t -> Unix.inet_addr = Obj.magic

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -77,6 +77,11 @@ val socketpair :
     This creates OS-level resources using [socketpair(2)].
     Note that, like all FDs created by Eio, they are both marked as close-on-exec by default. *)
 
+val pipe : Switch.t -> <Eio.Flow.source; Eio.Flow.close; unix_fd> * <Eio.Flow.sink; Eio.Flow.close; unix_fd>
+(** [pipe sw] returns a connected pair of flows [src] and [sink]. Data written to [sink]
+    can be read from [src].
+    Note that, like all FDs created by Eio, they are both marked as close-on-exec by default. *)
+
 (** API for Eio backends only. *)
 module Private : sig
   type _ Eio.Generic.ty += Unix_file_descr : [`Peek | `Take] -> Unix.file_descr Eio.Generic.ty
@@ -90,6 +95,8 @@ module Private : sig
         socket Effect.t                                      (** See {!FD.as_socket} *)
     | Socketpair : Eio.Switch.t * Unix.socket_domain * Unix.socket_type * int ->
         (socket * socket) Effect.t                           (** See {!socketpair} *)
+    | Pipe : Eio.Switch.t -> 
+        (<Eio.Flow.source; Eio.Flow.close; unix_fd> * <Eio.Flow.sink; Eio.Flow.close; unix_fd>) Effect.t (** See {!pipe} *)
 end
 
 module Ctf = Ctf_unix

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1446,6 +1446,12 @@ let rec run : type a.
               let b = FD.of_unix ~sw ~seekable:false ~close_unix:true b |> flow in
               continue k ((a :> Eio_unix.socket), (b :> Eio_unix.socket))
             )
+          | Eio_unix.Private.Pipe sw -> Some (fun k ->
+              let r, w = Unix.pipe ~cloexec:true () in
+              let r = (flow (FD.of_unix ~sw ~seekable:false ~close_unix:true r) :> <Eio.Flow.source; Eio.Flow.close; Eio_unix.unix_fd>) in
+              let w = (flow (FD.of_unix ~sw ~seekable:false ~close_unix:true w) :> <Eio.Flow.sink; Eio.Flow.close; Eio_unix.unix_fd>) in
+              continue k (r, w)
+            )
           | Low_level.Alloc -> Some (fun k ->
               match st.mem with
               | None -> continue k None

--- a/tests/flow.md
+++ b/tests/flow.md
@@ -118,3 +118,26 @@ Copying from src using `Read_source_buffer`:
 +dst: wrote "foobar"
 - : unit = ()
 ```
+
+## Pipes
+
+Writing to and reading from a pipe.
+
+```ocaml
+# Eio_main.run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let r, w = Eio_unix.pipe sw in
+  let msg = "Hello, world" in
+  Eio.Fiber.both
+    (fun () ->
+      let buf = Cstruct.create (String.length msg) in
+      let () = Eio.Flow.read_exact r buf in
+      traceln "Got: %s" (Cstruct.to_string buf)
+    )
+    (fun () ->
+      Eio.Flow.copy_string msg w;
+      Eio.Flow.close w
+    );;
++Got: Hello, world
+- : unit = ()
+```


### PR DESCRIPTION
This adds `Eio_unix.pipe` to create a connected pair of flows similar to `socketpair`, this is part of #330 