### PR TITLE
Condition: fix the example in the docstring

### DIFF
--- a/lib_eio/condition.mli
+++ b/lib_eio/condition.mli
@@ -16,7 +16,7 @@
       let await_x p =
         Eio.Mutex.use_ro mutex (fun () ->
            while not (p !x) do                  (* [x] cannot change, as mutex is locked. *)
-             Eio.Condition.await ~mutex cond    (* Mutex is unlocked while suspended. *)
+             Eio.Condition.await cond mutex     (* Mutex is unlocked while suspended. *)
            done
         )
     ]}


### PR DESCRIPTION
The interface changed in 49c22696d50ed20b9ff68c1b1bc6804f85ab99d6 to make Mutex.t a required argument to Condition.await