### PR TITLE
Work around various opam and dune issues on non-linux systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ bench:
 	dune exec -- ./bench/bench_stream.exe
 	dune exec -- ./bench/bench_semaphore.exe
 	dune exec -- ./bench/bench_cancel.exe
-	dune exec -- ./lib_eio_linux/tests/bench_noop.exe
+	if ocamlc -config | grep -q '^system: linux'; then dune exec -- ./lib_eio_linux/tests/bench_noop.exe; fi
 
 test_luv:
 	EIO_BACKEND=luv dune runtest

--- a/dune-project
+++ b/dune-project
@@ -34,6 +34,7 @@
  (name eio_linux)
  (synopsis "Eio implementation for Linux using io-uring")
  (description "An Eio implementation for Linux using io-uring.")
+ (allow_empty)  ; Work-around for dune bug #6938
  (depends
   (alcotest (and (>= 1.4.0) :with-test))
   (eio (= :version))

--- a/lib_eio_linux/tests/dune
+++ b/lib_eio_linux/tests/dune
@@ -1,3 +1,9 @@
+(* -*- tuareg -*- *)
+
+let linux = List.mem ("system", "linux") Jbuild_plugin.V1.ocamlc_config
+
+let () = Jbuild_plugin.V1.send @@ if not linux then "" else {|
+
 (library
  (name eurcp_lib)
  (enabled_if (= %{system} "linux"))
@@ -33,3 +39,5 @@
   (package eio_linux)
   (enabled_if (= %{system} "linux"))
   (deps (package eio_linux)))
+
+|}


### PR DESCRIPTION
Rebased version of @polytypic's #416. This is a work-around for https://github.com/ocaml/dune/issues/5505.

I skipped the change to the opam metadata - installing all packages at once is not expected to work and I don't think we should try to make it work.