### PR TITLE
eio_linux: make it safe to share FDs across domains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ test_luv:
 	EIO_BACKEND=luv dune runtest
 
 dscheck:
+	dune exec -- ./lib_eio/tests/dscheck/test_rcfd.exe
 	dune exec -- ./lib_eio/tests/dscheck/test_sync.exe
 	dune exec -- ./lib_eio/tests/dscheck/test_semaphore.exe
 	dune exec -- ./lib_eio/tests/dscheck/test_cells.exe

--- a/lib_eio/tests/dscheck/dune
+++ b/lib_eio/tests/dscheck/dune
@@ -2,10 +2,16 @@
 (copy_files# (files ../../core/cells.ml))
 (copy_files# (files ../../sem_state.ml))
 (copy_files# (files ../../sync.ml))
+(copy_files# (files ../../unix/rcfd.ml))
 
 (executables
-  (names test_cells test_semaphore test_sync)
+  (names test_cells test_semaphore test_sync test_rcfd)
   (libraries dscheck optint fmt eio))
+
+(rule
+  (alias dscheck)
+  (package eio)
+  (action (run %{exe:test_rcfd.exe})))
 
 (rule
   (alias dscheck)

--- a/lib_eio/tests/dscheck/test_rcfd.ml
+++ b/lib_eio/tests/dscheck/test_rcfd.ml
@@ -1,0 +1,39 @@
+let debug = false
+
+module T = Rcfd
+
+let test ~n_users ~n_closers () =
+  let messages = ref [] in
+  let log fmt = (fmt ^^ "@.") |> Format.kasprintf @@ fun msg -> messages := msg :: !messages in
+  if debug then log "== start ==";
+  let wrapped_fd = Unix.make () in
+  let t = T.make wrapped_fd in
+  let n_closed = ref 0 in
+  for _ = 1 to n_users do
+    Atomic.spawn (fun () ->
+        T.use t ~if_closed:ignore (fun fd ->
+            log "Using FD";
+            assert (Atomic.get fd = `Open);
+            log "Releasing FD";
+          )
+      )
+  done;
+  for _ = 1 to n_closers do
+    Atomic.spawn (fun () ->
+        log "Closing FD";
+        if T.close t then (
+          log "Closed FD";
+          incr n_closed
+        ) else (
+          log "FD already closed";
+        )
+      )
+  done;
+  Atomic.final (fun () ->
+      if debug then List.iter print_string (List.rev !messages);
+      assert (!n_closed = 1);
+      assert (Atomic.get wrapped_fd = `Closed);
+    )
+
+let () =
+  Atomic.trace (test ~n_users:2 ~n_closers:2);

--- a/lib_eio/tests/dscheck/unix.ml
+++ b/lib_eio/tests/dscheck/unix.ml
@@ -1,0 +1,7 @@
+type file_descr = [`Open | `Closed] Atomic.t
+
+let make () = Atomic.make `Open
+
+let close t =
+  if not (Atomic.compare_and_set t `Open `Closed) then
+    failwith "Already closed!"

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -25,6 +25,8 @@ module Private = struct
     | Socket_of_fd : Eio.Switch.t * bool * Unix.file_descr -> socket Effect.t
     | Socketpair : Eio.Switch.t * Unix.socket_domain * Unix.socket_type * int -> (socket * socket) Effect.t
     | Pipe : Eio.Switch.t -> (<Eio.Flow.source; Eio.Flow.close; unix_fd> * <Eio.Flow.sink; Eio.Flow.close; unix_fd>) Effect.t
+
+  module Rcfd = Rcfd
 end
 
 let await_readable fd = Effect.perform (Private.Await_readable fd)

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -100,6 +100,8 @@ module Private : sig
         (socket * socket) Effect.t                           (** See {!socketpair} *)
     | Pipe : Eio.Switch.t -> 
         (<Eio.Flow.source; Eio.Flow.close; unix_fd> * <Eio.Flow.sink; Eio.Flow.close; unix_fd>) Effect.t (** See {!pipe} *)
+
+  module Rcfd = Rcfd
 end
 
 module Ctf = Ctf_unix

--- a/lib_eio/unix/rcfd.ml
+++ b/lib_eio/unix/rcfd.ml
@@ -1,0 +1,171 @@
+(* To prevent races closing FDs, we do some ref-counting.
+
+   Logically, the states of the wrapper for an FD [x] are:
+
+   - open : the FD is available for use.
+   - closing/users : no further operations can start, but some are still in progress.
+   - closing/no-users : all operations have finished.
+   - closing/closed : we no longer own the FD.
+
+   We start by dividing ownership of [x] into [max_int] shares
+   (enough shares for every sys-thread to take one).
+   Having a fractional share (not 0 or 1) means you can use [x] but not close it.
+
+   In the [open] and [closing/users] states, [t] owns the fraction
+   [(max_int - ops) / max_int] of [x].
+
+   In [closing/no-users], [t] owns all of [x].
+
+   Initially, [t] is in the [open] state and [ops = 0].
+
+   If you increment [ops] in [open] or [closing/users], you get one share and can use the FD
+   (though in [closing/users] you should immediately return it).
+   When you decrement [ops] in these cases, you give back your share and must not use the FD further.
+
+   If you increment/decrement when in the state [closing/no-users] or [closing/closed],
+   you do not get/return a share.
+
+   A fiber can call {!close} to move from [open] at any time.
+   If there are operations in progress when it does this, it transitions to [closing/users].
+   Otherwise, it goes directly to [closing/no-users].
+   The fiber that does this is known as the "closing fiber"
+   and is responsible for finishing the close.
+
+   We move from [closing/users] to [closing/no-users] when [ops] becomes 0
+   (and [t] therefore owns all shares of [x]).
+   [ops] may continue to change after this, but we never return to [closing/users]
+   or give any user a share of [x] after this.
+
+   From [closing/no-users], we transition to [closing/closed],
+   transferring the now-full ownership of [x] to the closing fiber.
+
+   In reality, the three [closing/*] states are represented by the single constructor [Closing],
+   and the code must work whatever the true state might be. *)
+
+type state =
+  | Open of Unix.file_descr
+  | Closing of (unit -> unit)     (* Function is called when [ops] becomes 0. *)
+
+type t = {
+  ops : int Atomic.t;
+  fd : state Atomic.t;
+}
+
+let fully_closed = Closing ignore      (* Used for [closing/closed] *)
+
+let put t =
+  let old = Atomic.fetch_and_add t.ops (-1) in
+  if old = 1 then (
+    (* We decremented [ops] from one to zero. We may need to notify the closer. *)
+    match Atomic.get t.fd with
+    | Open _ -> ()     (* The fast path. We're not closing. *)
+    | Closing no_users as prev ->
+      (* There are four possibilities for the state when we did the decrement:
+         - open: But it got closed after that. There could be new active users by now.
+         - closing/users: We were the last user and transitioned to closing/no-users.
+                          We need to notify the closer, or make sure someone else will do it later.
+         - closing/no-users: We might need to notify, since a previous thread that reached zero
+                             might have then seen [ops > 0] and deferred it to us.
+         - closing/closed: No need to do anything, but notifying is harmless.
+       *)
+      if Atomic.get t.ops > 0 then ()  (* Someone else will deal with it. *)
+      else if Atomic.compare_and_set t.fd prev fully_closed then (
+        (* We observed [t.ops = 0] after closing, so we were then at either [closing/no-users]
+           or [closing/closed], and we're now certainly at [closing/closed].
+           If it was [closing/no-users] then we now own the FD, which we pass to the closer.
+           If it was [closing/closed] then we don't, but [no_users] is [ignore] anyway. *)
+        no_users ()
+      ) else (
+        (* Someone else notified the closer first. We're now in [closing/closed]. *)
+      )
+  ) else (
+    assert (old > 1)
+  )
+
+let get t =
+  Atomic.incr t.ops;
+  (* If the state was [open] or [closing/users] then we now own 1 share of the FD. *)
+  match Atomic.get t.fd with
+  | Open fd ->
+    (* The state was [open]. Give the share that we took to our caller. *)
+    Some fd
+  | Closing _ ->
+    (* We want to close [t], so don't start a new operation.
+       If the state was [open] or [closing/users] when we incremented [ops] then
+       we return the share we took to [t] (which cannot now be [closing/no-users] as we are a user).
+       Otherwise, it was [closing/no-users] or [closing/closed], and still is one of those. *)
+    put t;
+    None
+
+(* Note: we could simplify this a bit by incrementing [t.ops], as [remove] does.
+   However, that makes dscheck too slow. *)
+let close t =
+  match Atomic.get t.fd with
+  | Closing _ ->
+    (* Another caller closed [t] before us. *)
+    false
+  | Open fd as prev ->
+    let next = Closing (fun () -> Unix.close fd) in
+    if Atomic.compare_and_set t.fd prev next then (
+      (* We just transitioned from [open] to [closing/users] or [closing/no-users].
+         We are now the closer. *)
+      if Atomic.get t.ops = 0 && Atomic.compare_and_set t.fd next fully_closed then (
+        (* We were in [closing/no-users] and are now in [closing/closed].
+           We own the FD (and our original callback will never be called). *)
+        Unix.close fd
+      ) else (
+        (* The [next] callback remained installed and there is nothing left for us to do:
+           - If [t.ops] was non-zero, another thread will eventually return it to zero and call our callback.
+           - If the CAS failed, then another thread is invoking our callback. *)
+      );
+      true
+    ) else (
+      (* Another domain became the closer first. *)
+      false
+    )
+
+let remove t =
+  Atomic.incr t.ops;
+  match Atomic.get t.fd with
+  | Closing _ ->
+    (* Another domain is dealing with it. *)
+    put t;
+    None
+  | Open fd as prev ->
+    Eio.Private.Suspend.enter_unchecked (fun _ctx enqueue ->
+        if Atomic.compare_and_set t.fd prev (Closing (fun () -> enqueue (Ok (Some fd)))) then (
+          (* We transitioned from [open] to [closing/users]. We are the closer. *)
+          put t
+        ) else (
+          (* Another domain is handling the close instead. *)
+          put t;
+          enqueue (Ok (None))
+        )
+      )
+
+let make fd =
+  {
+    ops = Atomic.make 0;
+    fd = Atomic.make (Open fd);
+  }
+
+let is_open t =
+  match Atomic.get t.fd with
+  | Open _ -> true
+  | Closing _ -> false
+
+let use ~if_closed t f =
+  match get t with
+  | None -> if_closed ()
+  | Some fd ->
+    match f fd with
+    | r -> put t; r
+    | exception ex ->
+      let bt = Printexc.get_raw_backtrace () in
+      put t;
+      Printexc.raise_with_backtrace ex bt
+
+let peek t =
+  match Atomic.get t.fd with
+  | Open fd -> fd
+  | Closing _ -> failwith "FD already closed!"

--- a/lib_eio/unix/rcfd.mli
+++ b/lib_eio/unix/rcfd.mli
@@ -1,0 +1,71 @@
+(** A safe wrapper around [Unix.file_descr].
+
+    When FDs are shared between domains, there is the risk that one domain will try to use an FD
+    just as another domain is closing it. Then this can happen:
+
+    + Domain A decides to write to FD 3, which it shares with domain B.
+    + Domain B closes FD 3.
+    + Domain C opens a new file, getting assigned FD 3 by the OS.
+    + Domain A writes to FD 3, corrupting domain C's file.
+
+    This would break modularity, since the fibers in domains A and C may have no connection with each other.
+
+    To prevent this, we keep a ref-count, tracking how many fibers are using the FD.
+    Wrap uses of the FD in {!use} to ensure that it won't be closed while you're using it.
+
+    Calling {!close} while one or more operations are still in progress marks
+    the wrapper as closing (so that no futher operations can start); the last
+    operation to finish will close the underlying FD. *)
+
+type t
+
+val make : Unix.file_descr -> t
+(** [let t = make fd] wraps [fd].
+
+    [t] takes ownership of [fd]. The caller is responsible for ensuring that {!close}
+    (or {!remove}) is called at least once in the future. *)
+
+val use : if_closed:(unit -> 'a) -> t -> (Unix.file_descr -> 'a) -> 'a
+(** [use t fn ~if_closed] calls [fn fd], preventing [fd] from being closed until [fn] returns.
+
+    [if_closed ()] is used if [t] is closed before we can increment the ref-count.
+    [use] can be used in parallel from multiple domains at the same time.
+
+    This operation is lock-free and can be used safely from signal handlers, etc. *)
+
+val is_open : t -> bool
+(** [is_open t] returns [true] until [t] has been marked as closing, after which it returns [false].
+
+    This is mostly useful inside the callback of {!use}, to test whether
+    another fiber has started closing [t] (in which case you may decide to stop early). *)
+
+val close : t -> bool
+(** [close t] marks [t] as closed and arranges for its FD to be closed.
+
+    If there are calls to {!use} in progress, the last one to finish will close the underlying FD.
+    Note that this function returns without waiting for the close to happen in that case.
+
+    Returns [true] after successfully marking [t] as closing, or [false] if it was already marked.
+
+    If you need to wait until the underlying FD is closed, use {!remove} and then close the FD yourself instead. *)
+
+val remove : t -> Unix.file_descr option
+(** [remove t] closes [t] and returns the FD.
+
+    It immediately marks [t] as closing (so no further operations can start)
+    and then waits until there are no further users.
+
+    This operation suspends the calling fiber and so must run from an Eio fiber.
+    It does not allow itself to be cancelled,
+    since it takes ownership of the FD and that would be leaked if it aborted.
+
+    If another fiber marks [t] as closing before [remove] can, it returns [None] immediately. *)
+
+val peek : t -> Unix.file_descr
+(** [peek t] returns the file-descriptor without updating the ref-count.
+
+    You must ensure that [t] isn't closed while using the result.
+    This is a dangerous operation and may be removed in the future.
+
+    If [t] was closed, it instead raises an exception (if you're not sure when
+    [t] might get closed, you shouldn't be using this function). *)

--- a/lib_eio_linux/tests/fd_sharing.md
+++ b/lib_eio_linux/tests/fd_sharing.md
@@ -1,0 +1,61 @@
+# Setting up the environment
+
+```ocaml
+# #require "eio_linux";;
+```
+
+```ocaml
+open Eio.Std
+```
+
+# Tests
+
+One domain closes an FD after another domain has enqueued a uring operation mentioning it.
+
+```ocaml
+# Eio_linux.run @@ fun env ->
+  let dm = env#domain_mgr in
+  Switch.run @@ fun sw ->
+  let m = Mutex.create () in
+  Mutex.lock m;
+  let r, w = Eio_unix.pipe sw in
+  let ready, set_ready = Promise.create () in
+  Fiber.both
+    (fun () ->
+       Eio.Domain_manager.run dm (fun () ->
+         Fiber.both
+           (fun () ->
+              traceln "Domain 1 enqueuing read on FD";
+              let buf = Cstruct.create 1 in
+              match Eio.Flow.single_read r buf with
+              | _ -> assert false
+              | exception End_of_file -> traceln "Read EOF"
+           )
+           (fun () ->
+               (* We have enqueued a read request, but not yet submitted it to Linux.
+                  Wait for [m] to prevent submission until the main domain is ready. *)
+               traceln "Waiting for domain 0...";
+               Promise.resolve set_ready ();
+               Mutex.lock m;
+               traceln "Domain 1 flushing queue"
+           )
+        )
+    )
+    (fun () ->
+       Promise.await ready;
+       traceln "Domain 0 closing FD";
+       Eio.Flow.close r;
+       Fiber.yield ();
+       traceln "Domain 0 closed FD; waking domain 1";
+       Mutex.unlock m;
+       (* Allow the read to complete. *)
+       Eio.Flow.close w
+    );;
++Domain 1 enqueuing read on FD
++Waiting for domain 0...
++Domain 0 closing FD
++Domain 0 closed FD; waking domain 1
++Domain 1 flushing queue
++Read EOF
+- : unit = ()
+```


### PR DESCRIPTION
It was previously not safe to share file descriptors between domains. The `fd_sharing.md` test demonstrates the problem: one domain enqueues an operation using an FD and another domain closes it first.

`Eio_unix.Private.Rcfd` provides a ref-counted wrapper for file descriptors to fix this problem. It's lock-free and designed to be fast in the common case where an FD is only used from one domain, but safe in the case where it's used from several.

The `bench_fd` benchmark is, if anything, slightly faster with this change, though I don't know why:

![fd](https://user-images.githubusercontent.com/554131/217837749-3a5d4c0e-b16d-42e1-9108-3412ed029df2.png)

There is a dscheck test that tests Rcfd with all combinations of two users and two closers.

It includes an (unsafe) `peek` operation, as the public API already provided this. We might want to remove that at some point and provide a safe `Eio_unix.FD.use` operation instead.

There is support here for safely having two domains try to close an FD at once, although eio_linux itself still doesn't support that (you must close from the domain that opened it).

It could also allow us to support a `try_close` operation at some point.

Note that closing is now always done with `Unix.close`, not uring. Using uring previously avoided races in the single-domain case, but that's not necessary now that we have a general solution. I did have a `remove_or_close` function that would use uring in the common case, but `Unix.close` if an operation was in progress, but that seemed over-complicated.

I'm intending to use this for the generic eio_posix backend too.