### PR TITLE
buf_read : add bigstring version of take_while/take_while1

### DIFF
--- a/lib_eio/buf_read.ml
+++ b/lib_eio/buf_read.ml
@@ -297,19 +297,23 @@ let count_while p t =
   try aux 0
   with End_of_file -> t.len
 
-let take_while p t =
+let take_while_bigstring p t =
   let len = count_while p t in
-  let data = Cstruct.to_string (Cstruct.of_bigarray t.buf ~off:t.pos ~len) in
+  let data = Cstruct.of_bigarray t.buf ~off:t.pos ~len in
   consume t len;
   data
 
-let take_while1 p t =
+let take_while p t = Cstruct.to_string (take_while_bigstring p t)
+
+let take_while1_bigstring p t =
   let len = count_while p t in
   if len < 1 then Fmt.failwith "take_while1"
   else
-    let data = Cstruct.to_string (Cstruct.of_bigarray t.buf ~off:t.pos ~len) in
+    let data = Cstruct.of_bigarray t.buf ~off:t.pos ~len in
     consume t len;
     data
+
+let take_while1 p t = Cstruct.to_string (take_while1_bigstring p t)
 
 let skip_while p t =
   let rec aux i =

--- a/lib_eio/buf_read.mli
+++ b/lib_eio/buf_read.mli
@@ -172,9 +172,15 @@ val take_while : (char -> bool) -> string parser
     It will return the empty string if there are no matching characters
     (and therefore never raises [End_of_file]). *)
 
+val take_while_bigstring : (char -> bool) -> Cstruct.t parser
+(** [take_while_bigstring f] is like {!val:take_while} but returns [Cstruct.t] instead of [String.t]. *)
+
 val take_while1 : (char -> bool) -> string parser
 (** [take_while1 p] is like [take_while]. However, the parser fails with "take_while1"
     if at least one character of input hasn't been consumed by the parser. *)
+
+val take_while1_bigstring : (char -> bool) -> Cstruct.t parser
+(** [take_while1 f] is like [take_whiel1] but returns [Cstruct.t] instead of [String.t]. *)
 
 val skip_while : (char -> bool) -> unit parser
 (** [skip_while p] skips zero or more bytes for which [p] is [true].


### PR DESCRIPTION
This PR adds the bigstring version of `take_while/take_while1` so that we don't allocate strings if we are primarily only working with `Cstruct.t`