### PR TITLE
Simply Dockerfile now OCaml 5 is out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM ocaml/opam:debian-11-ocaml-5.0
 RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 # Ensure opam-repository is up-to-date:
 RUN cd opam-repository && git pull -q origin 08040ecbbbbb284606becd80c642a51ae1b6d7e1 && opam update
-# Switch to OCaml 5.0.0
-RUN opam pin remove -n ocaml-variants && opam install ocaml-base-compiler.5.0.0 --update-invariant
 # Install utop for interactive use:
 RUN opam install utop fmt
 # Install Eio's dependencies (adding just the opam files first to help with caching):


### PR DESCRIPTION
We no longer need to compile the compiler. This just avoids this warning when building:

```
[NOTE] ocaml-variants is not pinned.
[NOTE] Package ocaml-base-compiler is already installed (current version is 5.0.0).
```