### PR TITLE
Buf_read: add `try_` and `<|>` parsers

### DIFF
--- a/lib_eio/buf_read.ml
+++ b/lib_eio/buf_read.ml
@@ -38,6 +38,8 @@ module Syntax = struct
   let ( *> ) a b t =
     ignore (a t);
     b t
+
+  let ( <|> ) a b t = try a t with _ -> b t
 end
 
 open Syntax

--- a/lib_eio/buf_read.ml
+++ b/lib_eio/buf_read.ml
@@ -295,6 +295,17 @@ let end_of_input t =
   if not (at_end_of_input t) then
     failwith "Unexpected data after parsing"
 
+let try_ p t =
+  let consumed_bytes = consumed_bytes t in
+  let pos = t.pos in
+  let len = t.len in
+  try p t
+  with exn ->
+    t.consumed <- consumed_bytes;
+    t.pos <- pos;
+    t.len <- len;
+    Fmt.failwith "%a" Fmt.exn exn
+
 let pp_pos f t =
   Fmt.pf f "at offset %d" (consumed_bytes t)
 

--- a/lib_eio/buf_read.mli
+++ b/lib_eio/buf_read.mli
@@ -157,6 +157,10 @@ val end_of_input : unit parser
 (** [end_of_input] checks that there are no further bytes in the stream.
     @raise Failure if there are further bytes *)
 
+val try_ : 'a parser -> 'a parser
+(** [try_ p] is [p] except when [p] fails, it resets all {!val:consumed_bytes} during parsing
+    of [p] before propagating the parsing error. *)
+
 (** {2 Combinators} *)
 
 val seq : ?stop:bool parser -> 'a parser -> 'a Seq.t parser

--- a/lib_eio/buf_read.mli
+++ b/lib_eio/buf_read.mli
@@ -226,6 +226,15 @@ module Syntax : sig
   val ( *> ) : 'a parser -> 'b parser -> 'b parser
   (** [a *> b] is [map snd (pair a b)].
       It parses two things and keeps only the second. *)
+
+  val ( <|> ) : 'a parser -> 'a parser -> 'a parser
+  (** [a <|> b] is a choice or alternate operator. It first attempts to parse [a]. Failing which
+      it attempts to parse [b].
+
+      [<|>] doesn't change the default backtracking behavior - no backtracking. However together
+      with a `try_` operator one can implement parsers that support a limited form of
+      backtracking. It is recommended to wrap the left side of `a <|> b` with `try_`, e.g. 
+      `(try_ a) <|> b` to achieve this. *)
 end
 
 (** {2 Low-level API} *)

--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -443,6 +443,20 @@ val c2 : int = 1
 - : bool = true
 ```
 
+## <|>
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:50;;
+val i : R.t = <abstr>
+# next := ["abc"]; R.(char 'z' <|> (char 'a')) i;;
++mock_flow returning 3 bytes
+- : unit = ()
+# R.string "bc" i;;
+- : unit = ()
+# R.consumed_bytes i;;
+- : int = 3
+```
+
 ## Combinators
 
 Parsers can be combined in the usual ways:

--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -421,6 +421,28 @@ Exception: Eio__Buf_read.Buffer_limit_exceeded.
 - : string = "abc"
 ```
 
+## try_
+
+```ocaml
+# let i = R.of_flow mock_flow ~max_size:50;;
+val i : R.t = <abstr>
+# next := ["abc"]; R.(char 'a') i;;
++mock_flow returning 3 bytes
+- : unit = ()
+# let c1 = R.consumed_bytes i;;
+val c1 : int = 1
+# R.(try_ (char 'b' *> string "hello")) i;;
+Exception: Failure "Failure(\"Expected \\\"hello\\\" but got \\\"c\\\"\")".
+# let c2 = R.consumed_bytes i;;
+val c2 : int = 1
+# c1 = c2;;
+- : bool = true
+# R.(string "bc") i;;
+- : unit = ()
+# R.consumed_bytes i = 3;;
+- : bool = true
+```
+
 ## Combinators
 
 Parsers can be combined in the usual ways:


### PR DESCRIPTION
This PR implements `try` and `<|>` parsers in `Buf_read`. This allows to implement ABNF alternative grammar (https://www.rfc-editor.org/rfc/rfc5234.html#section-3.2) without having to left factor them first.

