### PR TITLE
lib_linux: expose log src

### DIFF
--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -249,3 +249,5 @@ module Low_level : sig
       an ipaddress. *)
 
 end
+
+val src : Logs.src


### PR DESCRIPTION
Expose log source so that we can individually control log level. 

Related to https://github.com/mirleft/ocaml-tls/pull/461