### PR TITLE
eio_linux: call submit as needed

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -39,7 +39,7 @@
   (logs (>= 0.7.0))
   (fmt (>= 0.8.9))
   (cmdliner (and (>= 1.1.0) :with-test))
-  (uring (>= 0.4))))
+  (uring (>= 0.5))))
 (package
  (name eio_luv)
  (synopsis "Eio implementation using luv (libuv)")

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -16,7 +16,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.4"}
+  "uring" {>= "0.5"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
We may fail to submit a job because the SQE queue is full. Previously we would wait until some existing request completed, but that might never happen. Instead, we just flush the SQE queue and retry.

Fixes #409.