### PR TITLE
net: add run_server to run eio servers

### DIFF
--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -269,3 +269,31 @@ let with_tcp_connect ?(timeout=Time.Timeout.none) ~host ~service t f =
   | exception (Exn.Io _ as ex) ->
     let bt = Printexc.get_raw_backtrace () in
     Exn.reraise_with_context ex bt "connecting to %S:%s" host service
+
+(* Run a server loop in a single domain. *)
+let run_server_loop ~connections ~on_error ~stop listening_socket connection_handler =
+  Switch.run @@ fun sw ->
+  let rec accept () =
+    Semaphore.acquire connections;
+    accept_fork ~sw ~on_error listening_socket (fun conn addr ->
+        Fun.protect (fun () -> connection_handler conn addr)
+            ~finally:(fun () -> Semaphore.release connections)
+      );
+    accept ()
+  in
+  match stop with
+  | None -> accept ()
+  | Some stop -> Fiber.first accept (fun () -> Promise.await stop)
+
+let run_server ?(max_connections=Int.max_int) ?(additional_domains) ?stop ~on_error listening_socket connection_handler : 'a =
+  if max_connections <= 0 then invalid_arg "max_connections";
+  Switch.run @@ fun sw ->
+  let connections = Semaphore.make max_connections in
+  let run_server_loop () = run_server_loop ~connections ~on_error ~stop listening_socket connection_handler in
+  additional_domains |> Option.iter (fun (domain_mgr, domains) ->
+      if domains < 0 then invalid_arg "additional_domains";
+      for _ = 1 to domains do
+        Fiber.fork ~sw (fun () -> Domain_manager.run domain_mgr (fun () -> ignore (run_server_loop () : 'a)))
+      done;
+    );
+  run_server_loop ()

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -170,6 +170,8 @@ class virtual listening_socket = object
   method virtual close : unit
 end
 
+type connection_handler = stream_socket -> Sockaddr.stream -> unit
+
 let accept ~sw (t : #listening_socket) = t#accept ~sw
 
 let accept_fork ~sw (t : #listening_socket) ~on_error handle =

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -182,11 +182,14 @@ val accept :
     The new socket will be closed automatically when [sw] finishes, if not closed earlier.
     If you want to handle multiple connections, consider using {!accept_fork} instead. *)
 
+type connection_handler = stream_socket -> Sockaddr.stream -> unit
+(** [connection_handler] handles incoming connections from a listening socket. *)
+
 val accept_fork :
   sw:Switch.t ->
   #listening_socket ->
   on_error:(exn -> unit) ->
-  (stream_socket -> Sockaddr.stream -> unit) ->
+  connection_handler ->
   unit
 (** [accept_fork socket fn] accepts a connection and handles it in a new fiber.
 


### PR DESCRIPTION
This PR adds `run_server` - to be used to spawn network socket server. The current version supports spawning both single domain and multi domain servers. The default is a single domain concurrent server.

Based on discussion in https://github.com/mirage/ocaml-cohttp/issues/961#issuecomment-1378661543.

/cc @talex5 @patricoferris 