### PR TITLE
Add Fiber.fork_seq

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,7 +14,8 @@
  (conflicts
   (ocaml-base-compiler (< 5.0.0~beta1))
   (ocaml-variants (< 5.0.0~beta1))
-  (ocaml-system (< 5.0.0~beta1)))
+  (ocaml-system (< 5.0.0~beta1))
+  (seq (< 0.3)))
  (depends
   (ocaml (>= 5.0.0))
   (bigstringaf (>= 0.9.0))
@@ -26,7 +27,7 @@
   (hmap (>= 0.8.1))
   (crowbar (and (>= 0.2) :with-test))
   (mtime (>= 2.0.0))
-  (mdx (and (>= 1.10.0) :with-test))
+  (mdx (and (>= 2.2.0) :with-test))
   (alcotest (and (>= 1.4.0) :with-test))
   (dscheck (and (>= 0.1.0) :with-test))))
 (package
@@ -36,7 +37,7 @@
  (depends
   (alcotest (and (>= 1.4.0) :with-test))
   (eio (= :version))
-  (mdx (and (>= 1.10.0) :with-test))
+  (mdx (and (>= 2.2.0) :with-test))
   (logs (>= 0.7.0))
   (fmt (>= 0.8.9))
   (cmdliner (and (>= 1.1.0) :with-test))
@@ -48,7 +49,7 @@
  (depends
   (eio (= :version))
   (iomux (>= 0.2))
-  (mdx (and (>= 1.10.0) :with-test))
+  (mdx (and (>= 2.2.0) :with-test))
   (fmt (>= 0.8.9))))
 (package
  (name eio_luv)
@@ -58,7 +59,7 @@
   (eio (= :version))
   (luv (>= 0.5.11))
   (luv_unix (>= 0.5.0))
-  (mdx (and (>= 1.10.0) :with-test))
+  (mdx (and (>= 2.2.0) :with-test))
   (fmt (>= 0.8.9))))
 (package
  (name eio_main)
@@ -66,7 +67,7 @@
  (description "Selects an appropriate Eio backend for the current platform.")
  (depopts eio_luv)
  (depends
-  (mdx (and (>= 1.10.0) :with-test))
+  (mdx (and (>= 2.2.0) :with-test))
   (eio_linux (and (= :version) (= :os "linux")))
   (eio_posix (and (= :version) (<> :os "windows")))
   (eio_luv (and (= :version) (or (= :os "windows") :with-test)))))

--- a/eio.opam
+++ b/eio.opam
@@ -20,7 +20,7 @@ depends: [
   "hmap" {>= "0.8.1"}
   "crowbar" {>= "0.2" & with-test}
   "mtime" {>= "2.0.0"}
-  "mdx" {>= "1.10.0" & with-test}
+  "mdx" {>= "2.2.0" & with-test}
   "alcotest" {>= "1.4.0" & with-test}
   "dscheck" {>= "0.1.0" & with-test}
   "odoc" {with-doc}
@@ -29,6 +29,7 @@ conflicts: [
   "ocaml-base-compiler" {< "5.0.0~beta1"}
   "ocaml-variants" {< "5.0.0~beta1"}
   "ocaml-system" {< "5.0.0~beta1"}
+  "seq" {< "0.3"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.7"}
   "alcotest" {>= "1.4.0" & with-test}
   "eio" {= version}
-  "mdx" {>= "1.10.0" & with-test}
+  "mdx" {>= "2.2.0" & with-test}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}

--- a/eio_luv.opam
+++ b/eio_luv.opam
@@ -13,7 +13,7 @@ depends: [
   "eio" {= version}
   "luv" {>= "0.5.11"}
   "luv_unix" {>= "0.5.0"}
-  "mdx" {>= "1.10.0" & with-test}
+  "mdx" {>= "2.2.0" & with-test}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
 ]

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.7"}
-  "mdx" {>= "1.10.0" & with-test}
+  "mdx" {>= "2.2.0" & with-test}
   "eio_linux" {= version & os = "linux"}
   "eio_posix" {= version & os != "windows"}
   "eio_luv" {= version & os = "windows" | with-test}

--- a/eio_posix.opam
+++ b/eio_posix.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.7"}
   "eio" {= version}
   "iomux" {>= "0.2"}
-  "mdx" {>= "1.10.0" & with-test}
+  "mdx" {>= "2.2.0" & with-test}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
This is useful for writing generator functions. e.g.

```ocaml
Switch.run @@ fun sw ->
let seq = Fiber.fork_seq ~sw (fun yield ->
    for i = 1 to 3 do
      traceln "Yielding %d" i;
      yield i
    done
  ) in
Seq.iter (traceln "Got: %d") seq
```