### PR TITLE
eio_linux: release uring if Linux is too old

### DIFF
--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -509,9 +509,10 @@ let with_sched ?(fallback=no_fallback) config fn =
   | exception Unix.Unix_error(Unix.ENOSYS, _, _) -> fallback (`Msg "io_uring is not available on this system")
   | uring ->
     let probe = Uring.get_probe uring in
-    if not (Uring.op_supported probe Uring.Op.shutdown) then
+    if not (Uring.op_supported probe Uring.Op.shutdown) then (
+      Uring.exit uring;
       fallback (`Msg "Linux >= 5.11 is required for io_uring support")
-    else (
+    ) else (
       match
         let mem =
           let fixed_buf_len = block_size * n_blocks in


### PR DESCRIPTION
If we manage to create a uring but find it doesn't support things we need we report an error. But we should release it too.