### PR TITLE
Unify Eio_linux.FD and Eio_posix.Fd as Eio_unix.Fd

### DIFF
--- a/lib_eio/unix/dune
+++ b/lib_eio/unix/dune
@@ -4,5 +4,5 @@
  (foreign_stubs
   (language c)
   (include_dirs include)
-  (names fork_action))
+  (names fork_action stubs))
  (libraries eio unix threads mtime.clock.os))

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -44,27 +44,19 @@ val await_writable : Unix.file_descr -> unit
 (**/**)
 module FD : sig
   val peek : < Resource.t; .. > -> Unix.file_descr
-  (** [peek x] is the Unix file descriptor underlying [x].
-      The caller must ensure that they do not continue to use the result after [x] is closed. *)
+  [@@deprecated "Use Eio_unix.Resource.fd instead"]
 
   val peek_opt : #Eio.Generic.t -> Unix.file_descr option
-  (** [peek_opt x] is the Unix file descriptor underlying [x], if any.
-      The caller must ensure that they do not continue to use the result after [x] is closed. *)
+  [@@deprecated "Use Eio_unix.Resource.fd_opt instead"]
 
   val take : < Resource.t; .. > -> Unix.file_descr
-  (** [take x] is like [peek], but also marks [x] as closed on success (without actually closing the FD).
-      [x] can no longer be used after this, and the caller is responsible for closing the FD. *)
+  [@@deprecated "Use Eio_unix.Resource.fd and Fd.remove instead"]
 
   val take_opt : #Eio.Generic.t -> Unix.file_descr option
-  (** [take_opt x] is like [peek_opt], but also marks [x] as closed on success (without actually closing the FD).
-      [x] can no longer be used after this, and the caller is responsible for closing the FD. *)
+  [@@deprecated "Use Eio_unix.Resource.fd_opt and Fd.remove instead"]
 
   val as_socket : sw:Switch.t -> close_unix:bool -> Unix.file_descr -> socket
-  (** [as_socket ~sw ~close_unix:true fd] is an Eio flow that uses [fd].
-      It can be cast to e.g. {!Eio.source} for a one-way flow.
-      The socket object will be closed when [sw] finishes.
-      @param close_unix If [true], closing the object will also close the underlying FD.
-                        If [false], the caller is responsible for keeping [FD] open until the object is closed. *)
+  [@@deprecated "Use Eio_unix.import_socket_stream instead"]
 end
 (**/**)
 

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -4,20 +4,36 @@
     For example, it is possible to leak file descriptors this way, or to use them after they've been closed,
     allowing one module to corrupt a file belonging to an unrelated module. *)
 
+[@@@alert "-unstable"]
+
 open Eio.Std
 
 type Eio.Exn.Backend.t += Unix_error of Unix.error * string * string
 (** Wrapper for embedding {!Unix.Unix_error} errors. *)
 
-type unix_fd = <
-  unix_fd : [`Peek | `Take] -> Unix.file_descr;
->
+module Fd = Fd
+(** A safe wrapper for {!Unix.file_descr}. *)
 
-type socket = <
-  Eio.Flow.two_way;
-  Eio.Flow.close;
-  unix_fd;
->
+(** Eio resources backed by an OS file descriptor. *)
+module Resource : sig
+  type t = < fd : Fd.t >
+  (** Resources that have FDs are sub-types of [t]. *)
+
+  val fd : <t;..> -> Fd.t
+  (** [fd t] returns the FD being wrapped by a resource. *)
+
+  type _ Eio.Generic.ty += FD : Fd.t Eio.Generic.ty
+  (** Resources that wrap FDs can handle this in their [probe] method to expose the FD. *)
+
+  val fd_opt : #Eio.Generic.t -> Fd.t option
+  (** [fd_opt t] returns the FD being wrapped by a generic resource, if any.
+
+      This just probes [t] using {!extension-FD}. *)
+end
+
+type source = < Eio.Flow.source;  Resource.t; Eio.Flow.close >
+type sink   = < Eio.Flow.sink;    Resource.t; Eio.Flow.close >
+type socket = < Eio.Flow.two_way; Resource.t; Eio.Flow.close >
 
 val await_readable : Unix.file_descr -> unit
 (** [await_readable fd] blocks until [fd] is readable (or has an error). *)
@@ -25,9 +41,9 @@ val await_readable : Unix.file_descr -> unit
 val await_writable : Unix.file_descr -> unit
 (** [await_writable fd] blocks until [fd] is writable (or has an error). *)
 
-(** Convert between [Unix.file_descr] and Eio objects. *)
+(**/**)
 module FD : sig
-  val peek : < unix_fd; .. > -> Unix.file_descr
+  val peek : < Resource.t; .. > -> Unix.file_descr
   (** [peek x] is the Unix file descriptor underlying [x].
       The caller must ensure that they do not continue to use the result after [x] is closed. *)
 
@@ -35,7 +51,7 @@ module FD : sig
   (** [peek_opt x] is the Unix file descriptor underlying [x], if any.
       The caller must ensure that they do not continue to use the result after [x] is closed. *)
 
-  val take : < unix_fd; .. > -> Unix.file_descr
+  val take : < Resource.t; .. > -> Unix.file_descr
   (** [take x] is like [peek], but also marks [x] as closed on success (without actually closing the FD).
       [x] can no longer be used after this, and the caller is responsible for closing the FD. *)
 
@@ -50,6 +66,15 @@ module FD : sig
       @param close_unix If [true], closing the object will also close the underlying FD.
                         If [false], the caller is responsible for keeping [FD] open until the object is closed. *)
 end
+(**/**)
+
+val import_socket_stream : sw:Switch.t -> close_unix:bool -> Unix.file_descr -> socket
+(** [import_socket_stream ~sw ~close_unix:true fd] is an Eio flow that uses [fd].
+
+    It can be cast to e.g. {!source} for a one-way flow.
+    The socket object will be closed when [sw] finishes.
+
+    The [close_unix] and [sw] arguments are passed to {!Fd.of_unix}. *)
 
 (** Convert between Eio.Net.Ipaddr and Unix.inet_addr. *)
 module Ipaddr : sig
@@ -80,16 +105,13 @@ val socketpair :
     This creates OS-level resources using [socketpair(2)].
     Note that, like all FDs created by Eio, they are both marked as close-on-exec by default. *)
 
-val pipe : Switch.t -> <Eio.Flow.source; Eio.Flow.close; unix_fd> * <Eio.Flow.sink; Eio.Flow.close; unix_fd>
+val pipe : Switch.t -> source * sink
 (** [pipe sw] returns a connected pair of flows [src] and [sink]. Data written to [sink]
     can be read from [src].
     Note that, like all FDs created by Eio, they are both marked as close-on-exec by default. *)
 
 (** API for Eio backends only. *)
 module Private : sig
