### PR TITLE
Remove debug-level logging

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -49,7 +49,6 @@
   (luv (>= 0.5.11))
   (luv_unix (>= 0.5.0))
   (mdx (and (>= 1.10.0) :with-test))
-  (logs (>= 0.7.0))
   (fmt (>= 0.8.9))))
 (package
  (name eio_main)

--- a/eio_luv.opam
+++ b/eio_luv.opam
@@ -14,7 +14,6 @@ depends: [
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}
   "mdx" {>= "1.10.0" & with-test}
-  "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
 ]

--- a/lib_eio_luv/dune
+++ b/lib_eio_luv/dune
@@ -1,4 +1,4 @@
 (library
  (name eio_luv)
  (public_name eio_luv)
- (libraries eio eio.unix luv luv_unix eio.utils logs fmt))
+ (libraries eio eio.unix luv luv_unix eio.utils fmt))


### PR DESCRIPTION
This doesn't seem useful and we also have tracing anyway. It clutters the logs when people turn on debug-level logging for their application. We might want to remove all logging eventually, but this is a start.

Alternative to #392.

It seems to make the noop benchmark very slightly faster:

![noop](https://user-images.githubusercontent.com/554131/211040075-2d301fcd-bd03-478d-9e06-5b45bd767d32.png)

/cc @bikallem