### PR TITLE
Make sure we mint exclusive ids

### DIFF
--- a/lib_eio/core/ctf.ml
+++ b/lib_eio/core/ctf.ml
@@ -28,11 +28,10 @@ end
 
 type id = int
 
-let last_id = ref 0
+let next_id = Atomic.make 1
 
 let mint_id () =
-  incr last_id;
-  !last_id
+  Atomic.fetch_and_add next_id 1
 
 type hiatus_reason =
   | Wait_for_work


### PR DESCRIPTION
This preserves the same id starting as 1, as fetch_and_add returns the value pre-increment. Therefore it now expresses next_id, not last_id.