### PR TITLE
Add a benchmark for reading from /dev/zero

### DIFF
--- a/bench/bench_fd.ml
+++ b/bench/bench_fd.ml
@@ -1,0 +1,37 @@
+open Eio.Std
+
+let time label len fn =
+  let t0 = Unix.gettimeofday () in
+  fn ();
+  let t1 = Unix.gettimeofday () in
+  Fmt.pr "%9s, %.1f@." label (float len /. (t1 -. t0) /. (2. ** 30.))
+
+let main ~domain_mgr zero =
+  let iters = 100_000 in
+  let len = 64 * 1024 in
+  let n_fibers = 4 in
+  let n_domains = 4 in
+  let buf = Cstruct.create len in
+  let run1 () =
+    for _ = 1 to iters do Eio.Flow.read_exact zero buf done
+  in
+  print_endline "     test, GB/s";
+  time "1 fiber" (iters * len) run1;
+  time (Fmt.str "%d fibers" n_fibers) (iters * n_fibers * len) (fun () ->
+      Switch.run @@ fun sw ->
+      for _ = 1 to n_fibers do
+        Fiber.fork ~sw run1
+      done
+    );
+  time (Fmt.str "%d domains" n_domains) (iters * n_domains * len) (fun () ->
+      Switch.run @@ fun sw ->
+      for _ = 1 to n_domains do
+        Fiber.fork ~sw (fun () -> Eio.Domain_manager.run domain_mgr run1)
+      done
+    )
+
+let ( / ) = Eio.Path.( / )
+
+let () =
+  Eio_main.run @@ fun env ->
+  Eio.Path.with_open_in (env#fs / "/dev/zero") (main ~domain_mgr:env#domain_mgr)

--- a/bench/dune
+++ b/bench/dune
@@ -1,4 +1,4 @@
 (executables
   (names bench_stream bench_promise bench_semaphore bench_yield bench_cancel bench_mutex
-         bench_buf_read bench_condition)
+         bench_buf_read bench_condition bench_fd)
   (libraries eio_main))


### PR DESCRIPTION
This just reads from /dev/zero in a loop, sharing a single FD between all fibers and domains. With eio_linux, I get:

```
$ EIO_BACKEND=io-uring dune exec -- ./bench_fd.exe
     test, GB/s
  1 fiber, 29.1
 4 fibers, 33.7
4 domains, 37.0

$ EIO_BACKEND=luv dune exec -- ./bench_fd.exe
     test, GB/s
  1 fiber, 2.4
 4 fibers, 4.3
4 domains, 9.5
```

For comparison:
```
$ dd if=/dev/zero of=/dev/null bs=65536 count=100000
100000+0 records in
100000+0 records out
6553600000 bytes (6.6 GB, 6.1 GiB) copied, 0.13827 s, 47.4 GB/s
```