### PR TITLE
eio_luv: add low-level process support

### DIFF
--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -143,6 +143,58 @@ module Low_level : sig
     val write : [ `Stream of [< `Pipe | `TCP | `TTY ] ] Handle.t -> Luv.Buffer.t list -> unit
     (** [write handle bufs] writes the contents of [bufs] to [handle]. *)
   end
+
+  module Pipe : sig
+    type t = [`Pipe] Stream.t
+    (** A pipe *)
+
+    val init : ?for_handle_passing:bool -> sw:Switch.t -> unit -> t
+    (** Wraps {!Luv.Pipe.init}*)
+  end
+
+  module Process : sig
+    type t
+    (** A process *)
+
+    val pid : t -> int
+    (** [pid t] returns the process id of [t]. *)
+
+    val to_parent_pipe :
+      ?readable_in_child:bool ->
+      ?writable_in_child:bool ->
+      ?overlapped:bool ->
+      fd:int ->
+      parent_pipe:Pipe.t ->
+      unit ->
+      Luv.Process.redirection
+    (** Wraps {!Luv.Process.to_parent_pipe}*)
+
+    val await_exit : t -> int * int64
+    (** [await_exit t] waits for the process [t] to finish.
+
+        It returns [(exit_status, term_signal)], see {!Luv.Process.spawn} for
+        more details on these values. *)
+
+    val has_exited : t -> bool
+    (** [has_exited t] checks if the process [t] has exited or not. *)
+
+    val send_signal : t -> int -> unit
+    (** A wrapper for {!Luv.Process.kill}. *)
+
+    val spawn :
+      ?cwd:string ->
+      ?env:(string * string) list ->
+      ?uid:int ->
+      ?gid:int ->
+      ?redirect:Luv.Process.redirection list ->
+      sw:Switch.t ->
+      string ->
+      string list -> t
+    (** Wraps {!Luv.Process.spawn}.
+
+        The process will be stopped when the switch is released if
+        it has not already exited.*)
+  end
 end
 
 (** {1 Eio API} *)

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -131,6 +131,18 @@ module Low_level : sig
         @param sw The handle is closed when [sw] is released, if not closed manually first.
         @param close_unix if [true] (the default), calling [close] also closes [fd]. *)
   end
+
+  module Stream : sig
+    type 'a t = [`Stream of 'a] Handle.t
+
+    val read_into : [< `Pipe | `TCP | `TTY ] t -> Luv.Buffer.t -> int
+    (** [read_into handle buf] reads some bytes from [handle] into [buf] returning the number
+        of bytes read.
+        @raise End_of_file if there is no more data to read *)
+
+    val write : [ `Stream of [< `Pipe | `TCP | `TTY ] ] Handle.t -> Luv.Buffer.t list -> unit
+    (** [write handle bufs] writes the contents of [bufs] to [handle]. *)
+  end
 end
 
 (** {1 Eio API} *)

--- a/lib_eio_luv/tests/process.md
+++ b/lib_eio_luv/tests/process.md
@@ -1,0 +1,116 @@
+# Set up the test environment
+
+```ocaml
+# #require "eio_luv";;
+# open Eio.Std;;
+# open Eio;;
+# module Process = Eio_luv.Low_level.Process;;
+module Process = Eio_luv.Low_level.Process
+```
+
+A helper function for reading all of the bytes from a handle.
+
+```ocaml
+let read_all handle buf =
+  let rec read acc =
+    match Eio_luv.Low_level.Stream.read_into handle buf with
+    | i -> read (acc + i)
+    | exception End_of_file -> acc
+  in read 0
+```
+
+A simple `echo hello` process redirects to stdout.
+
+```ocaml
+# Eio_luv.run @@ fun _env ->
+  Switch.run @@ fun sw ->
+  let redirect = Luv.Process.[
+    inherit_fd ~fd:stdout ~from_parent_fd:stdout ()
+  ] in
+  let t = Process.spawn ~sw ~redirect "echo" [ "echo"; "hello" ] in
+  Process.await_exit t;;
+hello
+- : int * int64 = (0, 0L)
+```
+
+Using a pipe to redirect output to a buffer.
+
+```ocaml
+# Eio_luv.run @@ fun _env ->
+  Switch.run @@ fun sw ->
+  let parent_pipe = Eio_luv.Low_level.Pipe.init ~sw () in
+  let buf = Luv.Buffer.create 32 in 
+  let redirect = Eio_luv.Low_level.Process.[
+    to_parent_pipe ~fd:Luv.Process.stdout ~parent_pipe ()
+  ] in
+  let t = Process.spawn ~sw ~redirect "echo" [ "echo"; "Hello,"; "World!" ] in
+  let read = read_all parent_pipe buf in
+  let _ = Process.await_exit t in
+  Luv.Buffer.to_string (Luv.Buffer.sub buf ~offset:0 ~length:read);;
+- : string = "Hello, World!\n"
+```
+
+Writing to stdin of a process works.
+
+```ocaml
+# Eio_luv.run @@ fun _env ->
+  Switch.run @@ fun sw ->
+  let parent_pipe = Eio_luv.Low_level.Pipe.init ~sw () in
+  let bufs = [ Luv.Buffer.from_string "Hello!" ] in 
+  let redirect = Luv.Process.[
+    inherit_fd ~fd:stdout ~from_parent_fd:stdout ();
+    Process.to_parent_pipe ~fd:stdin ~parent_pipe ()
+  ] in
+  let t = Process.spawn ~sw ~redirect "head" [ "head" ] in
+  Eio_luv.Low_level.Stream.write parent_pipe bufs;
+  Eio_luv.Low_level.Handle.close parent_pipe;
+  Process.await_exit t;;
+Hello!
+- : int * int64 = (0, 0L)
+```
+
+Stopping a process works.
+
+```ocaml
+# Eio_luv.run @@ fun _env ->
+  Switch.run @@ fun sw ->
+  let redirect = Luv.Process.[
+    inherit_fd ~fd:stdout ~from_parent_fd:stdout ()
+  ] in
+  let t = Process.spawn ~sw ~redirect "sleep" [ "sleep"; "10" ] in
+  Process.send_signal t Luv.Signal.sigkill;
+  Process.await_exit t;;
+- : int * int64 = (9, 0L)
+```
+
+Forgetting to wait for a process to finish stops the process.
+
+```ocaml
+# Eio_luv.run @@ fun _env ->
+  let proc =
+    Switch.run @@ fun sw ->
+    let redirect = Luv.Process.[
+      inherit_fd ~fd:stdout ~from_parent_fd:stdout ()
+    ] in
+    Process.spawn ~sw ~redirect "sleep" [ "sleep"; "10" ]
+  in
+  Process.await_exit proc;;
+- : int * int64 = (9, 0L)
+```
+
+Stopping a process interacts nicely with switches.
+
+```ocaml
+# Eio_luv.run @@ fun _env ->
+  let proc =
+    Switch.run @@ fun sw ->
+    let redirect = Luv.Process.[
+      inherit_fd ~fd:stdout ~from_parent_fd:stdout ()
+    ] in
+    let t = Process.spawn ~sw ~redirect "sleep" [ "sleep"; "10" ] in
+    Process.send_signal t Luv.Signal.sigkill;
+    t
+  in
+  Process.await_exit proc;;
+- : int * int64 = (9, 0L)
+```


### PR DESCRIPTION
This PR adds low-level process support to Eio_luv as per the suggestion in #330. A few questions:

1. Because this is the low-level API is it okay to just return `(int * int64)` from the callback function as the exit status (see https://aantron.github.io/luv/luv/Luv/Process/index.html#val-spawn for an explanation) ?
2. Should the low-level API use switches to protect against leaking a process spawn ?
3. I've exposed `Eio_luv.Low_level.Stream` is that alright (I don't know if it was just because there was no need for it or if there is some other reason it wasn't exposed) ?