### PR TITLE
Fix off-by-one in fuzz test

### DIFF
--- a/fuzz/fuzz_buf_read.ml
+++ b/fuzz/fuzz_buf_read.ml
@@ -62,7 +62,7 @@ module Model = struct
     | Some (line, rest) ->
       if String.length line >= max_size then raise Buffer_limit_exceeded;
       t := rest;
-      if String.ends_with ~suffix:"\r" line then String.sub line 0 (String.length line - 2)
+      if String.ends_with ~suffix:"\r" line then String.sub line 0 (String.length line - 1)
       else line
     | None when !t = "" -> raise End_of_file
     | None when String.length !t >= max_size -> raise Buffer_limit_exceeded


### PR DESCRIPTION
Broken in 10e8a0e810. `Astring.String.with_index_range`'s end is inclusive.