### PR TITLE
Fix various architectures

### DIFF
--- a/lib_eio_linux/dune
+++ b/lib_eio_linux/dune
@@ -1,7 +1,11 @@
 (library
  (name eio_linux)
  (public_name eio_linux)
- (enabled_if (= %{system} "linux"))
+ (enabled_if ; See https://github.com/ocaml/dune/issues/4895
+   (or (= %{system} "linux")          ; Linux-x86
+       (= %{system} "linux_eabihf")   ; Linux-arm32
+       (= %{system} "linux_elf")      ; Linux-x86_32
+       (= %{system} "elf")))          ; Linux-ppc64
  (foreign_stubs
   (language c)
   (flags :standard -D_LARGEFILE64_SOURCE)

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -58,7 +58,7 @@ let or_raise_fs = function
 (* Luv can't handle buffers with more than 2^32-1 bytes, limit it to
    31bit so we can also make sure 32bit archs don't overflow.
    See https://github.com/ocaml-multicore/eio/issues/335 *)
-let max_luv_buffer_size = 0x7fffffff
+let max_luv_buffer_size = 0x3fffffff   (* Max signed int on 32-bit OCaml platforms *)
 
 (* Return as much of [buf] as luv can handle. This is suitable if a short read/write is acceptable. *)
 let cstruct_to_luv_truncate buf =


### PR DESCRIPTION
Dune has various other odd names for Linux on different architectures: https://github.com/ocaml/dune/issues/4895
Note: I didn't do this for the tests. We'll still run the main test suite on these platforms.

Also, we defined `max_luv_buffer_size = 0x7fffffff`, but this doesn't work on 32-bit systems. Surprisingly, it doesn't trigger the `Integer literal exceeds the range of representable integers of type int` error either.

Something similar happens on 64-bits systems too:

```ocaml
utop # 0x3fffffffffffffff;;
- : int = 4611686018427387903

utop # 0x4000000000000000;;
- : int = -4611686018427387904

utop # 0x8000000000000000;;
Error: Integer literal exceeds the range of representable integers of type int
```

And this is pretty odd too:
```ocaml
utop # 4611686018427387903;;
- : int = 4611686018427387903

utop # 4611686018427387904;;
- : int = -4611686018427387904

utop # 4611686018427387905;;
Error: Integer literal exceeds the range of representable integers of type int
```

Apparently this isn't considered a bug: https://github.com/ocaml/ocaml/issues/4245