### PR TITLE
Signal

### DIFF
--- a/lib_eio/dune
+++ b/lib_eio/dune
@@ -3,3 +3,7 @@
   (public_name eio)
   (flags (:standard -open Eio__core -open Eio__core.Private))
   (libraries eio__core cstruct lwt-dllist fmt bigstringaf optint mtime))
+
+(rule
+ (targets config.ml)
+ (action (run ./include/discover.exe)))

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -28,6 +28,7 @@ module Time = Time
 module File = File
 module Fs = Fs
 module Path = Path
+module Signal = Signal
 
 module Stdenv = struct
   type t = <

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -120,6 +120,9 @@ module Fs = Fs
 (** Accessing paths on a file-system. *)
 module Path = Path
 
+(** Setting up signal handlers. *)
+module Signal = Signal
+
 (** Control over debugging. *)
 module Debug : sig
   (** Example:

--- a/lib_eio/include/discover.ml
+++ b/lib_eio/include/discover.ml
@@ -1,0 +1,102 @@
+module C = Configurator.V1
+
+let mangle (s:string) =
+  let is_alpha = function 'a' .. 'z' | 'A' .. 'Z' -> true | _ -> false in
+  let rec first_alpha i =
+    if is_alpha (String.get s i) then
+      i
+    else
+      first_alpha (succ i)
+  in
+  let skip = first_alpha 0 in
+  String.sub s skip ((String.length s) - skip) |>
+  String.lowercase_ascii
+
+let () =
+  let open C.C_define in
+  C.main ~name:"discover" @@
+  fun c ->
+  let sig_build =
+    C.C_define.import c
+      ~c_flags:["-I"; Filename.concat (Sys.getcwd ()) "include"]
+      ~includes:["signal.h"]
+  in
+  let process =
+    List.map
+      (function
+        | name, Value.Int v ->
+          Printf.sprintf "  let %s = %d" (mangle name) v
+        | name, Value.Switch v ->
+          if not v then
+            Printf.sprintf "  let %s_opt = None" (mangle name)
+          else
+            (match sig_build Type.[ name, Int; ] with
+             | (name, Value.Int v) :: [] ->
+               Printf.sprintf "  let %s_opt = Some %d" (mangle name) v
+             | _ -> assert false)
+        | _ -> assert false)
+  in
+  let signums =
+    sig_build
+      Type.[
+        "SIGHUP", Int;
+        "SIGINT", Int;
+        "SIGQUIT", Int;
+        "SIGILL", Int;
+        "SIGTRAP", Int;
+        "SIGABRT", Int;
+        "SIGEMT", Switch;
+        "SIGFPE", Int;
+        "SIGKILL", Int;
+        "SIGBUS", Int;
+        "SIGSEGV", Int;
+        "SIGSYS", Int;
+        "SIGPIPE", Int;
+        "SIGALRM", Int;
+        "SIGTERM", Int;
+        "SIGURG", Int;
+        "SIGSTOP", Int;
+        "SIGTSTP", Int;
+        "SIGCONT", Int;
+        "SIGCHLD", Int;
+        "SIGTTIN", Int;
+        "SIGTTOU", Int;
+        "SIGIO", Int;
+        "SIGXCPU", Int;
+        "SIGXFSZ", Int;
+        "SIGVTALRM", Int;
+        "SIGPROF", Int;
+        "SIGWINCH", Int;
+        "SIGINFO", Switch;
+        "SIGUSR1", Int;
+        "SIGUSR2", Int;
+        "SIGTHR", Switch;
+      ] |> process
+  in
+  let nsig =
+    let maxfound =
+      sig_build
+        Type.[
+          "NSIG", Switch;
+          "_NSIG", Switch;
+          "_SIG_MAXSIG", Switch;
+        ] |>
+      List.map
+        (function
+          | name, Value.Switch v ->
+            if not v then
+              0
+            else
+              (match sig_build Type.[ name, Int; ] with
+               | (_, Value.Int v) :: [] -> v
+               | _ -> assert false)
+          | _ -> assert false)
+    in
+    let maxfound = List.fold_left max 64 maxfound in
+    [ Printf.sprintf "  let nsig = %d" maxfound ]
+  in
+  C.Flags.write_lines "config.ml" @@
+  [ "module Signum = struct" ] @
+  nsig @
+  signums @
+  [ "end" ]

--- a/lib_eio/include/dune
+++ b/lib_eio/include/dune
@@ -1,0 +1,4 @@
+(executable
+ (name discover)
+ (modules discover)
+ (libraries dune-configurator))

--- a/lib_eio/signal.ml
+++ b/lib_eio/signal.ml
@@ -1,0 +1,70 @@
+(*
+ * Copyright (C) 2022 Christiano Haesbaert
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+include Config.Signum
+
+type sigbox = {
+  box        : unit Stream.t;
+  signum     : int;
+  hook       : Switch.hook ref;
+  subscribed : bool ref;
+}
+
+type signum = int
+
+let signum_to_int signum = (signum :> int)
+
+module Private = struct
+  type _ Effect.t +=
+    | Subscribe : (int * unit Stream.t) -> unit Effect.t
+    | Unsubscribe : (int * unit Stream.t) -> unit Effect.t
+    | Publish : int -> unit Effect.t
+
+  let subscribe sigbox = Effect.perform @@ Subscribe (sigbox.signum, sigbox.box)
+  let unsubscribe sigbox = Effect.perform @@ Unsubscribe (sigbox.signum, sigbox.box)
+  let publish signum = Effect.perform @@ Publish signum
+end
+
+let check_subscription sigbox =
+  if not !(sigbox.subscribed) then
+    invalid_arg "sigbox is not subscribed"
+
+let unsubscribe sigbox =
+  check_subscription sigbox;
+  Private.unsubscribe sigbox;
+  sigbox.subscribed := false;
+  Switch.remove_hook !(sigbox.hook)
+
+let subscribe ~sw signum =
+  assert (signum > 0 && signum < nsig);
+  let sigbox =
+    { box = Stream.create 1; signum;
+      hook = ref Switch.null_hook; subscribed = ref false }
+  in
+  sigbox.hook := Switch.on_release_cancellable sw (fun () -> unsubscribe sigbox);
+  Private.subscribe sigbox;
+  sigbox.subscribed := true;
+  sigbox
+
+let publish signum = Private.publish signum
+
+let wait sigbox =
+  check_subscription sigbox;
+  Stream.take sigbox.box
+
+let wait_one signum = Switch.run @@ fun sw -> subscribe ~sw signum |> wait
+
+let is_pending sigbox = not (Stream.is_empty sigbox.box)

--- a/lib_eio/signal.mli
+++ b/lib_eio/signal.mli
@@ -1,0 +1,107 @@
+(** Signals
+
+    Signals in EIO work on a subscription basis. A {!sigbox} is
+    subscribed to a specific {!signum} via [subscribe], which can in
+    turn be waited on with [wait].
+
+    When a signal arrives, all {!sigbox}es subscribed to the
+    corresponding signal are populated and [wait] returns.
+
+    Signals are buffered but not indefinately, the size of the buffer
+    and the number of signals queued depend on the backend implementation.
+
+    There can be multiple subscriptions for the same {!signum}, even
+    across different domains, but each individual {!sigbox} is local
+    to its domain and tied to a {!Switch.t}
+*)
+
+(** Example:
+    {[
+      Switch.run @@ fun sw ->
+      let sighupbox = Signal.(subscribe ~sw sighup) in
+      while !run do
+        Signal.wait sighupbox;
+        traceln "Got sighup";
+        daemon_reconfigure ();
+      done;
+      Signal.unsubscribe sighupbox
+    ]}
+
+    {[
+      Fiber.first
+        (fun () -> Signal.(wait_one sigint))
+        (fun () -> Time.sleep clock 1.0)
+    ]}
+*)
+
+type sigbox
+(** Stores signals that can be [wait]ed on, each {!sigbox} listens to
+    one {!signum}, you can have multiple {!sigbox} for the same
+    {!signum}, and in multiple domains.
+
+*)
+
+module Private : sig
+  type _ Effect.t +=
+    | Subscribe : (int * unit Stream.t) -> unit Effect.t
+    | Unsubscribe : (int * unit Stream.t) -> unit Effect.t
+    | Publish : int -> unit Effect.t
+end
+
+type signum = private int
+
+val subscribe : sw:Switch.t -> signum -> sigbox
+(** Create a subscription for waiting on signal {!signum}. *)
+
+val unsubscribe : sigbox -> unit
+(** Remove a subscription, possibly restoring the orignal {!signum} behaviour. *)
+
+val publish : signum -> unit
+(** Raise a signal, like kill. **)
+
+val wait : sigbox -> unit
+(** Wait for signals, it is an error to [wait] on an unsubscribed {!sigbox}. *)
+
+val wait_one : signum -> unit
+(** Like [wait] but only for a single occurrence of {!signum}. *)
+
+val is_pending : sigbox -> bool
+(** false if [wait] would block. *)
+
+val signum_to_int : signum -> int
+(** The system's idea of {!signum}, always a positive number, unlike signals from {!Sys}. *)
+
+(** Signals, some are optional since not every system supports those. *)
+val sighup : signum
+val sigint : signum
+val sigquit : signum
+val sigill : signum
+val sigtrap : signum
+val sigabrt : signum
+val sigemt_opt : signum option
+val sigfpe : signum
+val sigkill : signum
+val sigbus : signum
+val sigsegv : signum
+val sigsys : signum
+val sigpipe : signum
+val sigalrm : signum
+val sigterm : signum
+val sigurg : signum
+val sigstop : signum
+val sigtstp : signum
+val sigcont : signum
+val sigchld : signum
+val sigttin : signum
+val sigttou : signum
+val sigio : signum
+val sigxcpu : signum
+val sigxfsz : signum
+val sigvtalrm : signum
+val sigprof : signum
+val sigwinch : signum
+val siginfo_opt : signum option
+val sigusr1 : signum
+val sigusr2 : signum
+val sigthr_opt : signum option
+val nsig : int

--- a/lib_eio/stream.mli
+++ b/lib_eio/stream.mli
@@ -28,6 +28,16 @@ val add : 'a t -> 'a -> unit
 
     If this would take [t] over capacity, it blocks until there is space. *)
 
+val add_nonblocking : 'a t -> 'a -> bool
+(** [add_nonblocking t item] adds [item] to [t].
+
+    Returns true if added, false if it would block. *)
+
+val add_canfail : 'a t -> 'a -> unit
+(** [add_canfail t item] tries to add [item] to [t].
+
+    Adding can fail if [t] is full, only use this when you want unreliable streams. *)
+
 val take : 'a t -> 'a
 (** [take t] takes the next item from the head of [t].
 

--- a/lib_eio_linux/tests/test.ml
+++ b/lib_eio_linux/tests/test.ml
@@ -31,7 +31,7 @@ let test_poll_add () =
   Alcotest.(check string) "Received data" "!" result
 
 let test_poll_add_busy () =
-  Eio_linux.run ~queue_depth:2 @@ fun _stdenv ->
+  Eio_linux.run ~queue_depth:3 @@ fun _stdenv ->
   Switch.run @@ fun sw ->
   let r, w = Eio_unix.pipe sw in
   let a = read_one_byte ~sw r in

--- a/tests/signals.md
+++ b/tests/signals.md
@@ -1,0 +1,201 @@
+# Signal Handling
+
+```ocaml
+# #require "eio_main";;
+```
+
+```ocaml
+open Eio.Std
+```
+
+Same signal multiple times
+```ocaml
+# Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let box1 = Eio.Signal.subscribe ~sw Eio.Signal.sigusr2 in
+  Eio.Signal.(publish sigusr2);
+  Eio.Signal.(publish sigusr2);
+  Eio.Signal.wait box1; traceln "box1";
+  Eio.Signal.wait box1; traceln "box1";
+  Eio.Signal.unsubscribe box1;
+  ;;
++box1
++box1
+- : unit = ()
+```
+
+One signal and multiple fibers
+
+```ocaml
+# Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let box1 = Eio.Signal.subscribe ~sw Eio.Signal.sigusr2 in
+  let box2 = Eio.Signal.subscribe ~sw Eio.Signal.sigusr2 in
+  let got_box1, got_box2, got_box3 = ref false, ref false, ref false in
+  Eio.Fiber.all [
+    (fun () -> Eio.Signal.wait box1; got_box1 := true);
+    (fun () -> Eio.Signal.wait box2; got_box2 := true);
+    (fun () -> Eio.Signal.wait_one Eio.Signal.sigusr2; got_box3 := true);
+    (fun () -> Eio.Signal.(publish sigusr2));
+  ];
+  Eio.Signal.unsubscribe box1;
+  Eio.Signal.unsubscribe box2;
+  assert (!got_box1 && !got_box2 && !got_box3);
+  ;;
+- : unit = ()
+```
+
+Prove we fail on a unsubscribed box
+
+```ocaml
+# Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let box1 = Eio.Signal.subscribe ~sw Eio.Signal.sigusr2 in
+  Eio.Signal.(publish sigusr2);
+  Eio.Signal.wait box1;
+  Eio.Signal.unsubscribe box1;
+  Eio.Signal.wait box1;;
+Exception: Invalid_argument "sigbox is not subscribed".
+```
+
+Prove cancelation works
+
+```ocaml
+let prove_cancel () =
+  let child () =
+    Eio_main.run @@ fun _env ->
+    Eio.Fiber.first
+      (fun () -> Eio.Signal.(wait_one sigusr2))
+      (fun () -> ());
+    Eio.Signal.(publish sigusr2) (* suicide *)
+  in
+  let parent pid =
+    match Unix.(waitpid [] pid) with
+    | pid', Unix.WSIGNALED signum ->
+      assert (pid = pid');
+      assert (signum = Sys.sigusr2)
+    | _ -> failwith "unexpected waitpid return"
+  in
+  let pid = Unix.fork () in
+  if pid = 0 then
+    child ()
+  else
+    parent pid
+in
+prove_cancel ()
+```
+
+Prove we can receive in multiple domains and that handlers are
+properly cleared.
+
+```ocaml
+let multi ~hang =
+  let num_domains = 8 in
+  let ptoc = Unix.pipe () in
+  let ctop = Unix.pipe () in
+  let isigusr1 = Eio.Signal.(signum_to_int sigusr1) in
+  let wait_exited pid ec =
+    match (Unix.waitpid [] pid) with
+    | pid', Unix.WEXITED ec' ->
+      assert (pid = pid');
+      assert (ec = ec');
+    | _ -> failwith "unexpected waitpid return"
+  in
+  let rec signal_and_wait pid signum =
+    Unix.kill pid signum;
+    let pid', ec = Unix.(waitpid [ WNOHANG ] pid) in
+    if pid' <> 0 then (
+      assert (pid = pid');
+      match ec with
+      | Unix.WSIGNALED signum' -> assert (signum = signum')
+      | _ -> failwith "XXX unexpected waitpid return"
+    ) else (
+      Unix.sleepf 0.02;
+        signal_and_wait pid signum (* XXX is this tailrec !? *)
+    )
+  in
+  let write_byte fd byte =
+    let b = Bytes.create 1 in
+    Bytes.set_uint8 b 0 byte;
+    let n = Unix.single_write fd b 0 1 in
+    assert (n = 1)
+  in
+  let read_byte fd =
+    let b = Bytes.create 1 in
+    let n = Unix.read fd b 0 1 in
+    assert (n = 1);
+    Bytes.get_uint8 b 0
+  in
+  let parent pid =
+    Unix.close (snd ctop);
+    Unix.close (fst ptoc);
+    let input = fst ctop in
+    let _output = snd ptoc in
+    let wait_domains v =
+      let rec loop n =
+        if n = 0 then
+          ()
+        else
+          let () = assert ((read_byte input) = v) in
+          loop (pred n)
+      in
+      loop num_domains
+    in
+    wait_domains 255;
+    Unix.kill pid isigusr1;
+    wait_domains isigusr1;
+    (* if we told our  child to hang, at this point all handlers are being
+     * removed, we want to send another sigusr1 to terminate it, thus
+     * proving we restored the default signal behaviour *)
+    let () =
+      if hang then
+        signal_and_wait pid Sys.sigusr1 (* we're the parent *)
+      else
+        wait_exited pid 0
+    in
+    Unix.close (fst ctop);
+	Unix.close (snd ptoc)
+  in
+  let child () =
+    Unix.close (snd ptoc);
+    Unix.close (fst ctop);
+    let _input = fst ptoc in
+    let output = snd ctop in
+
+    Eio_main.run
+      (fun env ->
+         let domain_manager = Eio.Stdenv.domain_mgr env in
+         let clock = Eio.Stdenv.clock env in
+         let domain_main _i () =
+           Eio.Domain_manager.run domain_manager (fun () ->
+               Eio.Fiber.all [
+                 (fun () ->
+                    Eio.Signal.wait_one Eio.Signal.sigusr1;
+                    write_byte output isigusr1);
+
+                 (fun () ->
+                    (* let parent know we're up *)
+                    write_byte output 255);
+
+                 (fun () ->
+                    while hang do
+                     Eio.Time.sleep clock 60.0
+                   done)
+               ])
+         in
+         Eio.Fiber.all (List.init num_domains domain_main));
+    Unix._exit 0
+  in
+  let pid = Unix.fork () in
+  if pid <> 0 then
+    parent pid
+  else
+    child ()
+```
+
+```ocaml
+# multi ~hang:false;;
+- : unit = ()
+# multi ~hang:true;;
+- : unit = ()
+```


### PR DESCRIPTION
This implements Signals in a publish/subscriber pattern, the main goal is to
give a bit better semantics than pure POSIX signals while still being able to
work in cenarios where a native signal is needed (think a debugger and whatnot).

### Rationale

POSIX semantics for multithreading are very weak, signal dipositions continue to
be process-wide while signal masking is pthread-wide, this means when a signal
arrives to the process PID, any thread can end up handling the signal, this
together with the normal semantics of signals of being processed in whatever
altstack and interrupting code make it difficult to make proper use of it in
places like EIO.

I propose a publish/subscriber way of dealing with signals, a bit inspired by
how Libuv already handles it, users can subscribe to a signal number in a signal
box, this box can be waited on signals and integrates well with EIO Fibers,
blocking and so on.

A signal box (subscription) is always linked to a Switch.t in order to guarantee
the subscription is removed when the handler goes out of scope.

Multithreading is allowed, any Domain can create subscriptions, this makes it
interesting for things like every domain installing a handler for SIGTERM and
then doing a proper finishing when needed, or maybe handling a SIGHUP and
parking everyone until the main domain reconfigures and whatnot.

### Signal Numbers

The signals from Sys are in a negative form and the runtime translates them to
the system signal number, this would be ok if Sys exported all signals we want,
but it doesnt, so we have to discover our signal numbers. Sys actually works
with its own idea of a signal number (the negative) as well as the positive (the
system), with some minor inconveniences.

Since not every system has every signal, signals that are not guaranteed to
exist are exposed as an optional type, this forces the user to acknowledge "ok
this is not portable" as well as preventing him from using an invalid number.
The actual number is hidden from the user as a private int, but can be acquired
via Signal.signum_to_int.

### Libuv/Luv Implementation

Libuv provides pretty much the publish/subscriber mechanism already, so we just
make use of that, in luv signals are not really processed in the signal handler,
they just schedule something to be processed in the main loop.

### Uring Implementation

In uring we implement the publish/subscriber mechanism ourselves, since a signal
can have multiple listeners, we have to be careful to install a new handler when
it's the first and restore the original one when it's the last one being
removed. We do not make sigprocmask dances as they become a nightmare due to
inheritance.

The signal handler in uring must wake the signalbox (an Eio.Stream.t), which
means it must go into the scheduler, which means if we just handled it from the
signal handler, we would end up recursing, which means we wouldn't be able to
grab locks, which means we wouldn't be able to do Eio.Stream.add.

We solve this by using the old pipe trick, the signal handler just writes a byte
to a pipe via Unix.write (must be outside of EIO). We then have an extra Fiber
(like the eventfd listener) running by default that reads from the other end of
the pipe, gets the signal and publishes to all listeners via Eio.Stream.add.

### Why Not signalfd

I've actually written one version with signalfd, but it's a pretty terrible API
if you need multithreading, to make usage of it you basically have to mask all
signals on every Domain (which means you have to decide which ones you will mask
beforehand, possibly killing uses of catching SIGSEGV/SIGSTOP). Doing the pipe
trick gives us what we wanted from signalfd and is also portable if we want it
in other backends. I still have the signalfd code in a branch if anyone wants
it.
  There's a half-decent rant here:
  https://ldpreload.com/blog/signalfd-is-useless

### Why Stream.addcanfail

I've added addcanfail to Stream since signals can be lost, we don't want to
block the sender, we also don't want to be forking senders and/or buffering
signals indefinately. Actual POSIX signals can only be pending, there are never
"two SIGINT" to be processed, two SIGINT would be coalesced into one. We do a
bit more, when we introduce the pipe trick we end up buffering signals, which
means two SIGINTS would be two SIGINTS, so we're bound by the pipe buffer size.
Since draining the pipe is not dependant on the user calling anything, it's
virtually impossible to saturate it.

We still need addcanfail since the pipe reader cannot block on publish, imagine
you have multiple signals but the user never reads from one of the boxes, if the
pipe reader would block trying to send, it would not publish anything else.

Worth noting that libuv as well as libevent do the exact same, as it's an old
solution.

Pokes at #321 