### PR TITLE
eio_linux: add some missing close-on-execs

### DIFF
--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1100,7 +1100,7 @@ let net = object
         let host = Eio_unix.Ipaddr.to_unix host in
         Unix.SOCK_STREAM, Unix.ADDR_INET (host, port)
     in
-    let sock_unix = Unix.socket (socket_domain_of listen_addr) socket_type 0 in
+    let sock_unix = Unix.socket ~cloexec:true (socket_domain_of listen_addr) socket_type 0 in
     (* For Unix domain sockets, remove the path when done (except for abstract sockets). *)
     begin match listen_addr with
       | `Unix path ->
@@ -1125,7 +1125,7 @@ let net = object
         let host = Eio_unix.Ipaddr.to_unix host in
         Unix.SOCK_STREAM, Unix.ADDR_INET (host, port)
     in
-    let sock_unix = Unix.socket (socket_domain_of connect_addr) socket_type 0 in
+    let sock_unix = Unix.socket ~cloexec:true (socket_domain_of connect_addr) socket_type 0 in
     let sock = FD.of_unix ~sw ~seekable:false ~close_unix:true sock_unix in
     Low_level.connect sock addr;
     (flow sock :> <Eio.Flow.two_way; Eio.Flow.close>)

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -1118,14 +1118,14 @@ let net = object
     listening_socket sock
 
   method connect ~sw connect_addr =
-    let socket_type, addr =
+    let addr =
       match connect_addr with
-      | `Unix path         -> Unix.SOCK_STREAM, Unix.ADDR_UNIX path
+      | `Unix path         -> Unix.ADDR_UNIX path
       | `Tcp (host, port)  ->
         let host = Eio_unix.Ipaddr.to_unix host in
-        Unix.SOCK_STREAM, Unix.ADDR_INET (host, port)
+        Unix.ADDR_INET (host, port)
     in
-    let sock_unix = Unix.socket ~cloexec:true (socket_domain_of connect_addr) socket_type 0 in
+    let sock_unix = Unix.socket ~cloexec:true (socket_domain_of connect_addr) Unix.SOCK_STREAM 0 in
     let sock = FD.of_unix ~sw ~seekable:false ~close_unix:true sock_unix in
     Low_level.connect sock addr;
     (flow sock :> <Eio.Flow.two_way; Eio.Flow.close>)


### PR DESCRIPTION
`datagram_socket` did this, but `connect` and `listen` forgot.