### PR TITLE
Buf_write: Fix BE.uint48 and LE.uint48.

### DIFF
--- a/lib_eio/buf_read.ml
+++ b/lib_eio/buf_read.ml
@@ -241,6 +241,8 @@ let any_char t =
   consume t 1;
   c
 
+let uint8 t = Char.code (any_char t)
+
 let peek_char t =
   match ensure t 1 with
   | () -> Some (get t 0)

--- a/lib_eio/buf_read.mli
+++ b/lib_eio/buf_read.mli
@@ -107,6 +107,9 @@ val string : string -> unit parser
 
     @raise Failure if [s] is not a prefix of the stream. *)
 
+val uint8 : int parser
+(** [uint8] parses the next byte as an unsigned 8-bit integer. *)
+
 (** Big endian parsers *)
 module BE : sig
   val uint16 : int parser

--- a/lib_eio/buf_write.ml
+++ b/lib_eio/buf_write.ml
@@ -281,10 +281,10 @@ module BE = struct
   let uint48 t i =
     writable_exn t;
     ensure_space t 6;
-    Bigstringaf.unsafe_set_int32_be t.buffer t.write_pos
-      Int64.(to_int32 (shift_right_logical i 4));
-    Bigstringaf.unsafe_set_int16_be t.buffer (t.write_pos + 2)
-      Int64.(to_int i);
+    Bigstringaf.unsafe_set_int16_be t.buffer t.write_pos
+      Int64.(to_int (shift_right_logical i 32));
+    Bigstringaf.unsafe_set_int32_be t.buffer (t.write_pos + 2)
+      Int64.(to_int32 i);
     advance_pos t 6
 
   let uint64 t i =
@@ -325,7 +325,7 @@ module LE = struct
     Bigstringaf.unsafe_set_int16_le t.buffer t.write_pos
       Int64.(to_int i);
     Bigstringaf.unsafe_set_int32_le t.buffer (t.write_pos + 2)
-      Int64.(to_int32 (shift_right_logical i 2));
+      Int64.(to_int32 (shift_right_logical i 16));
     advance_pos t 6
 
   let uint64 t i =


### PR DESCRIPTION
Arguments to logical shift are provided in bits, not bytes.

No tests added yet. It would be nice to test the `Buf_write` <-> `Buf_read` roundtrip. I'd be happy to add them, but am not sure where the best place would be.