### PR TITLE
Remove test dependency on Astring

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,6 @@
   (psq (>= 0.2.0))
   (fmt (>= 0.8.9))
   (hmap (>= 0.8.1))
-  (astring (and (>= 0.8.5) :with-test))
   (crowbar (and (>= 0.2) :with-test))
   (mtime (>= 2.0.0))
   (alcotest (and (>= 1.4.0) :with-test))

--- a/eio.opam
+++ b/eio.opam
@@ -18,7 +18,6 @@ depends: [
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}
   "hmap" {>= "0.8.1"}
-  "astring" {>= "0.8.5" & with-test}
   "crowbar" {>= "0.2" & with-test}
   "mtime" {>= "2.0.0"}
   "alcotest" {>= "1.4.0" & with-test}

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,4 +1,4 @@
 (tests
   (package eio)
-  (libraries cstruct crowbar fmt astring eio eio.mock)
+  (libraries cstruct crowbar fmt eio eio.mock)
   (names fuzz_buf_read fuzz_buf_write))


### PR DESCRIPTION
The stdlib now provides most of what we need and we can implement the rest manually.

It made #399 awkward because `open Astring` was hiding some of the more recent additions to `Stdlib.String`.