### PR TITLE
eio_posix: yield on IO

### DIFF
--- a/tests/fs.md
+++ b/tests/fs.md
@@ -546,3 +546,19 @@ Check reading and writing vectors at arbitrary offsets:
 + "-ab"/"c123"
 - : unit = ()
 ```
+
+# Cancelling while readable
+
+Ensure reads can be cancelled promptly, even if there is no need to wait:
+
+```ocaml
+# Eio_main.run @@ fun env ->
+  Eio.Path.with_open_out (env#fs / "/dev/zero") ~create:`Never @@ fun null ->
+  Fiber.both
+     (fun () ->
+        let buf = Cstruct.create 4 in
+        for _ = 1 to 10 do Eio.Flow.read_exact null buf done;
+        assert false)
+     (fun () -> failwith "Simulated error");;
+Exception: Failure "Simulated error".
+```


### PR DESCRIPTION
Before, a read would only yield if it needed to block. This could prevent other fibers from running at all if data was always available and also prevented it from checking for cancellation.

Also, for operations on paths, run the operation in a system thread.

This could be optimised a bit, but this makes it correct at least. I tried it on the wrk benchmark and this change made it faster for some reason!

Part of #456.