-  type _ Eio.Generic.ty += Unix_file_descr : [`Peek | `Take] -> Unix.file_descr Eio.Generic.ty
-  (** See {!FD}. *)
-
   type _ Effect.t += 
     | Await_readable : Unix.file_descr -> unit Effect.t      (** See {!await_readable} *)
     | Await_writable : Unix.file_descr -> unit Effect.t      (** See {!await_writable} *)
@@ -98,8 +120,7 @@ module Private : sig
         socket Effect.t                                      (** See {!FD.as_socket} *)
     | Socketpair : Eio.Switch.t * Unix.socket_domain * Unix.socket_type * int ->
         (socket * socket) Effect.t                           (** See {!socketpair} *)
-    | Pipe : Eio.Switch.t -> 
-        (<Eio.Flow.source; Eio.Flow.close; unix_fd> * <Eio.Flow.sink; Eio.Flow.close; unix_fd>) Effect.t (** See {!pipe} *)
+    | Pipe : Eio.Switch.t -> (source * sink) Effect.t (** See {!pipe} *)
 
   module Rcfd = Rcfd
 

--- a/lib_eio/unix/fd.ml
+++ b/lib_eio/unix/fd.ml
@@ -1,0 +1,87 @@
+open Eio.Std
+
+type tristate = No | Yes | Unknown
+
+(* Note: [blocking] and [seekable] are not atomic,
+   but it doesn't matter if we query twice in rare cases. *)
+type t = {
+  fd : Rcfd.t;
+  mutable blocking : tristate;
+  mutable seekable : tristate;
+  close_unix : bool;                          (* Whether closing this also closes the underlying FD. *)
+  mutable release_hook : Eio.Switch.hook;     (* Use this on close to remove switch's [on_release] hook. *)
+}
+
+let err_closed op = Invalid_argument (op ^ ": file descriptor used after calling close!")
+
+let use t f ~if_closed = Rcfd.use t.fd f ~if_closed
+
+let use_exn op t f =
+  Rcfd.use t.fd f ~if_closed:(fun () -> raise (err_closed op))
+
+let close t =
+  Switch.remove_hook t.release_hook;
+  if t.close_unix then (
+    if not (Rcfd.close t.fd) then raise (err_closed "close")
+  ) else (
+    match Rcfd.remove t.fd with
+    | Some _ -> ()
+    | None -> raise (err_closed "close")
+  )
+
+let remove t =
+  Switch.remove_hook t.release_hook;
+  Rcfd.remove t.fd
+
+let tristate_of_bool_opt = function
+  | None -> Unknown
+  | Some true -> Yes
+  | Some false -> No
+
+let of_unix_no_hook ?(close_unix=true) ?blocking ?seekable fd =
+  let seekable = tristate_of_bool_opt seekable in
+  let blocking = tristate_of_bool_opt blocking in
+  { fd = Rcfd.make fd; blocking; seekable; close_unix; release_hook = Switch.null_hook }
+
+let of_unix ~sw ?blocking ?seekable ~close_unix fd =
+  let t = of_unix_no_hook ?blocking ?seekable ~close_unix fd in
+  t.release_hook <- Switch.on_release_cancellable sw (fun () -> close t);
+  t
+
+external eio_is_blocking : Unix.file_descr -> bool = "eio_unix_is_blocking"
+
+let is_blocking t =
+  match t.blocking with
+  | No -> false
+  | Yes -> true
+  | Unknown ->
+    use t ~if_closed:(Fun.const false) @@ fun fd ->
+    let blocking = eio_is_blocking fd in
+    t.blocking <- if blocking then Yes else No;
+    blocking
+
+let is_seekable t =
+  match t.seekable with
+  | No -> false
+  | Yes -> true
+  | Unknown ->
+    use t ~if_closed:(Fun.const false) @@ fun fd ->
+    let seekable =
+      match Unix.lseek fd 0 Unix.SEEK_CUR with
+      | (_ : int) -> true
+      | exception Unix.Unix_error (Unix.ESPIPE, "lseek", "") -> false
+    in
+    t.seekable <- if seekable then Yes else No;
+    seekable
+
+let rec use_exn_list op xs k =
+  match xs with
+  | [] -> k []
+  | x :: xs ->
+    use_exn op x @@ fun x ->
+    use_exn_list op xs @@ fun xs ->
+    k (x :: xs)
+
+let stdin = of_unix_no_hook Unix.stdin
+let stdout = of_unix_no_hook Unix.stdout
+let stderr= of_unix_no_hook Unix.stderr

--- a/lib_eio/unix/fd.ml
+++ b/lib_eio/unix/fd.ml
@@ -85,3 +85,5 @@ let rec use_exn_list op xs k =
 let stdin = of_unix_no_hook Unix.stdin
 let stdout = of_unix_no_hook Unix.stdout
 let stderr= of_unix_no_hook Unix.stderr
+
+let pp f t = Rcfd.pp f t.fd

--- a/lib_eio/unix/fd.mli
+++ b/lib_eio/unix/fd.mli
@@ -1,0 +1,70 @@
+open Eio.Std
+
+type t
+(** A wrapper around a {!Unix.file_descr}. *)
+
+(** {2 Creation} *)
+
+val of_unix : sw:Switch.t -> ?blocking:bool -> ?seekable:bool -> close_unix:bool -> Unix.file_descr -> t
+(** [of_unix ~sw ~close_unix fd] wraps [fd].
+
+    @param sw Close [fd] automatically when [sw] is finished.
+    @param blocking Indicates whether [fd] is in blocking mode.
+                    If not given, [fd] is probed for its blocking state if needed.
+    @param seekable The value to be returned by {!is_seekable}. Defaults to probing if needed.
+    @param close_unix Whether {!close} also closes [fd] (this should normally be [true]). *)
+
+(** {2 Using FDs} *)
+
+val use : t -> (Unix.file_descr -> 'a) -> if_closed:(unit -> 'a) -> 'a
+(** [use t fn ~if_closed] calls [fn wrapped_fd], ensuring that [wrapped_fd] will not be closed
+    before [fn] returns.
+
+    If [t] is already closed, it returns [if_closed ()] instead. *)
+
+val use_exn : string -> t -> (Unix.file_descr -> 'a) -> 'a
+(** [use_exn op t fn] calls [fn wrapped_fd], ensuring that [wrapped_fd] will not be closed
+    before [fn] returns.
+
+    If [t] is already closed, it raises an exception, using [op] as the name of the failing operation. *)
+
+val use_exn_list : string -> t list -> (Unix.file_descr list -> 'a) -> 'a
+(** [use_exn_list op fds fn] calls {!use_exn} on each FD in [fds], calling [fn wrapped_fds] on the results. *)
+
+(** {2 Closing} *)
+
+val close : t -> unit
+(** [close t] marks [t] as closed, so that {!use} can no longer be used to start new operations.
+
+    The wrapped FD will be closed once all current users of the FD have finished (unless [close_unix = false]).
+
+    @raise Invalid_argument if [t] is closed by another fiber first. *)
+
+val remove : t -> Unix.file_descr option
+(** [remove t] marks [t] as closed, so that {!use} can no longer be used to start new operations.
+
+    It then waits for all current users of the wrapped FD to finish using it, and then returns the FD.
+
+    This operation suspends the calling fiber and so must run from an Eio fiber.
+    It does not allow itself to be cancelled,
+    since it takes ownership of the FD and that would be leaked if it aborted.
+
+    Returns [None] if [t] is closed by another fiber first. *)
+
+(** {2 Flags} *)
+
+val is_blocking : t -> bool
+(** [is_blocking t] returns the value of [blocking] passed to {!of_unix}.
+
+    If not known, it first probes for it (and if the FD is already closed, returns [false]). *)
+
+val is_seekable : t -> bool
+(** [is_seekable t] returns the value of [seekable] passed to {!of_unix}.
+
+    If not known, it first probes for it (and if the FD is already closed, returns [false]). *)
+
+(** {2 Standard FDs} *)
+
+val stdin : t
+val stdout : t
+val stderr : t

--- a/lib_eio/unix/fd.mli
+++ b/lib_eio/unix/fd.mli
@@ -68,3 +68,8 @@ val is_seekable : t -> bool
 val stdin : t
 val stdout : t
 val stderr : t
+
+(** {2 Printing} *)
+
+val pp : t Fmt.t
+(** Displays the FD number. *)

--- a/lib_eio/unix/fork_action.mli
+++ b/lib_eio/unix/fork_action.mli
@@ -31,12 +31,15 @@ val with_actions : t list -> (c_action list -> 'a) -> 'a
 (** {2 Actions} *)
 
 val execve : string -> argv:string array -> env:string array -> t
-(** See [execve(2)]. *)
+(** See [execve(2)].
+
+    This replaces the current executable,
+    so it only makes sense as the last action to be performed. *)
 
 val chdir : string -> t
 (** [chdir path] changes directory to [path]. *)
 
-val fchdir : Rcfd.t -> t
+val fchdir : Fd.t -> t
 (** [fchdir fd] changes directory to [fd]. *)
 
 type blocking = [
@@ -45,7 +48,7 @@ type blocking = [
   | `Preserve_blocking   (** Don't change the blocking mode of the FD. *)
 ]
 
-val inherit_fds : (int * Rcfd.t * [< blocking]) list -> t
+val inherit_fds : (int * Fd.t * [< blocking]) list -> t
 (** [inherit_fds mapping] marks file descriptors as not close-on-exec and renumbers them.
 
     For each (fd, src, flags) in [mapping], we use [dup2] to duplicate [src] as [fd].

--- a/lib_eio/unix/inherit_fds.mli
+++ b/lib_eio/unix/inherit_fds.mli
@@ -1,7 +1,7 @@
 (** Plan how to renumber FDs in a child process. *)
 
 type action = { src : int; dst : int }
-(** { src; dst} is (roughly) a request to [dup2(src, dst)].
+(** [{ src; dst}] is (roughly) a request to [dup2(src, dst)].
 
     [dst] should not be marked as close-on-exec.
     If [src = dst] then simply clear the close-on-exec flag for the FD.

--- a/lib_eio/unix/rcfd.ml
+++ b/lib_eio/unix/rcfd.ml
@@ -169,3 +169,14 @@ let peek t =
   match Atomic.get t.fd with
   | Open fd -> fd
   | Closing _ -> failwith "FD already closed!"
+
+let pp f t =
+  match Atomic.get t.fd with
+  | Closing _ -> Fmt.string f "(closed FD)"
+  | Open fd ->
+    match Sys.os_type with
+    | "Unix" ->
+      let id : int = Obj.magic (fd : Unix.file_descr) in
+      Fmt.pf f "FD-%d" id
+    | _ ->
+      Fmt.string f "(FD)"

--- a/lib_eio/unix/rcfd.mli
+++ b/lib_eio/unix/rcfd.mli
@@ -69,3 +69,6 @@ val peek : t -> Unix.file_descr
 
     If [t] was closed, it instead raises an exception (if you're not sure when
     [t] might get closed, you shouldn't be using this function). *)
+
+val pp : t Fmt.t
+(** Displays the FD number. *)

--- a/lib_eio/unix/stubs.c
+++ b/lib_eio/unix/stubs.c
@@ -1,0 +1,14 @@
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <caml/mlvalues.h>
+#include <caml/unixsupport.h>
+
+CAMLprim value eio_unix_is_blocking(value v_fd) {
+  int fd = Int_val(v_fd);
+  int r = fcntl(fd, F_GETFL, 0);
+  if (r == -1)
+    uerror("fcntl", Nothing);
+
+  return Val_bool(r & O_NONBLOCK == 0);
+}

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -411,15 +411,15 @@ let secure_random = object
 end
 
 let stdenv ~run_event_loop =
-  let stdin = lazy (source (Eio_unix.Fd.stdin)) in
-  let stdout = lazy (sink (Eio_unix.Fd.stdout)) in
-  let stderr = lazy (sink (Eio_unix.Fd.stderr)) in
+  let stdin = source Eio_unix.Fd.stdin in
+  let stdout = sink Eio_unix.Fd.stdout in
+  let stderr = sink Eio_unix.Fd.stderr in
   let fs = (new dir ~label:"fs" Fs, ".") in
   let cwd = (new dir ~label:"cwd" Cwd, ".") in
   object (_ : stdenv)
-    method stdin  = Lazy.force stdin
-    method stdout = Lazy.force stdout
-    method stderr = Lazy.force stderr
+    method stdin  = stdin
+    method stdout = stdout
+    method stderr = stderr
     method net = net
     method domain_mgr = domain_mgr ~run_event_loop
     method clock = clock

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -23,40 +23,23 @@
 
 open Eio.Std
 
-(** Wrap [Unix.file_descr] to track whether it has been closed. *)
+type fd := Eio_unix.Fd.t
+
+(**/**)
 module FD : sig
-  type t
-  (** Either a [Unix.file_descr] or nothing (if closed) .*)
+  type t = fd
 
   val is_open : t -> bool
-  (** [is_open t] is [true] if {!close} hasn't been called yet. *)
-
   val close : t -> unit
-  (** [close t] closes [t].
-      @raise Invalid_arg if [t] is already closed. *)
-
   val of_unix : sw:Switch.t -> seekable:bool -> close_unix:bool -> Unix.file_descr -> t
-  (** [let t = of_unix ~sw ~seekable ~close_unix fd] wraps [fd] as an open file descriptor.
-      This is unsafe if [fd] is closed directly (before or after wrapping it).
-      @param sw [t] is closed when [sw] is released, if not closed manually first.
-      @param close_unix If [true], closing [t] also closes [fd].
-                        If [false], the caller is responsible for closing [fd],
-                        which must not happen until after [t] is closed.
-      @param seekable If true, we pass [-1] to io_uring as the "file offset", to use the current offset.
-                      If false, pass [0] as the file offset, which is needed for sockets. *)
-
   val to_unix : [< `Peek | `Take] -> t -> Unix.file_descr
-  (** [to_unix op t] returns the wrapped descriptor.
-      This allows unsafe access to the FD.
-      If [op] is [`Take] then [t] is marked as closed (but the underlying FD is not actually closed).
-      @raise Invalid_arg if [t] is closed. *)
 end
+(**/**)
 
 (** {1 Eio API} *)
 
-type has_fd = < fd : FD.t >
-type source = < Eio.Flow.source; Eio.Flow.close; has_fd >
-type sink   = < Eio.Flow.sink  ; Eio.Flow.close; has_fd >
+type source = Eio_unix.source
+type sink   = Eio_unix.sink
 
 type stdenv = <
   stdin  : source;
@@ -72,8 +55,10 @@ type stdenv = <
   debug : Eio.Debug.t;
 >
 
-val get_fd : <has_fd; ..> -> FD.t
+(**/**)
+val get_fd : <Eio_unix.Resource.t; ..> -> FD.t
 val get_fd_opt : #Eio.Generic.t -> FD.t option
+(**/**)
 
 (** {1 Main Loop} *)
 
@@ -143,75 +128,75 @@ module Low_level : sig
     flags:Uring.Open_flags.t ->
     perm:Unix.file_perm ->
     resolve:Uring.Resolve.t ->
-    ?dir:FD.t -> string -> FD.t
+    ?dir:fd -> string -> fd
   (** [openat2 ~sw ~flags ~perm ~resolve ~dir path] opens [dir/path].
 
       See {!Uring.openat2} for details. *)
 
-  val read_upto : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> int
+  val read_upto : ?file_offset:Optint.Int63.t -> fd -> Uring.Region.chunk -> int -> int
   (** [read_upto fd chunk len] reads at most [len] bytes from [fd],
       returning as soon as some data is available.
 
       @param file_offset Read from the given position in [fd] (default: 0).
       @raise End_of_file Raised if all data has already been read. *)
 
-  val read_exactly : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> unit
+  val read_exactly : ?file_offset:Optint.Int63.t -> fd -> Uring.Region.chunk -> int -> unit
   (** [read_exactly fd chunk len] reads exactly [len] bytes from [fd],
       performing multiple read operations if necessary.
 
       @param file_offset Read from the given position in [fd] (default: 0).
       @raise End_of_file Raised if the stream ends before [len] bytes have been read. *)
 
-  val readv : ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> int
+  val readv : ?file_offset:Optint.Int63.t -> fd -> Cstruct.t list -> int
   (** [readv] is like {!read_upto} but can read into any cstruct(s),
       not just chunks of the pre-shared buffer.
 
       If multiple buffers are given, they are filled in order. *)
 
-  val write : ?file_offset:Optint.Int63.t -> FD.t -> Uring.Region.chunk -> int -> unit
+  val write : ?file_offset:Optint.Int63.t -> fd -> Uring.Region.chunk -> int -> unit
   (** [write fd buf len] writes exactly [len] bytes from [buf] to [fd].
 
       It blocks until the OS confirms the write is done,
       and resubmits automatically if the OS doesn't write all of it at once. *)
 
-  val writev : ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> unit
+  val writev : ?file_offset:Optint.Int63.t -> fd -> Cstruct.t list -> unit
   (** [writev] is like {!write} but can write from any cstruct(s),
       not just chunks of the pre-shared buffer.
 
       If multiple buffers are given, they are sent in order.
       It will make multiple OS calls if the OS doesn't write all of it at once. *)
 
-  val writev_single : ?file_offset:Optint.Int63.t -> FD.t -> Cstruct.t list -> int
+  val writev_single : ?file_offset:Optint.Int63.t -> fd -> Cstruct.t list -> int
   (** [writev_single] is like [writev] but only performs a single write operation.
       It returns the number of bytes written, which may be smaller than the requested amount. *)
 
-  val splice : FD.t -> dst:FD.t -> len:int -> int
+  val splice : fd -> dst:fd -> len:int -> int
   (** [splice src ~dst ~len] attempts to copy up to [len] bytes of data from [src] to [dst].
 
       @return The number of bytes copied.
       @raise End_of_file [src] is at the end of the file.
       @raise Unix.Unix_error(EINVAL, "splice", _) if splice is not supported for these FDs. *)
 
-  val connect : FD.t -> Unix.sockaddr -> unit
+  val connect : fd -> Unix.sockaddr -> unit
   (** [connect fd addr] attempts to connect socket [fd] to [addr]. *)
 
-  val await_readable : FD.t -> unit
+  val await_readable : fd -> unit
   (** [await_readable fd] blocks until [fd] is readable (or has an error). *)
 
-  val await_writable : FD.t -> unit
+  val await_writable : fd -> unit
   (** [await_writable fd] blocks until [fd] is writable (or has an error). *)
 
-  val fstat : FD.t -> Eio.File.Stat.t
+  val fstat : fd -> Eio.File.Stat.t
   (** Like {!Unix.LargeFile.fstat}. *)
 
-  val read_dir : FD.t -> string list
+  val read_dir : fd -> string list
   (** [read_dir dir] reads all directory entries from [dir].
       The entries are not returned in any particular order
       (not even necessarily the order in which Linux returns them). *)
 
   (** {1 Sockets} *)
 
-  val accept : sw:Switch.t -> FD.t -> (FD.t * Unix.sockaddr)
+  val accept : sw:Switch.t -> fd -> (fd * Unix.sockaddr)
   (** [accept ~sw t] blocks until a new connection is received on listening socket [t].
 
       It returns the new connection and the address of the connecting peer.
@@ -219,17 +204,17 @@ module Low_level : sig
       The new connection is attached to [sw] and will be closed when that finishes, if
       not already closed manually by then. *)
 
-  val shutdown : FD.t -> Unix.shutdown_command -> unit
+  val shutdown : fd -> Unix.shutdown_command -> unit
   (** Like {!Unix.shutdown}. *)
 
-  val send_msg : FD.t -> ?fds:FD.t list -> ?dst:Unix.sockaddr -> Cstruct.t list -> unit
+  val send_msg : fd -> ?fds:fd list -> ?dst:Unix.sockaddr -> Cstruct.t list -> unit
   (** [send_msg socket bufs] is like [writev socket bufs], but also allows setting the destination address
       (for unconnected sockets) and attaching FDs (for Unix-domain sockets). *)
 
-  val recv_msg : FD.t -> Cstruct.t list -> Uring.Sockaddr.t * int
+  val recv_msg : fd -> Cstruct.t list -> Uring.Sockaddr.t * int
   (** [recv_msg socket bufs] is like [readv socket bufs] but also returns the address of the sender. *)
 
-  val recv_msg_with_fds : sw:Switch.t -> max_fds:int -> FD.t -> Cstruct.t list -> Uring.Sockaddr.t * int * FD.t list
+  val recv_msg_with_fds : sw:Switch.t -> max_fds:int -> fd -> Cstruct.t list -> Uring.Sockaddr.t * int * fd list
   (** [recv_msg_with_fds] is like [recv_msg] but also allows receiving up to [max_fds] file descriptors
       (sent using SCM_RIGHTS over a Unix domain socket). *)
 
@@ -254,21 +239,8 @@ module Low_level : sig
     type t
     (** A child process. *)
 
+    module Fork_action = Eio_unix.Private.Fork_action
     (** Setup actions to perform in the child process. *)
-    module Fork_action : sig
-      type t = Eio_unix.Private.Fork_action.t
-
-      val execve : string -> argv:string array -> env:string array -> t
-      (** See execve(2).
-          This replaces the current executable,
-          so it only makes sense as the last action to be performed. *)
-
-      val chdir : string -> t
-      (** [chdir path] changes directory to [path]. *)
-
-      val fchdir : FD.t -> t
-      (** [fchdir dir] changes directory to [dir]. *)
-    end
 
     val spawn : sw:Switch.t -> Fork_action.t list -> t
     (** [spawn ~sw actions] forks a child process, which executes [actions].

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -34,6 +34,7 @@ module FD : sig
   val of_unix : sw:Switch.t -> seekable:bool -> close_unix:bool -> Unix.file_descr -> t
   val to_unix : [< `Peek | `Take] -> t -> Unix.file_descr
 end
+[@@deprecated "Use Eio_unix.Fd instead"]
 (**/**)
 
 (** {1 Eio API} *)
@@ -56,8 +57,11 @@ type stdenv = <
 >
 
 (**/**)
-val get_fd : <Eio_unix.Resource.t; ..> -> FD.t
-val get_fd_opt : #Eio.Generic.t -> FD.t option
+val get_fd : <Eio_unix.Resource.t; ..> -> fd
+[@@deprecated "Use Eio_unix.Resource.fd instead"]
+
+val get_fd_opt : #Eio.Generic.t -> fd option
+[@@deprecated "Use Eio_unix.Resource.fd_opt instead"]
 (**/**)
 
 (** {1 Main Loop} *)

--- a/lib_eio_linux/fd.ml
+++ b/lib_eio_linux/fd.ml
@@ -1,71 +1,12 @@
-open Eio.Std
+include Eio_unix.Fd
 
-module Rcfd = Eio_unix.Private.Rcfd
-module Ctf = Eio.Private.Ctf
-
-type t = {
-  fd : Rcfd.t;
-  seekable : bool;
-  close_unix : bool;                          (* Whether closing this also closes the underlying FD. *)
-  mutable release_hook : Eio.Switch.hook;     (* Use this on close to remove switch's [on_release] hook. *)
-}
-
-let to_rcfd t = t.fd
-
-let err_closed op = Invalid_argument (op ^ ": file descriptor used after calling close!")
-
-let use t f ~if_closed = Rcfd.use t.fd f ~if_closed
-
-let use_exn op t f =
-  Rcfd.use t.fd f ~if_closed:(fun () -> raise (err_closed op))
-
-let rec use_exn_list op xs k =
-  match xs with
-  | [] -> k []
-  | x :: xs ->
-    use_exn op x @@ fun x ->
-    use_exn_list op xs @@ fun xs ->
-    k (x :: xs)
-
-let is_open t = Rcfd.is_open t.fd
-
-let close t =
-  Ctf.label "close";
-  Switch.remove_hook t.release_hook;
-  if t.close_unix then (
-    if not (Rcfd.close t.fd) then raise (err_closed "close")
-  ) else (
-    match Rcfd.remove t.fd with
-    | Some _ -> ()
-    | None -> raise (err_closed "close")
-  )
-
-let is_seekable fd =
-  match Unix.lseek fd 0 Unix.SEEK_CUR with
-  | (_ : int) -> true
-  | exception Unix.Unix_error(Unix.ESPIPE, "lseek", "") -> false
+let is_open t =
+  use t (fun _ -> true)
+    ~if_closed:(fun () -> false)
 
 let to_unix op t =
   match op with
-  | `Peek -> Rcfd.peek t.fd
-  | `Take ->
-    Switch.remove_hook t.release_hook;
-    match Rcfd.remove t.fd with
-    | Some fd -> fd
-    | None -> raise (err_closed "to_unix")
+  | `Take -> remove t |> Option.get
+  | `Peek -> use_exn "to_unix" t Fun.id
 
-let of_unix_no_hook ~seekable ~close_unix fd =
-  { fd = Rcfd.make fd; seekable; close_unix; release_hook = Switch.null_hook }
-
-let of_unix ~sw ~seekable ~close_unix fd =
-  let t = of_unix_no_hook ~seekable ~close_unix fd in
-  t.release_hook <- Switch.on_release_cancellable sw (fun () -> close t);
-  t
-
-let uring_file_offset t =
-  if t.seekable then Optint.Int63.minus_one else Optint.Int63.zero
-
-let file_offset t = function
-  | Some x -> `Pos x
-  | None when t.seekable -> `Seekable_current
-  | None -> `Nonseekable_current
+let of_unix ~sw ~seekable ~close_unix fd = of_unix ~sw ~seekable ~close_unix fd

--- a/lib_eio_linux/fd.ml
+++ b/lib_eio_linux/fd.ml
@@ -1,3 +1,5 @@
+(* Deprecated *)
+
 include Eio_unix.Fd
 
 let is_open t =

--- a/lib_eio_linux/tests/fd_passing.md
+++ b/lib_eio_linux/tests/fd_passing.md
@@ -18,17 +18,17 @@ Sending a file descriptor over a Unix domain socket:
   let fd = Eio.Path.open_out ~sw (env#cwd / "tmp.txt") ~create:(`Exclusive 0o600) in
   Eio.Flow.copy_string "Test data" fd;
   let r, w = Unix.(socketpair PF_UNIX SOCK_STREAM 0) in
-  let r = Eio_linux.FD.of_unix ~sw ~seekable:false ~close_unix:true r in
-  let w = Eio_linux.FD.of_unix ~sw ~seekable:false ~close_unix:true w in
+  let r = Eio_unix.Fd.of_unix ~sw ~seekable:false ~close_unix:true r in
+  let w = Eio_unix.Fd.of_unix ~sw ~seekable:false ~close_unix:true w in
   Fiber.both
-    (fun () -> Eio_linux.Low_level.send_msg w [Cstruct.of_string "x"] ~fds:[Eio_linux.get_fd_opt fd |> Option.get])
+    (fun () -> Eio_linux.Low_level.send_msg w [Cstruct.of_string "x"] ~fds:[Eio_unix.Resource.fd_opt fd |> Option.get])
     (fun () ->
        let buf = Cstruct.of_string "?" in
        let addr, got, fds = Eio_linux.Low_level.recv_msg_with_fds ~sw r ~max_fds:10 [buf] in
        traceln "Got: %S plus %d FD" (Cstruct.to_string buf) (List.length fds);
        match fds with
        | [fd] ->
-         let fd = Eio_linux.FD.to_unix `Peek fd in
+         Eio_unix.Fd.use_exn "read" fd @@ fun fd ->
          ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
          traceln "Read: %S" (really_input_string (Unix.in_channel_of_descr fd) 9);
        | _ -> assert false

--- a/lib_eio_posix/domain_mgr.ml
+++ b/lib_eio_posix/domain_mgr.ml
@@ -18,6 +18,8 @@ open Eio.Std
 
 [@@@alert "-unstable"]
 
+module Fd = Eio_unix.Fd
+
 (* Run an event loop in the current domain, using [fn x] as the root fiber. *)
 let run_event_loop fn x =
   Sched.with_sched @@ fun sched ->
@@ -47,8 +49,8 @@ let run_event_loop fn x =
       | Eio_unix.Private.Pipe sw -> Some (fun k ->
           match
             let r, w = Low_level.pipe ~sw in
-            let source = (Flow.of_fd r :> <Eio.Flow.source; Eio.Flow.close; Eio_unix.unix_fd>) in
-            let sink = (Flow.of_fd w :> <Eio.Flow.sink; Eio.Flow.close; Eio_unix.unix_fd>) in
+            let source = (Flow.of_fd r :> Eio_unix.source) in
+            let sink = (Flow.of_fd w :> Eio_unix.sink) in
             (source, sink)
           with
           | r -> continue k r

--- a/lib_eio_posix/eio_posix.ml
+++ b/lib_eio_posix/eio_posix.ml
@@ -17,9 +17,9 @@
 module Low_level = Low_level
 
 type stdenv = <
-  stdin  : <Eio.Flow.source; Eio_unix.unix_fd>;
-  stdout : <Eio.Flow.sink; Eio_unix.unix_fd>;
-  stderr : <Eio.Flow.sink; Eio_unix.unix_fd>;
+  stdin  : <Eio.Flow.source; Eio_unix.Resource.t>;
+  stdout : <Eio.Flow.sink; Eio_unix.Resource.t>;
+  stderr : <Eio.Flow.sink; Eio_unix.Resource.t>;
   net : Eio.Net.t;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;
@@ -34,9 +34,9 @@ let run main =
   (* SIGPIPE makes no sense in a modern application. *)
   Sys.(set_signal sigpipe Signal_ignore);
   Sys.(set_signal sigchld (Signal_handle (fun (_:int) -> Children.handle_sigchld ())));
-  let stdin = (Flow.of_fd Low_level.Fd.stdin :> <Eio.Flow.source; Eio_unix.unix_fd>) in
-  let stdout = (Flow.of_fd Low_level.Fd.stdout :> <Eio.Flow.sink; Eio_unix.unix_fd>) in
-  let stderr = (Flow.of_fd Low_level.Fd.stderr :> <Eio.Flow.sink; Eio_unix.unix_fd>) in
+  let stdin = (Flow.of_fd Eio_unix.Fd.stdin :> <Eio.Flow.source; Eio_unix.Resource.t>) in
+  let stdout = (Flow.of_fd Eio_unix.Fd.stdout :> <Eio.Flow.sink; Eio_unix.Resource.t>) in
+  let stderr = (Flow.of_fd Eio_unix.Fd.stderr :> <Eio.Flow.sink; Eio_unix.Resource.t>) in
   Domain_mgr.run_event_loop main @@ object (_ : stdenv)
     method stdin = stdin
     method stdout = stdout

--- a/lib_eio_posix/eio_posix.mli
+++ b/lib_eio_posix/eio_posix.mli
@@ -1,9 +1,9 @@
 (** Fallback Eio backend for POSIX systems. *)
 
 type stdenv = <
-  stdin  : <Eio.Flow.source; Eio_unix.unix_fd>;
-  stdout : <Eio.Flow.sink; Eio_unix.unix_fd>;
-  stderr : <Eio.Flow.sink; Eio_unix.unix_fd>;
+  stdin  : <Eio.Flow.source; Eio_unix.Resource.t>;
+  stdout : <Eio.Flow.sink; Eio_unix.Resource.t>;
+  stderr : <Eio.Flow.sink; Eio_unix.Resource.t>;
   net : Eio.Net.t;
   domain_mgr : Eio.Domain_manager.t;
   clock : Eio.Time.clock;

--- a/lib_eio_posix/fd.ml
+++ b/lib_eio_posix/fd.ml
@@ -1,3 +1,5 @@
+(* Deprecated *)
+
 include Eio_unix.Fd
 
 type has_fd = Eio_unix.Resource.t

--- a/lib_eio_posix/fd.ml
+++ b/lib_eio_posix/fd.ml
@@ -1,62 +1,12 @@
-open Eio.Std
+include Eio_unix.Fd
 
-module Rcfd = Eio_unix.Private.Rcfd
-
-type t = {
-  fd : Rcfd.t;
-
-  (* stdin, stdout and stderr are blocking, and so need special care.
-     For these, we first wait for them to become e.g. readable and then hope
-     that the read doesn't block. This may fail if multiple fibers try to read
-     at the same time. We could check that it's still readable after being
-     resumed, but that still won't work if multiple domains read at the same
-     time. Same problem for writes. *)
-  blocking : bool;
-  close_unix : bool;                          (* Whether closing this also closes the underlying FD. *)
-  mutable release_hook : Eio.Switch.hook;     (* Use this on close to remove switch's [on_release] hook. *)
-}
-
-let to_rcfd t = t.fd
-
-let err_closed op = Invalid_argument (op ^ ": file descriptor used after calling close!")
-
-let use_exn op t f =
-  Rcfd.use t.fd f ~if_closed:(fun () -> raise (err_closed op))
-
-let close t =
-  Switch.remove_hook t.release_hook;
-  if t.close_unix then (
-    if not (Rcfd.close t.fd) then raise (err_closed "close")
-  ) else (
-    match Rcfd.remove t.fd with
-    | Some _ -> ()
-    | None -> raise (err_closed "close")
-  )
-
-let of_unix_no_hook ?(close_unix=true) ~blocking fd =
-  { fd = Rcfd.make fd; blocking; close_unix; release_hook = Switch.null_hook }
-
-let of_unix ~sw ~blocking ~close_unix fd =
-  let t = of_unix_no_hook ~blocking ~close_unix fd in
-  t.release_hook <- Switch.on_release_cancellable sw (fun () -> close t);
-  t
-
-let is_blocking t = t.blocking
-
-let stdin = of_unix_no_hook ~blocking:true Unix.stdin
-let stdout = of_unix_no_hook ~blocking:true Unix.stdout
-let stderr= of_unix_no_hook ~blocking:true Unix.stderr
+type has_fd = Eio_unix.Resource.t
 
 let to_unix op t =
   match op with
-  | `Peek -> Rcfd.peek t.fd
-  | `Take ->
-    Switch.remove_hook t.release_hook;
-    match Rcfd.remove t.fd with
-    | Some fd -> fd
-    | None -> raise (err_closed "to_unix")
+  | `Take -> remove t |> Option.get
+  | `Peek -> use_exn "to_unix" t Fun.id
 
-type has_fd = < fd : t >
+let of_unix ~sw ~blocking ~close_unix fd = of_unix ~sw ~blocking ~close_unix fd
 
-type _ Eio.Generic.ty += FD : t Eio.Generic.ty
-let get_fd_opt t = Eio.Generic.probe t FD
+let get_fd_opt = Eio_unix.Resource.fd_opt

--- a/lib_eio_posix/fd.mli
+++ b/lib_eio_posix/fd.mli
@@ -2,7 +2,7 @@
 
 open Eio.Std
 
-type t
+type t = Eio_unix.Fd.t
 (** A wrapper around a {!Unix.file_descr}. *)
 
 val of_unix : sw:Switch.t -> blocking:bool -> close_unix:bool -> Unix.file_descr -> t
@@ -38,15 +38,8 @@ val to_unix : [`Peek | `Take] -> t -> Unix.file_descr
 
     [to_unix `Peek t] returns the wrapped FD directly. You must ensure that it is not closed while using it. *)
 
-val to_rcfd : t -> Eio_unix.Private.Rcfd.t
-(** Get the underlying ref-counted FD.
-    Note: you must not close this directly, as that will not remove the hook. *)
-
 type has_fd = < fd : t >
 (** Resources that have FDs are sub-types of [has_fd]. *)
-
-type _ Eio.Generic.ty += FD : t Eio.Generic.ty
-(** Resources that wrap FDs can handle this in their [probe] method to expose the FD. *)
 
 val get_fd_opt : #Eio.Generic.t -> t option
 (** [get_fd_opt r] returns the [t] being wrapped by a resource, if any.

--- a/lib_eio_posix/flow.ml
+++ b/lib_eio_posix/flow.ml
@@ -1,3 +1,5 @@
+module Fd = Eio_unix.Fd
+
 let fstat fd =
   try
     let ust = Low_level.fstat fd in
@@ -61,8 +63,7 @@ let shutdown fd cmd =
     | `All -> Unix.SHUTDOWN_ALL
   with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
 
-let of_fd fd = object (_ : <Eio.Flow.two_way; Eio.Flow.close; Eio.File.rw; Eio_unix.unix_fd; Fd.has_fd>)
-  method unix_fd op = Fd.to_unix op fd
+let of_fd fd = object (_ : <Eio_unix.socket; Eio.File.rw>)
   method fd = fd
 
   method read_methods = []
@@ -78,8 +79,7 @@ let of_fd fd = object (_ : <Eio.Flow.two_way; Eio.Flow.close; Eio.File.rw; Eio_u
   method close = Fd.close fd
 
   method probe : type a. a Eio.Generic.ty -> a option = function
-    | Fd.FD -> Some fd
-    | Eio_unix.Private.Unix_file_descr op -> Some (Fd.to_unix op fd)
+    | Eio_unix.Resource.FD -> Some fd
     | _ -> None
 end
 

--- a/lib_eio_posix/fs.ml
+++ b/lib_eio_posix/fs.ml
@@ -24,6 +24,8 @@
 
 open Eio.Std
 
+module Fd = Eio_unix.Fd
+
 class virtual posix_dir = object
   inherit Eio.Fs.dir
 

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -229,18 +229,7 @@ module Process = struct
   let exit_status t = t.exit_status
   let pid t = t.pid
 
-  module Fork_action = struct
-    type t = Eio_unix.Private.Fork_action.t
-
-    let fchdir fd = Eio_unix.Private.Fork_action.fchdir (Fd.to_rcfd fd)
-    let chdir = Eio_unix.Private.Fork_action.chdir
-    let execve = Eio_unix.Private.Fork_action.execve
-
-    let inherit_fds m : t =
-      m
-      |> List.map (fun (dst, src, flags) -> (dst, Fd.to_rcfd src, flags))
-      |> Eio_unix.Private.Fork_action.inherit_fds
-  end
+  module Fork_action = Eio_unix.Private.Fork_action
 
   (* Read a (typically short) error message from a child process. *)
   let rec read_response fd =

--- a/lib_eio_posix/low_level.mli
+++ b/lib_eio_posix/low_level.mli
@@ -12,45 +12,48 @@
 
 open Eio.Std
 
-module Fd = Fd
+type fd := Eio_unix.Fd.t
 
-val await_readable : Fd.t -> unit
-val await_writable : Fd.t -> unit
+module Fd = Fd
+[@@deprecated "Use Eio_unix.Fd instead"]
+
+val await_readable : fd -> unit
+val await_writable : fd -> unit
 
 val sleep_until : Mtime.t -> unit
 
-val read : Fd.t -> bytes -> int -> int -> int
-val write : Fd.t -> bytes -> int -> int -> int
+val read : fd -> bytes -> int -> int -> int
+val write : fd -> bytes -> int -> int -> int
 
-val socket : sw:Switch.t -> Unix.socket_domain -> Unix.socket_type -> int -> Fd.t
-val connect : Fd.t -> Unix.sockaddr -> unit
-val accept : sw:Switch.t -> Fd.t -> Fd.t * Unix.sockaddr
+val socket : sw:Switch.t -> Unix.socket_domain -> Unix.socket_type -> int -> fd
+val connect : fd -> Unix.sockaddr -> unit
+val accept : sw:Switch.t -> fd -> fd * Unix.sockaddr
 
-val shutdown : Fd.t -> Unix.shutdown_command -> unit
+val shutdown : fd -> Unix.shutdown_command -> unit
 
-val recv_msg : Fd.t -> bytes -> int * Unix.sockaddr
-val send_msg : Fd.t -> dst:Unix.sockaddr -> bytes -> int
+val recv_msg : fd -> bytes -> int * Unix.sockaddr
+val send_msg : fd -> dst:Unix.sockaddr -> bytes -> int
 
 val getrandom : Cstruct.t -> unit
 
-val fstat : Fd.t -> Unix.LargeFile.stats
+val fstat : fd -> Unix.LargeFile.stats
 val lstat : string -> Unix.LargeFile.stats
 
 val realpath : string -> string
 
-val mkdir : ?dirfd:Fd.t -> mode:int -> string -> unit
-val unlink : ?dirfd:Fd.t -> dir:bool -> string -> unit
-val rename : ?old_dir:Fd.t -> string -> ?new_dir:Fd.t -> string -> unit
+val mkdir : ?dirfd:fd -> mode:int -> string -> unit
+val unlink : ?dirfd:fd -> dir:bool -> string -> unit
+val rename : ?old_dir:fd -> string -> ?new_dir:fd -> string -> unit
 
 val readdir : string -> string array
 
-val readv : Fd.t -> Cstruct.t array -> int
-val writev : Fd.t -> Cstruct.t array -> int
+val readv : fd -> Cstruct.t array -> int
+val writev : fd -> Cstruct.t array -> int
 
-val preadv : file_offset:Optint.Int63.t -> Fd.t -> Cstruct.t array -> int
-val pwritev : file_offset:Optint.Int63.t -> Fd.t -> Cstruct.t array -> int
+val preadv : file_offset:Optint.Int63.t -> fd -> Cstruct.t array -> int
+val pwritev : file_offset:Optint.Int63.t -> fd -> Cstruct.t array -> int
 
-val pipe : sw:Switch.t -> Fd.t * Fd.t
+val pipe : sw:Switch.t -> fd * fd
 
 module Open_flags : sig
   type t
@@ -72,7 +75,7 @@ module Open_flags : sig
   val ( + ) : t -> t -> t
 end
 
-val openat : ?dirfd:Fd.t -> sw:Switch.t -> mode:int -> string -> Open_flags.t -> Fd.t
+val openat : ?dirfd:fd -> sw:Switch.t -> mode:int -> string -> Open_flags.t -> fd
 (** Note: the returned FD is always non-blocking and close-on-exec. *)
 
 module Process : sig

--- a/lib_eio_posix/low_level.mli
+++ b/lib_eio_posix/low_level.mli
@@ -79,30 +79,8 @@ module Process : sig
   type t
   (** A child process. *)
 
+  module Fork_action = Eio_unix.Private.Fork_action
   (** Setup actions to perform in the child process. *)
-  module Fork_action : sig
-    type t = Eio_unix.Private.Fork_action.t
-
-    val execve : string -> argv:string array -> env:string array -> t
-    (** See execve(2).
-        This replaces the current executable,
-        so it only makes sense as the last action to be performed. *)
-
-    val chdir : string -> t
-    (** [chdir path] changes directory to [path]. *)
-
-    val fchdir : Fd.t -> t
-    (** [fchdir dir] changes directory to [dir]. *)
-
-    val inherit_fds : (int * Fd.t * [< `Blocking | `Nonblocking | `Preserve_blocking]) list -> t
-    (** [inherit_fds mapping] marks file descriptors as not close-on-exec and renumbers them.
-
-        For each key in [mapping], we use [dup2] to duplicate the source descriptor.
-        If there are cycles in [mapping], a temporary FD is used to break the cycle.
-        A mapping from an FD to itself simply clears the close-on-exec flag.
-
-        For each FD, you can also say whether it should be set as blocking or non-blocking. *)
-  end
 
   val spawn : sw:Switch.t -> Fork_action.t list -> t
   (** [spawn ~sw actions] forks a child process, which executes [actions].

--- a/lib_eio_posix/net.ml
+++ b/lib_eio_posix/net.ml
@@ -106,7 +106,7 @@ let listen ~reuse_addr ~reuse_port ~backlog ~sw (listen_addr : Eio.Net.Sockaddr.
     | `Unix _ | `Tcp _ ->
       Switch.null_hook
   in
-  Low_level.Fd.use_exn "listen" sock (fun fd ->
+  Fd.use_exn "listen" sock (fun fd ->
       if reuse_addr then
         Unix.setsockopt fd Unix.SO_REUSEADDR true;
       if reuse_port then

--- a/lib_eio_posix/test/poll.md
+++ b/lib_eio_posix/test/poll.md
@@ -15,13 +15,15 @@ to re-add it using `EPOLL_CTL_ADD`, not `EPOLL_CTL_MOD`.
 # Eio_posix.run @@ fun _env ->
   Switch.run (fun sw ->
      let r, w = Eio_unix.pipe sw in
-     Eio_unix.await_writable (Eio_unix.FD.peek w)
+     Eio_unix.Fd.use_exn "await_writable" (Eio_unix.Resource.fd w) @@ fun fd ->
+     Eio_unix.await_writable fd
   );
   (* [r] and [w] are now closed. We'll likely allocate the same FD numbers the second time.
      Check we don't get confused and try to [EPOLL_CTL_MOD] them. *)
   Switch.run (fun sw ->
      let r, w = Eio_unix.pipe sw in
-     Eio_unix.await_writable (Eio_unix.FD.peek w)
+     Eio_unix.Fd.use_exn "await_writable" (Eio_unix.Resource.fd w) @@ fun fd ->
+     Eio_unix.await_writable fd
   );;
 - : unit = ()
 ```

--- a/lib_eio_posix/test/spawn.md
+++ b/lib_eio_posix/test/spawn.md
@@ -133,10 +133,9 @@ FOO=bar
 Inheriting file descriptors:
 
 ```ocaml
-let fd flow = Eio_posix.Low_level.Fd.get_fd_opt flow |> Option.get
-let unix flow = Eio_posix.Low_level.Fd.to_unix `Peek (fd flow)
+let fd flow = Eio_unix.Resource.fd flow
 let int_of_fd : Unix.file_descr -> int = Obj.magic
-let id flow = int_of_fd (unix flow)
+let id flow = Eio_unix.Fd.use_exn "id" (fd flow) int_of_fd
 let read_all pipe =
   let r = Eio.Buf_read.of_flow pipe ~max_size:1024 in
   Eio.Buf_read.take_all r


### PR DESCRIPTION
Now that eio_luv is gone, there is no need for different backends to have different types for wrapped file descriptors. This means we can use wrapped FDs in more places, avoiding races (before, any API shared between backends had to use `Unix.file_descr`).

This also allows e.g. `Eio_unix.pipe` to return resources with an `Fd.t` attached explicitly in the type. It also avoids duplicating the fork actions in each backend.

In the first commit the old APIs are mostly still present (using wrappers defined in terms of the new API), and the tests still use them. The second commit updates the tests to the new API and marks the old APIs as deprecated.

The Linux backend needs to know if FDs are seekable, while the POSIX one wants to know if they're blocking, so the unified version tracks both but only does the query if needed.

More API improvements should be possible as a result of this, such as adding an `Eio_unix.Stdenv.t`, where resources have FDs in their types, but that can be a separate PR. That should also be useful for the subprocess PR, allowing us to inherit generic FDs, not just flows.