### PR TITLE
Fix luv signals (issue #400)

### DIFF
--- a/tests/signal.md
+++ b/tests/signal.md
@@ -1,0 +1,39 @@
+# Setting up the environment
+
+```ocaml
+# #require "eio_main";;
+# open Eio.Std;;
+```
+
+# Test cases
+
+Prove we can catch sigint:
+```ocaml
+# Eio_main.run @@ fun _stdenv ->
+  let interrupted = Eio.Condition.create () in
+  let old = Sys.signal Sys.sigint
+      (Signal_handle (fun num -> if num = Sys.sigint then Eio.Condition.broadcast interrupted))
+  in
+  Fiber.both
+    (fun () ->
+      Eio.Condition.await_no_mutex interrupted;
+      traceln "interrupted!";
+    )
+    (fun () ->
+      let ppid = Unix.getpid () in
+      match Unix.fork () with
+      | 0 ->
+        Unix.kill ppid Sys.sigint;
+        Unix._exit 0
+      | child_pid ->
+        let wait () =
+          let pid, status = Unix.waitpid [] child_pid in
+          assert (pid = child_pid);
+          assert (status = (Unix.WEXITED 0))
+        in
+        try wait () with Unix.Unix_error (Unix.EINTR, _, _) -> wait ()
+    );
+  Sys.set_signal Sys.sigint old;;
++interrupted!
+- : unit = ()
+```


### PR DESCRIPTION
This makes sure we can process signals in luv the same way we do in uring. As stated in #400 the main issue is that luv's mainloop will restart on EINTR and we will never unwind back to ocaml land, so even though the process got the signal, the runtime will not see it until something else goes on.

The trick here is to abuse POSIX thread semantics and shove all signals into one specific systhread by blocking them in the other threads.

Additionally, I've fixed a bug in Ocaml 5.0 where the systhreads end up starting with all signals blocked: https://github.com/ocaml/ocaml/pull/11880. This PR works even with/without the bug.

### Danger Zone
This is tricky ! If you're thinking we can do better than pipes, think again ! Unix.sigsuspend doesn't work on multithreaded, we don't have a real Unix.pause (it's implemented on top of sigsuspend !).
The semantics for kill(2) to "self" are different than "from outside" when multithreaded, and the runtime doesn't expose pthread_kill(2). That's why on the test we have to fork and signal back to the parent. I know, it's horrible.