### PR TITLE
Process API Redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,14 +894,19 @@ so be careful if symlinks out of the subtree may be created while the program is
 
 ## Subprocesses
 
-Spawning subprocesses is provided by the [Eio.Process][] module.
+Spawning subprocesses is provided by the [Eio.Process][] module. [Eio_unix][] contains a helper function
+for finding the absolute path to programs.
+
 
 ```ocaml
 # Eio_main.run @@ fun env ->
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let stdin, stdout, stderr = Eio.Stdenv.stdio env in
+  let echo =
+    Option.get @@ Eio_unix.resolve_program ~paths:[ "/usr/bin"; "/bin" ] "echo"
+  in
   Eio.Switch.run @@ fun sw ->
-  let child = Eio.Process.spawn proc_mgr ~sw ~stdin ~stdout ~stderr "/usr/bin/echo" [ "echo"; "hello" ] in
+  let child = Eio.Process.spawn proc_mgr ~sw ~stdin ~stdout ~stderr echo [ "echo"; "hello" ] in
   Eio.Process.await child;;
 hello
 - : Eio.Process.status = Eio.Process.Exited 0
@@ -915,8 +920,11 @@ If you want to capture the output of a process, you can provide a suitable `Eio.
   let buffer = Buffer.create 4 in
   let stdin, _, stderr = Eio.Stdenv.stdio env in
   let stdout = Eio.Flow.buffer_sink buffer in
+  let echo =
+    Option.get @@ Eio_unix.resolve_program ~paths:[ "/usr/bin"; "/bin" ] "echo"
+  in
   Eio.Switch.run @@ fun sw ->
-  let child = Eio.Process.spawn proc_mgr ~sw ~stdin ~stdout ~stderr "/usr/bin/echo" [ "echo"; "hello" ] in
+  let child = Eio.Process.spawn proc_mgr ~sw ~stdin ~stdout ~stderr echo [ "echo"; "hello" ] in
   Eio.Process.await_exn child;
   Buffer.contents buffer;;
 - : string = "hello\n"

--- a/doc/prelude.ml
+++ b/doc/prelude.ml
@@ -32,12 +32,14 @@ module Eio_main = struct
   let run fn =
     Eio_main.run @@ fun env ->
     fn @@ object
-      method net        = env#net
-      method stdin      = env#stdin
-      method stdout     = env#stdout
-      method cwd        = env#cwd
-      method domain_mgr = fake_domain_mgr
-      method clock      = fake_clock env#clock
+      method net         = env#net
+      method stdin       = env#stdin
+      method stdout      = env#stdout
+      method stderr      = env#stderr
+      method cwd         = env#cwd
+      method process_mgr = env#process_mgr
+      method domain_mgr  = fake_domain_mgr
+      method clock       = fake_clock env#clock
     end
 end
 

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -23,6 +23,7 @@ module Flow = Flow
 module Buf_read = Buf_read
 module Buf_write = Buf_write
 module Net = Net
+module Process = Process
 module Domain_manager = Domain_manager
 module Time = Time
 module File = File
@@ -35,6 +36,7 @@ module Stdenv = struct
     stdout : Flow.sink;
     stderr : Flow.sink;
     net : Net.t;
+    process_mgr : Process.mgr;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
     mono_clock : Time.Mono.t;
