### PR TITLE
Use dune.3.7.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.0)
+(lang dune 3.7)
 (name eio)
 (formatting disabled)
 (generate_opam_files true)

--- a/eio.opam
+++ b/eio.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.7"}
   "ocaml" {>= "5.0.0"}
   "bigstringaf" {>= "0.9.0"}
   "cstruct" {>= "6.0.1"}

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.7"}
   "alcotest" {>= "1.4.0" & with-test}
   "eio" {= version}
   "mdx" {>= "1.10.0" & with-test}

--- a/eio_luv.opam
+++ b/eio_luv.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.7"}
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.7"}
   "mdx" {>= "1.10.0" & with-test}
   "eio_linux" {= version & os = "linux"}
   "eio_posix" {= version & os != "windows"}

--- a/eio_posix.opam
+++ b/eio_posix.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.7"}
   "eio" {= version}
   "iomux" {>= "0.2"}
   "mdx" {>= "1.10.0" & with-test}

--- a/lib_eio/buf_write.ml
+++ b/lib_eio/buf_write.ml
@@ -163,7 +163,6 @@ type t =
   ; mutable bytes_written  : int        (* Total written bytes. Wraps. *)
   ; mutable state          : state
   ; mutable wake_writer    : unit -> unit
-  ; id                     : Ctf.id
   }
 (* Invariant: [write_pos >= scheduled_pos] *)
 
@@ -378,7 +377,6 @@ let of_buffer ?sw buffer =
           ; bytes_written   = 0
           ; state           = Active
           ; wake_writer     = ignore
-          ; id              = Ctf.mint_id ()
           }
   in
   begin match sw with

--- a/lib_eio/mock/backend.ml
+++ b/lib_eio/mock/backend.ml
@@ -10,7 +10,7 @@ type t = {
   (* Suspended fibers waiting to run again.
      [Lf_queue] is like [Stdlib.Queue], but is thread-safe (lock-free) and
      allows pushing items to the head too, which we need. *)
-  mutable run_q : (unit -> exit) Lf_queue.t;
+  run_q : (unit -> exit) Lf_queue.t;
 }
 
 (* Resume the next runnable fiber, if any. *)

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -54,11 +54,10 @@ module Low_level : sig
     (** [close t] closes [t].
         @raise Invalid_arg if [t] is already closed. *)
 
-    val of_luv : ?close_unix:bool -> sw:Switch.t -> Luv.File.t -> t
+    val of_luv : sw:Switch.t -> Luv.File.t -> t
     (** [of_luv ~sw fd] wraps [fd] as an open file descriptor.
         This is unsafe if [fd] is closed directly (before or after wrapping it).
-        @param sw The FD is closed when [sw] is released, if not closed manually first.
-        @param close_unix if [true] (the default), calling [close] also closes [fd]. *)
+        @param sw The FD is closed when [sw] is released, if not closed manually first. *)
 
     val to_luv : t -> Luv.File.t
     (** [to_luv t] returns the wrapped descriptor.


### PR DESCRIPTION
This is a PR to show the diff needed to bump everything to `dune.3.7.0` in order to get #405 working. Looks like:

 - Luv (even if it is on its way out) `File`s never make use of the `close_unix` param 
 - The mock backend doesn't need the runq to be mutable
 - A `Buf_write.t` has a CTF id which we would presumably like to use one day but at the moment don't so I've removed it (perhaps suppressing the warning there might be useful and ultimately actually using it would be good too).