### PR TITLE
Mint exclusive IDs

### DIFF
--- a/lib_eio/tests/ctf.md
+++ b/lib_eio/tests/ctf.md
@@ -1,0 +1,50 @@
+# Test unique ID generation
+
+
+```ocaml
+# #require "eio";;
+# for _ = 1 to 5 do
+    Printf.printf "%d\n%!" (Eio.Private.Ctf.mint_id () :> int)
+  done;;
+1
+2
+3
+4
+5
+- : unit = ()
+```
+
+A new domain gets a new chunk:
+
+```ocaml
+# Domain.spawn
+    (fun () ->
+      for _ = 1 to 5 do
+        Printf.printf "%d\n%!" (Eio.Private.Ctf.mint_id () :> int)
+      done);;
+1024
+1025
+1026
+1027
+1028
+- : unit Domain.t = <abstr>
+```
+
+When the original domain exhausts its chunk, it jumps to the next free chunk:
+
+```ocaml
+# for _ = 1 to 1024 - 9 do
+    Eio.Private.Ctf.mint_id () |> ignore
+  done;;
+- : unit = ()
+
+# for _ = 1 to 5 do
+    Printf.printf "%d\n%!" (Eio.Private.Ctf.mint_id () :> int)
+  done;;
+1021
+1022
+1023
+2048
+2049
+- : unit = ()
+```


### PR DESCRIPTION
Another take on https://github.com/ocaml-multicore/eio/pull/368 to generate unique IDs in a multicore context.

The proposal is to encode the domain ID in the generated ID, and have one counter per domain (using domain local storage), so that there's no contention on the ID counter. As it its implemented, it requires knowing the maximum number of IDs. It is currently hardcoded to 128, but the value is not specified. 

An alternative solution for that is to create a fixed array of atomic counters, say of size N, and map domain ID to the counter `ID mod N`. It requires the usage of atomic variables to support the situation where the number of domains is greated than N, but reduces contention as multiple counters are used. 