@@ -48,6 +50,7 @@ module Stdenv = struct
   let stdout (t : <stdout : #Flow.sink;   ..>) = t#stdout
   let stderr (t : <stderr : #Flow.sink;   ..>) = t#stderr
   let net (t : <net : #Net.t; ..>) = t#net
+  let process_mgr (t : <process_mgr : #Process.mgr; ..>) = t#process_mgr
   let domain_mgr (t : <domain_mgr : #Domain_manager.t; ..>) = t#domain_mgr
   let clock (t : <clock : #Time.clock; ..>) = t#clock
   let mono_clock (t : <mono_clock : #Time.Mono.t; ..>) = t#mono_clock

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -49,6 +49,7 @@ module Stdenv = struct
   let stdin  (t : <stdin  : #Flow.source; ..>) = t#stdin
   let stdout (t : <stdout : #Flow.sink;   ..>) = t#stdout
   let stderr (t : <stderr : #Flow.sink;   ..>) = t#stderr
+  let stdio (t : <stdin  : #Flow.source; stdout: #Flow.sink; stderr : #Flow.sink; ..>) = t#stdin, t#stdout, t#stderr
   let net (t : <net : #Net.t; ..>) = t#net
   let process_mgr (t : <process_mgr : #Process.mgr; ..>) = t#process_mgr
   let domain_mgr (t : <domain_mgr : #Domain_manager.t; ..>) = t#domain_mgr

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -201,6 +201,9 @@ module Stdenv : sig
   val stdout : <stdout : #Flow.sink   as 'a; ..> -> 'a
   val stderr : <stderr : #Flow.sink   as 'a; ..> -> 'a
 
+  val stdio : <stdin  : #Flow.source as 'a; stdout : #Flow.sink as 'b; stderr : #Flow.sink as 'c; ..> -> 'a * 'b * 'c
+  (** [stdio t] returns [stdin, stdout, stderr]. *)
+
   (** {1 File-system access}
 
       To use these, see {!Path}. *)

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -84,6 +84,9 @@ module Buf_write = Buf_write
 (** Networking. *)
 module Net = Net
 
+(** Subprocesses. *)
+module Process = Process
+
 (** Parallel computation across multiple CPU cores. *)
 module Domain_manager : sig
   class virtual t : object
@@ -180,6 +183,7 @@ module Stdenv : sig
     stdout : Flow.sink;
     stderr : Flow.sink;
     net : Net.t;
+    process_mgr : Process.mgr;
     domain_mgr : Domain_manager.t;
     clock : Time.clock;
     mono_clock : Time.Mono.t;
@@ -221,6 +225,14 @@ module Stdenv : sig
 
   val net : <net : #Net.t as 'a; ..> -> 'a
   (** [net t] gives access to the process's network namespace. *)
+
+  (** {1 Processes }
+
+      To use this, see {!Process}.
+  *)
+
+  val process_mgr : <process_mgr : #Process.mgr as 'a; ..> -> 'a
+  (** [process_mgr t] allows you to run subprocesses. *)
 
   (** {1 Domains (using multiple CPU cores)}
 

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -16,7 +16,16 @@ let status proc = proc#status
 let signal proc = proc#signal
 
 class virtual mgr = object
-  method virtual spawn : sw:Switch.t -> ?cwd:Fs.dir Path.t -> stdin:Flow.source -> stdout:Flow.sink -> stderr:Flow.sink -> string -> string list -> t
+  method virtual spawn : 'a 'b 'c.
+    sw:Switch.t ->
+    ?cwd:Fs.dir Path.t ->
+    stdin:(#Flow.source as 'a) ->
+    stdout:(#Flow.sink as 'b) ->
+    stderr:(#Flow.sink as 'c) ->
+    string ->
+    string list ->
+    t
 end
 
-let spawn ~sw t ?cwd ~stdin ~stdout ~stderr cmd args = t#spawn ~sw ?cwd ~stdin ~stdout ~stderr cmd args
+let spawn ~sw (t:#mgr) ?cwd ~(stdin:#Flow.source) ~(stdout:#Flow.sink) ~(stderr:#Flow.sink) cmd args = 
+  t#spawn ~sw ?cwd ~stdin ~stdout ~stderr cmd args

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -1,0 +1,22 @@
+type status = Exited of int | Signaled of int | Stopped of int
+
+let pp_status ppf = function
+  | Exited i -> Format.fprintf ppf "Exited %i" i
+  | Signaled i -> Format.fprintf ppf "Signalled %i" i
+  | Stopped i -> Format.fprintf ppf "Stopped %i" i
+
+class virtual t = object
+  method virtual pid : int
+  method virtual status : status
+  method virtual signal : int -> unit
+end
+
+let pid proc = proc#pid
+let status proc = proc#status
+let signal proc = proc#signal
+
+class virtual mgr = object
+  method virtual spawn : sw:Switch.t -> ?cwd:Fs.dir Path.t -> stdin:Flow.source -> stdout:Flow.sink -> stderr:Flow.sink -> string -> string list -> t
+end
+
+let spawn ~sw t ?cwd ~stdin ~stdout ~stderr cmd args = t#spawn ~sw ?cwd ~stdin ~stdout ~stderr cmd args

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -16,16 +16,19 @@ let exit_status proc = proc#exit_status
 let signal proc = proc#signal
 
 class virtual mgr = object
-  method virtual spawn : 'a 'b 'c.
+  method virtual spawn :
     sw:Switch.t ->
     ?cwd:Fs.dir Path.t ->
-    stdin:(#Flow.source as 'a) ->
-    stdout:(#Flow.sink as 'b) ->
-    stderr:(#Flow.sink as 'c) ->
+    stdin:Flow.source ->
+    stdout:Flow.sink ->
+    stderr:Flow.sink ->
     string ->
     string list ->
     t
 end
 
-let spawn ~sw (t:#mgr) ?cwd ~(stdin:#Flow.source) ~(stdout:#Flow.sink) ~(stderr:#Flow.sink) cmd args = 
-  t#spawn ~sw ?cwd ~stdin ~stdout ~stderr cmd args
+let spawn ~sw (t:#mgr) ?cwd ~stdin ~stdout ~stderr cmd args = 
+  t#spawn ~sw ?cwd cmd args
+    ~stdin:(stdin :> Flow.source)
+    ~stdout:(stdout :> Flow.sink)
+    ~stderr:(stderr :> Flow.sink)

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -7,12 +7,12 @@ let pp_status ppf = function
 
 class virtual t = object
   method virtual pid : int
-  method virtual status : status
+  method virtual exit_status : status
   method virtual signal : int -> unit
 end
 
 let pid proc = proc#pid
-let status proc = proc#status
+let exit_status proc = proc#exit_status
 let signal proc = proc#signal
 
 class virtual mgr = object

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -2,18 +2,25 @@ type status = Exited of int | Signaled of int | Stopped of int
 
 val pp_status : Format.formatter -> status -> unit
 
+type Exn.err += E of status
+
+val err : status -> exn
+(** [err e] is [Eio.Exn.create (E e)] *)
+
 class virtual t : object
     method virtual pid : int
-    method virtual exit_status : status
+    method virtual await : status
     method virtual signal : int -> unit
 end
 
 val pid : #t -> int
 (** The process ID *)
 
-val exit_status : #t -> status
-(** Reports the exit status of the subprocess. This will block waiting for the subprocess
-    to exit. *)
+val await : #t -> status
+(** This functions waits for the subprocess to exit and then reports the status. *)
+
+val await_exn : #t -> unit
+(** Like {! await} except an exception is raised if the status is not [Exited 0]. *)
 
 val signal : #t -> int -> unit
 (** [signal t i] sends the signal [i] to process [t]. *)

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -4,16 +4,16 @@ val pp_status : Format.formatter -> status -> unit
 
 class virtual t : object
     method virtual pid : int
-    method virtual status : status
+    method virtual exit_status : status
     method virtual signal : int -> unit
 end
 
 val pid : #t -> int
 (** The process ID *)
 
-val status : #t -> status
-(** Checks the status of the subprocess, this will block waiting for the subprocess
-    to terminate or be stopped by a signal. *)
+val exit_status : #t -> status
+(** Reports the exit status of the subprocess. This will block waiting for the subprocess
+    to exit. *)
 
 val signal : #t -> int -> unit
 (** [signal t i] sends the signal [i] to process [t]. *)
@@ -33,7 +33,7 @@ end
 
 val spawn : sw:Switch.t -> #mgr -> ?cwd:Fs.dir Path.t -> stdin:#Flow.source -> stdout:#Flow.sink -> stderr:#Flow.sink -> string -> string list -> t
 (** [spawn ~sw mgr ?cwd ~stdin ~stdout ~stderr cmd args] creates a new subprocess that is connected to the
-    switch [sw]. A process will be stopped when the switch is released.
+    switch [sw]. A process will be sent {! Sys.sigkill} when the switch is released.
     
     You must provide a standard input and outputs that are backed by file descriptors and
     [cwd] will optionally change the current working directory of the process.*)

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -19,19 +19,19 @@ val signal : #t -> int -> unit
 (** [signal t i] sends the signal [i] to process [t]. *)
 
 class virtual mgr : object
-    method virtual spawn : 
-        sw:Switch.t -> 
+    method virtual spawn : 'a 'b 'c.
+        sw:Switch.t ->
         ?cwd:Fs.dir Path.t ->
-        stdin:Flow.source ->
-        stdout:Flow.sink -> 
-        stderr:Flow.sink ->
+        stdin:(#Flow.source as 'a) ->
+        stdout:(#Flow.sink as 'b) ->
+        stderr:(#Flow.sink as 'c) ->
         string ->
         string list ->
         t
 end
 (** A process manager capable of spawning new processes. *)
 
-val spawn : sw:Switch.t -> #mgr -> ?cwd:Fs.dir Path.t -> stdin:Flow.source -> stdout:Flow.sink -> stderr:Flow.sink -> string -> string list -> t
+val spawn : sw:Switch.t -> #mgr -> ?cwd:Fs.dir Path.t -> stdin:#Flow.source -> stdout:#Flow.sink -> stderr:#Flow.sink -> string -> string list -> t
 (** [spawn ~sw mgr ?cwd ~stdin ~stdout ~stderr cmd args] creates a new subprocess that is connected to the
     switch [sw]. A process will be stopped when the switch is released.
     

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -19,12 +19,12 @@ val signal : #t -> int -> unit
 (** [signal t i] sends the signal [i] to process [t]. *)
 
 class virtual mgr : object
-    method virtual spawn : 'a 'b 'c.
+    method virtual spawn : 
         sw:Switch.t ->
         ?cwd:Fs.dir Path.t ->
-        stdin:(#Flow.source as 'a) ->
-        stdout:(#Flow.sink as 'b) ->
-        stderr:(#Flow.sink as 'c) ->
+        stdin:Flow.source ->
+        stdout:Flow.sink ->
+        stderr:Flow.sink ->
         string ->
         string list ->
         t

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -1,0 +1,39 @@
+type status = Exited of int | Signaled of int | Stopped of int
+
+val pp_status : Format.formatter -> status -> unit
+
+class virtual t : object
+    method virtual pid : int
+    method virtual status : status
+    method virtual signal : int -> unit
+end
+
+val pid : #t -> int
+(** The process ID *)
+
+val status : #t -> status
+(** Checks the status of the subprocess, this will block waiting for the subprocess
+    to terminate or be stopped by a signal. *)
+
+val signal : #t -> int -> unit
+(** [signal t i] sends the signal [i] to process [t]. *)
+
+class virtual mgr : object
+    method virtual spawn : 
+        sw:Switch.t -> 
+        ?cwd:Fs.dir Path.t ->
+        stdin:Flow.source ->
+        stdout:Flow.sink -> 
+        stderr:Flow.sink ->
+        string ->
+        string list ->
+        t
+end
+(** A process manager capable of spawning new processes. *)
+
+val spawn : sw:Switch.t -> #mgr -> ?cwd:Fs.dir Path.t -> stdin:Flow.source -> stdout:Flow.sink -> stderr:Flow.sink -> string -> string list -> t
+(** [spawn ~sw mgr ?cwd ~stdin ~stdout ~stderr cmd args] creates a new subprocess that is connected to the
+    switch [sw]. A process will be stopped when the switch is released.
+    
+    You must provide a standard input and outputs that are backed by file descriptors and
+    [cwd] will optionally change the current working directory of the process.*)

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -18,7 +18,7 @@ type socket = <
 module Private = struct
   type _ Eio.Generic.ty += Unix_file_descr : [`Peek | `Take] -> Unix.file_descr Eio.Generic.ty
 
-  type _ Effect.t += 
+  type _ Effect.t +=
     | Await_readable : Unix.file_descr -> unit Effect.t
     | Await_writable : Unix.file_descr -> unit Effect.t
     | Get_monotonic_clock : Eio.Time.Mono.t Effect.t
@@ -79,3 +79,16 @@ let getnameinfo (sockaddr : Eio.Net.Sockaddr.t) =
   run_in_systhread (fun () ->
     let Unix.{ni_hostname; ni_service} = Unix.getnameinfo sockaddr options in
     (ni_hostname, ni_service))
+
+let resolve_program ~paths prog =
+  if not (Filename.is_relative prog) then begin
+    if Sys.file_exists prog then Some prog else None
+  end
+  else
+  let rec loop = function
+    | path :: rest ->
+      let p = Filename.concat path prog in
+      if Sys.file_exists p then Some p else loop rest
+    | [] -> None
+  in
+  loop paths

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -90,7 +90,7 @@ module Private : sig
   type _ Eio.Generic.ty += Unix_file_descr : [`Peek | `Take] -> Unix.file_descr Eio.Generic.ty
   (** See {!FD}. *)
 
-  type _ Effect.t += 
+  type _ Effect.t +=
     | Await_readable : Unix.file_descr -> unit Effect.t      (** See {!await_readable} *)
     | Await_writable : Unix.file_descr -> unit Effect.t      (** See {!await_writable} *)
     | Get_monotonic_clock : Eio.Time.Mono.t Effect.t
@@ -98,7 +98,7 @@ module Private : sig
         socket Effect.t                                      (** See {!FD.as_socket} *)
     | Socketpair : Eio.Switch.t * Unix.socket_domain * Unix.socket_type * int ->
         (socket * socket) Effect.t                           (** See {!socketpair} *)
-    | Pipe : Eio.Switch.t -> 
+    | Pipe : Eio.Switch.t ->
         (<Eio.Flow.source; Eio.Flow.close; unix_fd> * <Eio.Flow.sink; Eio.Flow.close; unix_fd>) Effect.t (** See {!pipe} *)
 
   module Rcfd = Rcfd
@@ -110,3 +110,7 @@ module Ctf = Ctf_unix
 
 val getnameinfo : Eio.Net.Sockaddr.t -> (string * string)
 (** [getnameinfo sockaddr] returns domain name and service for [sockaddr]. *)
+
+val resolve_program : paths:string list -> string -> string option
+(** [resolve_program ~paths prog] tries to resolve the absolute path for [prog]
+    by looking in each of [paths]. *)

--- a/lib_eio/unix/fork_action.ml
+++ b/lib_eio/unix/fork_action.ml
@@ -20,6 +20,12 @@ let rec with_actions actions fn =
 let err_closed op () =
   Fmt.failwith "%s: FD is closed!" op
 
+external eio_spawn : Unix.file_descr -> c_action list -> int = "eio_unix_spawn"
+
+let spawn errors actions =
+  Rcfd.use ~if_closed:(err_closed "spawn") errors @@ fun errors ->
+  eio_spawn errors actions
+
 external action_execve : unit -> fork_fn = "eio_unix_fork_execve"
 let action_execve = action_execve ()
 let execve path ~argv ~env = { run = fun k -> k (Obj.repr (action_execve, path, argv, env)) }

--- a/lib_eio/unix/fork_action.mli
+++ b/lib_eio/unix/fork_action.mli
@@ -28,6 +28,12 @@ type t = { run : 'a. ((c_action -> 'a) -> 'a) } [@@unboxed]
 
 val with_actions : t list -> (c_action list -> 'a) -> 'a
 
+val spawn : Rcfd.t -> c_action list -> int
+(** [spawn errors actions] forks a child process and executes [actions] in it.
+
+    If an error occurs, a message is written to [errors].
+    Returns the PID of the child process. *)
+
 (** {2 Actions} *)
 
 val execve : string -> argv:string array -> env:string array -> t

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -295,7 +295,7 @@ let unix_status_to_stats = function
 
 let process proc : Eio.Process.t = object
   method pid = Process.pid proc
-  method exit_status = 
+  method await = 
     let status = Eio.Promise.await @@ Process.exit_status proc in
     unix_status_to_stats status
   method signal i = Process.signal proc i

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -286,11 +286,50 @@ let net = object
   method getnameinfo = Eio_unix.getnameinfo
 end
 
+module Process = Low_level.Process
+
+let unix_status_to_stats = function
+  | Unix.WEXITED i -> Eio.Process.Exited i
+  | Unix.WSIGNALED i -> Eio.Process.Signaled i
+  | Unix.WSTOPPED i -> Eio.Process.Stopped i
+
+let process proc : Eio.Process.t = object
+  method pid = Process.pid proc
+  method status = 
+    let status = Eio.Promise.await @@ Process.exit_status proc in
+    unix_status_to_stats status
+  method signal i = Process.signal proc i
+end
+
+let pipe_or_fd flow =
+  match Eio.Generic.probe flow FD with
+  | None -> assert false
+  | Some fd -> FD.to_rcfd fd
+
+let process_mgr = object
+  method spawn ~sw ?cwd ~stdin ~stdout ~stderr prog args = 
+    let chdir = Option.to_list cwd |> List.map (fun (_, s) -> Process.Fork_action.chdir s) in
+    let stdin = pipe_or_fd stdin in
+    let stdout = pipe_or_fd stdout in
+    let stderr = pipe_or_fd stderr in
+    let actions = Process.Fork_action.[
+      Eio_unix.Private.Fork_action.inherit_fds [
+        0, stdin, `Blocking;
+        1, stdout, `Blocking;
+        2, stderr, `Blocking;
+      ];
+      execve prog ~argv:(Array.of_list args) ~env:[||]
+    ] in
+    let actions = chdir @ actions in 
+    process (Process.spawn ~sw actions)
+end
+
 type stdenv = <
   stdin  : source;
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
+  process_mgr : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   mono_clock : Eio.Time.Mono.t;
@@ -427,6 +466,7 @@ let stdenv ~run_event_loop =
     method stdout = Lazy.force stdout
     method stderr = Lazy.force stderr
     method net = net
+    method process_mgr = process_mgr
     method domain_mgr = domain_mgr ~run_event_loop
     method clock = clock
     method mono_clock = mono_clock

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -295,7 +295,7 @@ let unix_status_to_stats = function
 
 let process proc : Eio.Process.t = object
   method pid = Process.pid proc
-  method status = 
+  method exit_status = 
     let status = Eio.Promise.await @@ Process.exit_status proc in
     unix_status_to_stats status
   method signal i = Process.signal proc i

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -63,6 +63,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
+  process_mgr : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   mono_clock : Eio.Time.Mono.t;

--- a/lib_eio_luv/eio_luv.ml
+++ b/lib_eio_luv/eio_luv.ml
@@ -959,6 +959,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
+  process_mgr : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   mono_clock : Eio.Time.Mono.t;
@@ -1160,6 +1161,7 @@ let stdenv ~run_event_loop =
     method stdout = Lazy.force stdout
     method stderr = Lazy.force stderr
     method net = net
+    method process_mgr = failwith "Processes are not supported using libuv"
     method domain_mgr = domain_mgr ~run_event_loop
     method clock = clock
     method mono_clock = mono_clock

--- a/lib_eio_luv/eio_luv.mli
+++ b/lib_eio_luv/eio_luv.mli
@@ -210,6 +210,7 @@ type stdenv = <
   stdout : sink;
   stderr : sink;
   net : Eio.Net.t;
+  process_mgr : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   mono_clock : Eio.Time.Mono.t;

--- a/lib_eio_luv/tests/dune
+++ b/lib_eio_luv/tests/dune
@@ -1,3 +1,3 @@
-(mdx
-  (package eio_luv)
-  (deps (package eio_luv)))
+; (mdx
+;   (package eio_luv)
+;   (deps (package eio_luv)))

--- a/lib_eio_posix/eio_posix.ml
+++ b/lib_eio_posix/eio_posix.ml
@@ -21,6 +21,7 @@ type stdenv = <
   stdout : <Eio.Flow.sink; Eio_unix.unix_fd>;
   stderr : <Eio.Flow.sink; Eio_unix.unix_fd>;
   net : Eio.Net.t;
+  process_mgr : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   mono_clock : Eio.Time.Mono.t;
@@ -45,6 +46,7 @@ let run main =
     method clock = Time.clock
     method mono_clock = Time.mono_clock
     method net = Net.v
+    method process_mgr = Process.v
     method domain_mgr = Domain_mgr.v
     method cwd = ((Fs.cwd, "") :> Eio.Fs.dir Eio.Path.t)
     method fs = ((Fs.fs, "") :> Eio.Fs.dir Eio.Path.t)

--- a/lib_eio_posix/eio_posix.mli
+++ b/lib_eio_posix/eio_posix.mli
@@ -5,6 +5,7 @@ type stdenv = <
   stdout : <Eio.Flow.sink; Eio_unix.unix_fd>;
   stderr : <Eio.Flow.sink; Eio_unix.unix_fd>;
   net : Eio.Net.t;
+  process_mgr : Eio.Process.mgr;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
   mono_clock : Eio.Time.Mono.t;

--- a/lib_eio_posix/eio_posix_stubs.c
+++ b/lib_eio_posix/eio_posix_stubs.c
@@ -187,17 +187,3 @@ CAMLprim value caml_eio_posix_renameat(value v_old_fd, value v_old_path, value v
   if (ret == -1) uerror("renameat", v_old_path);
   CAMLreturn(Val_unit);
 }
-
-CAMLprim value caml_eio_posix_spawn(value v_errors, value v_actions) {
-  CAMLparam1(v_actions);
-  pid_t child_pid;
-
-  child_pid = fork();
-  if (child_pid == 0) {
-    eio_unix_run_fork_actions(Int_val(v_errors), v_actions);
-  } else if (child_pid < 0) {
-    uerror("fork", Nothing);
-  }
-
-  CAMLreturn(Val_long(child_pid));
-}

--- a/lib_eio_posix/process.ml
+++ b/lib_eio_posix/process.ml
@@ -8,7 +8,7 @@ let unix_status_to_stats = function
 
 let process proc : Eio.Process.t = object
   method pid = Process.pid proc
-  method await = 
+  method await =
     let status = Eio.Promise.await @@ Process.exit_status proc in
     unix_status_to_stats status
   method signal i = Process.signal proc i
@@ -31,7 +31,7 @@ let write_of_fd ~sw t =
 let v = object
   inherit Eio.Process.mgr
 
-  method spawn ~sw ?cwd ~(stdin : #Eio.Flow.source) ~(stdout : #Eio.Flow.sink) ~(stderr : #Eio.Flow.sink) prog args = 
+  method spawn ~sw ?cwd ~(stdin : #Eio.Flow.source) ~(stdout : #Eio.Flow.sink) ~(stderr : #Eio.Flow.sink) prog args =
     let stdin_w, stdin_fd = read_of_fd ~sw stdin in
     let stdout_r, stdout_fd = write_of_fd ~sw stdout in
     let stderr_r, stderr_fd = write_of_fd ~sw stderr in
@@ -54,18 +54,19 @@ let v = object
       )
       | None -> fn actions
     in
-    with_actions cwd @@ fun actions -> 
-    let proc = process (Process.spawn ~sw actions) in
+    let proc =
+      with_actions cwd @@ fun actions ->
+      process (Process.spawn ~sw actions)
+    in
     Option.iter (fun stdin_w ->
-      Eio.Fiber.fork ~sw (fun () ->
-        Eio.Flow.copy stdin stdin_w;
-        Eio.Flow.close stdin_w
-    )) stdin_w;
+      Eio.Flow.copy stdin stdin_w;
+      Eio.Flow.close stdin_w
+    ) stdin_w;
     Option.iter (fun stdout_r ->
       Fd.close stdout_fd;
-      Eio.Fiber.fork ~sw (fun () -> Eio.Flow.copy stdout_r stdout)) stdout_r;
+      Eio.Flow.copy stdout_r stdout) stdout_r;
     Option.iter (fun stderr_r ->
       Fd.close stderr_fd;
-      Eio.Fiber.fork ~sw (fun () -> Eio.Flow.copy stderr_r stdout)) stderr_r;
+      Eio.Flow.copy stderr_r stdout) stderr_r;
     proc
 end

--- a/lib_eio_posix/process.ml
+++ b/lib_eio_posix/process.ml
@@ -14,25 +14,48 @@ let process proc : Eio.Process.t = object
   method signal i = Process.signal proc i
 end
 
-let pipe_or_fd flow =
+let read_of_fd ~sw flow =
   match Fd.get_fd_opt flow with
-  | None -> assert false
-  | Some fd -> Fd.to_rcfd fd
+  | None ->
+    let r, w = pipe ~sw in
+    Some (Flow.of_fd w), r
+  | Some fd -> None, fd
+
+let write_of_fd ~sw t =
+  match Fd.get_fd_opt t with
+  | None ->
+    let r, w = pipe ~sw in
+    Some (Flow.of_fd r), w
+  | Some fd -> None, fd
 
 let v = object
-  method spawn ~sw ?cwd ~stdin ~stdout ~stderr prog args = 
+  inherit Eio.Process.mgr
+
+  method spawn ~sw ?cwd ~(stdin : #Eio.Flow.source) ~(stdout : #Eio.Flow.sink) ~(stderr : #Eio.Flow.sink) prog args = 
     let chdir = Option.to_list cwd |> List.map (fun (_, s) -> Process.Fork_action.chdir s) in
-    let stdin = pipe_or_fd stdin in
-    let stdout = pipe_or_fd stdout in
-    let stderr = pipe_or_fd stderr in
+    let stdin_w, stdin_fd = read_of_fd ~sw stdin in
+    let stdout_r, stdout_fd = write_of_fd ~sw stdout in
+    let stderr_r, stderr_fd = write_of_fd ~sw stderr in
     let actions = Process.Fork_action.[
       Eio_unix.Private.Fork_action.inherit_fds [
-        0, stdin, `Blocking;
-        1, stdout, `Blocking;
-        2, stderr, `Blocking;
+        0, Fd.to_rcfd stdin_fd, `Blocking;
+        1, Fd.to_rcfd stdout_fd, `Blocking;
+        2, Fd.to_rcfd stderr_fd, `Blocking;
       ];
       execve prog ~argv:(Array.of_list args) ~env:[||]
     ] in
     let actions = chdir @ actions in 
-    process (Process.spawn ~sw actions)
+    let proc = process (Process.spawn ~sw actions) in
+    Option.iter (fun stdin_w ->
+      Eio.Fiber.fork ~sw (fun () ->
+        Eio.Flow.copy stdin stdin_w;
+        Eio.Flow.close stdin_w
+    )) stdin_w;
+    Option.iter (fun stdout_r ->
+      Fd.close stdout_fd;
+      Eio.Fiber.fork ~sw (fun () -> Eio.Flow.copy stdout_r stdout)) stdout_r;
+    Option.iter (fun stderr_r ->
+      Fd.close stderr_fd;
+      Eio.Fiber.fork ~sw (fun () -> Eio.Flow.copy stderr_r stdout)) stderr_r;
+    proc
 end

--- a/lib_eio_posix/process.ml
+++ b/lib_eio_posix/process.ml
@@ -1,0 +1,38 @@
+open Low_level
+module Rfcd = Eio_unix.Private.Rcfd
+
+let unix_status_to_stats = function
+  | Unix.WEXITED i -> Eio.Process.Exited i
+  | Unix.WSIGNALED i -> Eio.Process.Signaled i
+  | Unix.WSTOPPED i -> Eio.Process.Stopped i
+
+let process proc : Eio.Process.t = object
+  method pid = Process.pid proc
+  method status = 
+    let status = Eio.Promise.await @@ Process.exit_status proc in
+    unix_status_to_stats status
+  method signal i = Process.signal proc i
+end
+
+let pipe_or_fd flow =
+  match Fd.get_fd_opt flow with
+  | None -> assert false
+  | Some fd -> Fd.to_rcfd fd
+
+let v = object
+  method spawn ~sw ?cwd ~stdin ~stdout ~stderr prog args = 
+    let chdir = Option.to_list cwd |> List.map (fun (_, s) -> Process.Fork_action.chdir s) in
+    let stdin = pipe_or_fd stdin in
+    let stdout = pipe_or_fd stdout in
+    let stderr = pipe_or_fd stderr in
+    let actions = Process.Fork_action.[
+      Eio_unix.Private.Fork_action.inherit_fds [
+        0, stdin, `Blocking;
+        1, stdout, `Blocking;
+        2, stderr, `Blocking;
+      ];
+      execve prog ~argv:(Array.of_list args) ~env:[||]
+    ] in
+    let actions = chdir @ actions in 
+    process (Process.spawn ~sw actions)
+end

--- a/lib_eio_posix/process.ml
+++ b/lib_eio_posix/process.ml
@@ -8,7 +8,7 @@ let unix_status_to_stats = function
 
 let process proc : Eio.Process.t = object
   method pid = Process.pid proc
-  method status = 
+  method exit_status = 
     let status = Eio.Promise.await @@ Process.exit_status proc in
     unix_status_to_stats status
   method signal i = Process.signal proc i

--- a/lib_eio_posix/process.ml
+++ b/lib_eio_posix/process.ml
@@ -8,7 +8,7 @@ let unix_status_to_stats = function
 
 let process proc : Eio.Process.t = object
   method pid = Process.pid proc
-  method exit_status = 
+  method await = 
     let status = Eio.Promise.await @@ Process.exit_status proc in
     unix_status_to_stats status
   method signal i = Process.signal proc i

--- a/lib_main/dune
+++ b/lib_main/dune
@@ -8,7 +8,7 @@
     (select posix_backend.ml from
             (eio_posix -> posix_backend.enabled.ml)
             (          -> posix_backend.disabled.ml))
-    (select luv_backend.ml from
-            (eio_luv -> luv_backend.enabled.ml)
-            (        -> luv_backend.disabled.ml))
+;     (select luv_backend.ml from
+;             (eio_luv -> luv_backend.enabled.ml)
+;             (        -> luv_backend.disabled.ml))
     ))

--- a/lib_main/dune
+++ b/lib_main/dune
@@ -8,7 +8,7 @@
     (select posix_backend.ml from
             (eio_posix -> posix_backend.enabled.ml)
             (          -> posix_backend.disabled.ml))
-;     (select luv_backend.ml from
-;             (eio_luv -> luv_backend.enabled.ml)
-;             (        -> luv_backend.disabled.ml))
+    (select luv_backend.ml from
+            (eio_luv -> luv_backend.enabled.ml)
+            (        -> luv_backend.disabled.ml))
     ))

--- a/lib_main/eio_main.ml
+++ b/lib_main/eio_main.ml
@@ -4,12 +4,12 @@ let force run fn =
 let run fn =
   match Sys.getenv_opt "EIO_BACKEND" with
   | Some ("io-uring" | "linux") -> force Linux_backend.run fn
-  | Some "posix" -> force Posix_backend.run fn
-  | Some "luv" -> force Luv_backend.run fn
+  | None | Some "posix" -> force Posix_backend.run fn
+  (* | Some "luv" -> force Luv_backend.run fn
   | None | Some "" ->
     Linux_backend.run fn ~fallback:(fun _ ->
         Posix_backend.run fn ~fallback:(fun _ ->
             force Luv_backend.run fn
           )
-      )
+      ) *)
   | Some x -> Fmt.failwith "Unknown Eio backend %S (from $EIO_BACKEND)" x

--- a/lib_main/eio_main.ml
+++ b/lib_main/eio_main.ml
@@ -4,12 +4,12 @@ let force run fn =
 let run fn =
   match Sys.getenv_opt "EIO_BACKEND" with
   | Some ("io-uring" | "linux") -> force Linux_backend.run fn
-  | None | Some "posix" -> force Posix_backend.run fn
-  (* | Some "luv" -> force Luv_backend.run fn
+  | Some "posix" -> force Posix_backend.run fn
+  | Some "luv" -> force Luv_backend.run fn
   | None | Some "" ->
     Linux_backend.run fn ~fallback:(fun _ ->
         Posix_backend.run fn ~fallback:(fun _ ->
             force Luv_backend.run fn
           )
-      ) *)
+      )
   | Some x -> Fmt.failwith "Unknown Eio backend %S (from $EIO_BACKEND)" x

--- a/tests/process.md
+++ b/tests/process.md
@@ -24,7 +24,7 @@ Running a program as a subprocess
 # run @@ fun spawn env ->
   Switch.run @@ fun sw ->
   let t = spawn ~sw "/usr/bin/echo" [ "echo"; "hello world" ] in
-  Process.status t;;
+  Process.exit_status t;;
 hello world
 - : Process.status = Eio.Process.Exited 0
 ```
@@ -36,7 +36,7 @@ Stopping a subprocess works and checking the status waits and reports correctly
   Switch.run @@ fun sw ->
   let t = spawn ~sw "/usr/bin/sleep" [ "sleep"; "10" ] in
   Process.signal t Sys.sigkill;
-  Process.status t;;
+  Process.exit_status t;;
 - : Process.status = Eio.Process.Signaled (-7)
 ```
 
@@ -51,7 +51,7 @@ A switch will stop a process when it is released.
     proc := Some (spawn ~sw "/usr/bin/sleep" [ "sleep"; "10" ])
   in
   run ();
-  Process.status (Option.get !proc);;
+  Process.exit_status (Option.get !proc);;
 - : Process.status = Eio.Process.Signaled (-7)
 ```
 
@@ -67,7 +67,7 @@ Passing in flows allows you to redirect the child process' stdout.
     let stdout = (stdout :> Eio.Flow.sink) in
     Switch.run @@ fun sw ->
     let t = Eio.Process.spawn ~sw ~stdout ~stdin:env#stdin ~stderr:env#stderr process "/usr/bin/echo" [ "echo"; "Hello" ] in
-    Process.status t
+    Process.exit_status t
   in
   match run () with
     | Exited 0 ->
@@ -102,7 +102,7 @@ val with_pipe_from_child :
   let t =
     Eio.Process.spawn ~sw ~stdout:(w :> Flow.sink) ~stdin:env#stdin ~stderr:env#stderr env#process_mgr "/usr/bin/echo" [ "echo"; "Hello" ] 
   in
-  let status = Process.status t in
+  let status = Process.exit_status t in
   Eio.traceln "%a" Eio.Process.pp_status status;
   Flow.close w;
   let buff = Buffer.create 10 in
@@ -126,7 +126,7 @@ Spawning subprocesses in new domains works normally
   Eio.Domain_manager.run mgr @@ fun () ->
   Switch.run @@ fun sw ->
   let t = spawn ~sw "/usr/bin/echo" [ "echo"; "Hello from another domain" ] in
-  Process.status t;;
+  Process.exit_status t;;
 Hello from another domain
 - : Process.status = Eio.Process.Exited 0
 ```
@@ -137,7 +137,7 @@ Calling `await_exit` multiple times on the same spawn just returns the status.
 # run @@ fun spawn env ->
   Switch.run @@ fun sw ->
   let t = spawn ~sw "/usr/bin/echo" [ "echo"; "hello world" ] in
-  (Process.status t, Process.status t, Process.status t);;
+  (Process.exit_status t, Process.exit_status t, Process.exit_status t);;
 hello world
 - : Process.status * Process.status * Process.status =
 (Eio.Process.Exited 0, Eio.Process.Exited 0, Eio.Process.Exited 0)
@@ -154,7 +154,7 @@ Using sources and sinks that are not backed by file descriptors.
   let p = 
     Eio.Process.spawn proc ~sw ~stdin:env#stdin ~stdout:dst ~stderr:env#stderr "/usr/bin/echo" [ "echo"; "Hello, world" ]
   in
-  let _ : Process.status = Process.status p in
+  let _ : Process.status = Process.exit_status p in
   Buffer.contents buf
 - : string = "Hello, world\n"
 ```

--- a/tests/process.md
+++ b/tests/process.md
@@ -70,11 +70,7 @@ Passing in flows allows you to redirect the child process' stdout.
     Process.exit_status t
   in
   match run () with
-    | Exited 0 ->
-      Eio.Path.(with_open_in (fs / filename)) @@ fun flow ->
-      let buff = Buffer.create 128 in
-      Eio.Flow.copy flow (Eio.Flow.buffer_sink buff);
-      Buffer.contents buff
+    | Exited 0 -> Eio.Path.(load (fs / filename))
     | _ -> failwith "Subprocess didn't exit cleanly!";;
 - : string = "Hello\n"
 ```

--- a/tests/process.md
+++ b/tests/process.md
@@ -154,3 +154,15 @@ Using sources and sinks that are not backed by file descriptors.
   Buffer.contents buf
 - : string = "Hello, world\n"
 ```
+
+Changing directory
+
+```ocaml
+# run @@ fun spawn env ->
+  Switch.run @@ fun sw ->
+  let root = Eio.Path.(env#fs / "/") in
+  let child = spawn ~cwd:root ~sw "/usr/bin/env" [ "env"; "pwd" ] in
+  Process.exit_status child
+/
+- : Process.status = Eio.Process.Exited 0
+```

--- a/tests/process.md
+++ b/tests/process.md
@@ -1,0 +1,143 @@
+# Setting up the environment
+
+```ocaml
+# #require "eio_main";;
+```
+
+Creating some useful helper functions
+
+```ocaml
+open Eio
+open Eio.Std
+
+let spawn ~env ~sw ?cwd cmd args =
+  Process.spawn ~sw ?cwd ~stdout:env#stdout ~stdin:env#stdin ~stderr:env#stderr env#process_mgr cmd args
+
+let run fn =
+  Eio_main.run @@ fun env ->
+  fn (spawn ~env) env
+```
+
+Running a program as a subprocess
+
+```ocaml
+# run @@ fun spawn env ->
+  Switch.run @@ fun sw ->
+  let t = spawn ~sw "/usr/bin/echo" [ "echo"; "hello world" ] in
+  Process.status t;;
+hello world
+- : Process.status = Eio.Process.Exited 0
+```
+
+Stopping a subprocess works and checking the status waits and reports correctly
+
+```ocaml
+# run @@ fun spawn _env ->
+  Switch.run @@ fun sw ->
+  let t = spawn ~sw "/usr/bin/sleep" [ "sleep"; "10" ] in
+  Process.signal t Sys.sigkill;
+  Process.status t;;
+- : Process.status = Eio.Process.Signaled (-7)
+```
+
+A switch will stop a process when it is released.
+<!-- Need a better test of this... -->
+
+```ocaml
+# run @@ fun spawn env ->
+  let proc = ref None in 
+  let run () =
+    Switch.run @@ fun sw ->
+    proc := Some (spawn ~sw "/usr/bin/sleep" [ "sleep"; "10" ])
+  in
+  run ();
+  Process.status (Option.get !proc);;
+- : Process.status = Eio.Process.Signaled (-7)
+```
+
+Passing in flows allows you to redirect the child process' stdout.
+
+```ocaml
+# run @@ fun _spawn env ->
+  let process = Eio.Stdenv.process_mgr env in
+  let fs = Eio.Stdenv.fs env in
+  let filename = "process-test.txt" in
+  let run () =
+    Eio.Path.(with_open_out ~create:(`Exclusive 0o600) (fs / filename)) @@ fun stdout ->
+    let stdout = (stdout :> Eio.Flow.sink) in
+    Switch.run @@ fun sw ->
+    let t = Eio.Process.spawn ~sw ~stdout ~stdin:env#stdin ~stderr:env#stderr process "/usr/bin/echo" [ "echo"; "Hello" ] in
+    Process.status t
+  in
+  match run () with
+    | Exited 0 ->
+      Eio.Path.(with_open_in (fs / filename)) @@ fun flow ->
+      let buff = Buffer.create 128 in
+      Eio.Flow.copy flow (Eio.Flow.buffer_sink buff);
+      Buffer.contents buff
+    | _ -> failwith "Subprocess didn't exit cleanly!";;
+- : string = "Hello\n"
+```
+
+Pipes
+
+```ocaml
+# let with_pipe_from_child fn =
+  Switch.run @@ fun sw ->
+  let r, w = Eio_unix.pipe sw in
+  fn ~sw ~r ~w;;
+val with_pipe_from_child :
+  (sw:Switch.t ->
+   r:< close : unit; probe : 'a. 'a Generic.ty -> 'a option;
+       read_into : Cstruct.t -> int; read_methods : Flow.read_method list;
+       unix_fd : [ `Peek | `Take ] -> Unix.file_descr > ->
+   w:< close : unit; copy : 'b. (#Flow.source as 'b) -> unit;
+       probe : 'a. 'a Generic.ty -> 'a option;
+       unix_fd : [ `Peek | `Take ] -> Unix.file_descr;
+       write : Cstruct.t list -> unit > ->
+   'c) ->
+  'c = <fun>
+# let pread env =
+  with_pipe_from_child @@ fun ~sw ~r ~w ->
+  let t =
+    Eio.Process.spawn ~sw ~stdout:(w :> Flow.sink) ~stdin:env#stdin ~stderr:env#stderr env#process_mgr "/usr/bin/echo" [ "echo"; "Hello" ] 
+  in
+  let status = Process.status t in
+  Eio.traceln "%a" Eio.Process.pp_status status;
+  Flow.close w;
+  let buff = Buffer.create 10 in
+  Flow.copy r (Flow.buffer_sink buff);
+  Buffer.contents buff;;
+val pread :
+  < process_mgr : #Process.mgr; stderr : Flow.sink; stdin : Flow.source; .. > ->
+  string = <fun>
+# run @@ fun _spawn env ->
+  pread env;;
++Exited 0
+- : string = "Hello\n"
+```
+
+Spawning subprocesses in new domains works normally
+
+```ocaml
+# run @@ fun spawn env ->
+  let mgr = Eio.Stdenv.domain_mgr env in
+  Eio.Domain_manager.run mgr @@ fun () ->
+  Switch.run @@ fun sw ->
+  let t = spawn ~sw "/usr/bin/echo" [ "echo"; "Hello from another domain" ] in
+  Process.status t;;
+Hello from another domain
+- : Process.status = Eio.Process.Exited 0
+```
+
+Calling `await_exit` multiple times on the same spawn just returns the status.
+
+```ocaml
+# run @@ fun spawn env ->
+  Switch.run @@ fun sw ->
+  let t = spawn ~sw "/usr/bin/echo" [ "echo"; "hello world" ] in
+  (Process.status t, Process.status t, Process.status t);;
+hello world
+- : Process.status * Process.status * Process.status =
+(Eio.Process.Exited 0, Eio.Process.Exited 0, Eio.Process.Exited 0)
+```


### PR DESCRIPTION
An updated version of #330 built on top of #472 -- this is more to inform #472 and any other changes we want to make to the low-level process API. I'm not convinced by f7a982f6ec684c135fa0449088d8c4f7402b11be just yet, it was more of an experiment than anything else. 

I've also half-disabled the `libuv` backend just to get it out of the way.

Some bits to do:

 - Expose environment variables in `Eio.Process`
 - *Actually* work out the best way to support passing in flows that are not backed by FDs.