### PR TITLE
use raw system call of getrandom for glibc version before 2.25

### DIFF
--- a/lib_eio_linux/eio_stubs.c
+++ b/lib_eio_linux/eio_stubs.c
@@ -4,7 +4,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/eventfd.h>
+#if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
 #include <sys/random.h>
+#endif
 #include <sys/syscall.h>
 #include <limits.h>
 #include <errno.h>
@@ -97,7 +99,11 @@ CAMLprim value caml_eio_getrandom(value v_ba, value v_off, value v_len) {
   do {
     void *buf = Caml_ba_data_val(v_ba) + off;
     caml_enter_blocking_section();
+#if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
     ret = getrandom(buf, len, 0);
+#else
+    ret = syscall(SYS_getrandom, buf, len, 0);
+#endif
     caml_leave_blocking_section();
   } while (ret == -1 && errno == EINTR);
   if (ret == -1) uerror("getrandom", Nothing);

--- a/lib_eio_posix/eio_posix_stubs.c
+++ b/lib_eio_posix/eio_posix_stubs.c
@@ -2,7 +2,11 @@
 
 #include <sys/types.h>
 #ifdef __linux__
+#if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
 #include <sys/random.h>
+#else
+#include <sys/syscall.h>
+#endif
 #endif
 #include <sys/uio.h>
 #include <sys/stat.h>
@@ -40,7 +44,11 @@ CAMLprim value caml_eio_posix_getrandom(value v_ba, value v_off, value v_len) {
     void *buf = (uint8_t *)Caml_ba_data_val(v_ba) + off;
     caml_enter_blocking_section();
 #ifdef __linux__
+#if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
     ret = getrandom(buf, len, 0);
+#else
+    ret = syscall(SYS_getrandom, buf, len, 0);
+#endif
 #else
     arc4random_buf(buf, len);
     ret = len;


### PR DESCRIPTION
'getrandom' was added to glibc in version 2.25. Older versions of glibc would fall back to use raw system call to correctly compile eio.