### PR TITLE
Add Eio_unix.pipe workaround, zap Eio_linux.pipe

### DIFF
--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -74,10 +74,6 @@ type stdenv = <
 val get_fd : <has_fd; ..> -> FD.t
 val get_fd_opt : #Eio.Generic.t -> FD.t option
 
-val pipe : Switch.t -> source * sink
-(** [pipe sw] is a source-sink pair [(r, w)], where data written to [w] can be read from [r].
-    It is implemented as a Unix pipe. *)
-
 (** {1 Main Loop} *)
 
 val run :


### PR DESCRIPTION
Make sure we workaround uring pipe bug from #319 in Eio_unix.pipe. Zap Eio_linux.pipe since it's only used in tests.

cc @patricoferris 