### PR TITLE
Make Eio.Promise lock-free

### DIFF
--- a/bench/bench_promise.ml
+++ b/bench/bench_promise.ml
@@ -9,6 +9,12 @@ and response = {
   next_request : request Promise.u;
 }
 
+(* Simulate other work in the domain, and also prevent it from going to sleep.
+   Otherwise, we're just measuring how long it takes the OS to wake a sleeping thread. *)
+let rec spin () =
+  Fiber.yield ();
+  spin ()
+
 (* A client and server exchange these payload values.
    Each contains the current message and a resolver which the other party can use to reply. *)
 
@@ -49,7 +55,11 @@ let bench_resolved ~clock ~n_iters =
   Printf.printf "Reading a resolved promise: %.3f ns\n%!" (1e9 *. (t1 -. t0) /. float n_iters);
   assert (!t = n_iters)
 
-let run_bench ~domain_mgr ~clock ~use_domains ~n_iters =
+let maybe_spin v fn =
+  if v then Fiber.first spin fn
+  else fn ()
+
+let run_bench ~domain_mgr ~spin ~clock ~use_domains ~n_iters =
   let init_p, init_r = Promise.create () in
   Gc.full_major ();
   let _minor0, prom0, _major0 = Gc.counters () in
@@ -58,28 +68,30 @@ let run_bench ~domain_mgr ~clock ~use_domains ~n_iters =
     (fun () ->
        if use_domains then (
          Eio.Domain_manager.run domain_mgr @@ fun () ->
-         run_server ~n_iters ~i:0 init_r
+         maybe_spin spin (fun () -> run_server ~n_iters ~i:0 init_r)
        ) else (
-         run_server ~n_iters ~i:0 init_r
+         maybe_spin spin (fun () -> run_server ~n_iters ~i:0 init_r)
        )
     )
     (fun () ->
-       run_client ~n_iters ~i:0 init_p
+       maybe_spin spin (fun () -> run_client ~n_iters ~i:0 init_p)
     );
   let t1 = Eio.Time.now clock in
   let time_total = t1 -. t0 in
   let time_per_iter = time_total /. float n_iters in
   let _minor1, prom1, _major1 = Gc.counters () in
   let prom = prom1 -. prom0 in
-  Printf.printf "%11b, %8d, %8.2f, %13.4f\n%!" use_domains n_iters (1e9 *. time_per_iter) (prom /. float n_iters)
+  let domains = Printf.sprintf "%b/%b" use_domains spin in
+  Printf.printf "%11s, %8d, %8.2f, %13.4f\n%!" domains n_iters (1e9 *. time_per_iter) (prom /. float n_iters)
 
 let main ~domain_mgr ~clock =
   bench_resolved ~clock ~n_iters:(10_000_000);
-  Printf.printf "use_domains,   n_iters, ns/iter, promoted/iter\n%!";
-  [false, 1_000_000;
-   true,    100_000]
-  |> List.iter (fun (use_domains, n_iters) ->
-      run_bench ~domain_mgr ~clock ~use_domains ~n_iters
+  Printf.printf "domains/spin, n_iters,  ns/iter, promoted/iter\n%!";
+  [false, false, 1_000_000;
+   true,  true,    100_000;
+   true,  false,   100_000]
+  |> List.iter (fun (use_domains, spin, n_iters) ->
+      run_bench ~domain_mgr ~spin ~clock ~use_domains ~n_iters
     )
 
 let () =


### PR DESCRIPTION
This is slightly faster and simplifies the code.

I added an extra benchmark using two domains with a spinning fiber so they don't go to sleep.

![promise](https://user-images.githubusercontent.com/554131/210992668-be41f51b-24f5-442f-928a-cd86ce100ab4.png)

It's a bit clearer without the 3rd one:

![promise2](https://user-images.githubusercontent.com/554131/210993938-4b332fc4-ac9d-4bdf-9ce9-301ff204dbfc.png)

