### PR TITLE
Windows: fix "unavailable signal" error

### DIFF
--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -26,9 +26,6 @@ module Suspended = Eio_utils.Suspended
 module Zzz = Eio_utils.Zzz
 module Lf_queue = Eio_utils.Lf_queue
 
-(* SIGPIPE makes no sense in a modern application. *)
-let () = Sys.(set_signal sigpipe Signal_ignore)
-
 type amount = Exactly of int | Upto of int
 
 let system_thread = Ctf.mint_id ()
@@ -1553,3 +1550,8 @@ let rec run : type a.
       )
   in
   Option.get !result
+
+let run ?queue_depth ?n_blocks ?block_size ?polling_timeout ?fallback main =
+  (* SIGPIPE makes no sense in a modern application. *)
+  Sys.(set_signal sigpipe Signal_ignore);
+  run ?queue_depth ?n_blocks ?block_size ?polling_timeout ?fallback main

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -21,9 +21,6 @@ module Ctf = Eio.Private.Ctf
 module Fiber_context = Eio.Private.Fiber_context
 module Lf_queue = Eio_utils.Lf_queue
 
-(* SIGPIPE makes no sense in a modern application. *)
-let () = Sys.(set_signal sigpipe Signal_ignore)
-
 type Eio.Exn.Backend.t +=
   | Luv_error of Luv.Error.t
   | Outside_sandbox of string * string
@@ -1331,6 +1328,8 @@ let stop_signal_thread (tid, omask, outp) =
   Unix.sigprocmask SIG_SETMASK omask |> ignore
 
 let run main =
+  (* Unix's SIGPIPE makes no sense in a modern application. *)
+  if Sys.os_type = "Unix" then Sys.(set_signal sigpipe Signal_ignore);
   let sigctx = start_signal_thread () in
   Fun.protect (fun () -> run2 main)
     ~finally:(fun () -> stop_signal_thread sigctx)

--- a/tests/flow.md
+++ b/tests/flow.md
@@ -141,3 +141,19 @@ Writing to and reading from a pipe.
 +Got: Hello, world
 - : unit = ()
 ```
+
+Make sure we don't crash on SIGPIPE:
+
+```ocaml
+# Eio_main.run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let r, w = Eio_unix.pipe sw in
+  Eio.Flow.close r;
+  try
+    Eio.Flow.copy_string "Test" w;
+    assert false
+  with Eio.Io (Eio.Net.E Connection_reset _, _) ->
+    traceln "Connection_reset (good)"
++Connection_reset (good)
+- : unit = ()
+```


### PR DESCRIPTION
Only try to ignore SIGPIPE signals on Unix-type systems. Otherwise, it fails with:

    Fatal error: exception Invalid_argument("Sys.signal: unavailable signal")

Also, delay doing this until `Eio_luv.run` is called, so that merely linking with `Eio_luv` doesn't change the behaviour of your program.

Reported-by: Nicolás Ojeda Bär in https://github.com/ocaml-multicore/eio/issues/125#issuecomment-1230171255.

@polytypic can you confirm this works on Windows? I assume it's still needed.