### PR TITLE
Move Eio.Stdenv.t to Eio_unix.Stdenv.base

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Eio replaces existing concurrency libraries such as Lwt
 * [Best Practices](#best-practices)
   * [Switches](#switches-1)
   * [Casting](#casting)
-  * [Passing Stdenv.t](#passing-stdenvt)
+  * [Passing env](#passing-env)
 * [Further Reading](#further-reading)
 
 <!-- vim-markdown-toc -->
@@ -1675,7 +1675,7 @@ end
 
 Note: the `#type` syntax only works on types defined by classes, whereas the slightly more verbose `<type; ..>` works on all object types.
 
-### Passing Stdenv.t
+### Passing env
 
 The `env` value you get from `Eio_main.run` is a powerful capability,
 and programs are easier to understand when it's not passed around too much.

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -30,20 +30,6 @@ module Fs = Fs
 module Path = Path
 
 module Stdenv = struct
-  type t = <
-    stdin  : Flow.source;
-    stdout : Flow.sink;
-    stderr : Flow.sink;
-    net : Net.t;
-    domain_mgr : Domain_manager.t;
-    clock : Time.clock;
-    mono_clock : Time.Mono.t;
-    fs : Fs.dir Path.t;
-    cwd : Fs.dir Path.t;
-    secure_random : Flow.source;
-    debug : Debug.t;
-  >
-
   let stdin  (t : <stdin  : #Flow.source; ..>) = t#stdin
   let stdout (t : <stdout : #Flow.sink;   ..>) = t#stdout
   let stderr (t : <stderr : #Flow.sink;   ..>) = t#stderr

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -66,7 +66,7 @@ end
     methods directly. Using the functions results in better error messages from the compiler,
     and may provide extra features or sanity checks.
 
-    The system resources are available from the {!Stdenv.t} provided by your event loop
+    The system resources are available from the environment argument provided by your event loop
     (e.g. {!Eio_main.run}). *)
 
 (** A base class for objects that can be queried at runtime for extra features. *)
@@ -163,7 +163,7 @@ end
 (** The standard environment of a process. *)
 module Stdenv : sig
   (** All access to the outside world comes from running the event loop,
-      which provides a {!t}.
+      which provides an environment (e.g. an {!Eio_unix.Stdenv.base}).
 
       Example:
       {[
@@ -174,20 +174,6 @@ module Stdenv : sig
             ~net:env#net
       ]}
   *)
-
-  type t = <
-    stdin  : Flow.source;
-    stdout : Flow.sink;
-    stderr : Flow.sink;
-    net : Net.t;
-    domain_mgr : Domain_manager.t;
-    clock : Time.clock;
-    mono_clock : Time.Mono.t;
-    fs : Fs.dir Path.t;
-    cwd : Fs.dir Path.t;
-    secure_random : Flow.source;
-    debug : Debug.t;
-  >
 
   (** {1 Standard streams}
 

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -1,5 +1,7 @@
 [@@@alert "-unstable"]
 
+open Eio.Std
+
 module Fd = Fd
 
 module Resource = struct
@@ -27,9 +29,9 @@ module Private = struct
     | Await_readable : Unix.file_descr -> unit Effect.t
     | Await_writable : Unix.file_descr -> unit Effect.t
     | Get_monotonic_clock : Eio.Time.Mono.t Effect.t
-    | Socket_of_fd : Eio.Switch.t * bool * Unix.file_descr -> socket Effect.t
-    | Socketpair : Eio.Switch.t * Unix.socket_domain * Unix.socket_type * int -> (socket * socket) Effect.t
-    | Pipe : Eio.Switch.t -> (source * sink) Effect.t
+    | Socket_of_fd : Switch.t * bool * Unix.file_descr -> socket Effect.t
+    | Socketpair : Switch.t * Unix.socket_domain * Unix.socket_type * int -> (socket * socket) Effect.t
+    | Pipe : Switch.t -> (source * sink) Effect.t
 
   module Rcfd = Rcfd
 
@@ -95,3 +97,19 @@ let getnameinfo (sockaddr : Eio.Net.Sockaddr.t) =
   run_in_systhread (fun () ->
     let Unix.{ni_hostname; ni_service} = Unix.getnameinfo sockaddr options in
     (ni_hostname, ni_service))
+
+module Stdenv = struct
+  type base = <
+    stdin  : source;
+    stdout : sink;
+    stderr : sink;
+    net : Eio.Net.t;
+    domain_mgr : Eio.Domain_manager.t;
+    clock : Eio.Time.clock;
+    mono_clock : Eio.Time.Mono.t;
+    fs : Eio.Fs.dir Eio.Path.t;
+    cwd : Eio.Fs.dir Eio.Path.t;
+    secure_random : Eio.Flow.source;
+    debug : Eio.Debug.t;
+  >
+end

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -102,6 +102,26 @@ val pipe : Switch.t -> source * sink
     can be read from [src].
     Note that, like all FDs created by Eio, they are both marked as close-on-exec by default. *)
 
+(** The set of resources provided to a process on a Unix-compatible system. *)
+module Stdenv : sig
+  type base = <
+    stdin  : source;
+    stdout : sink;
+    stderr : sink;
+    net : Eio.Net.t;
+    domain_mgr : Eio.Domain_manager.t;
+    clock : Eio.Time.clock;
+    mono_clock : Eio.Time.Mono.t;
+    fs : Eio.Fs.dir Eio.Path.t;
+    cwd : Eio.Fs.dir Eio.Path.t;
+    secure_random : Eio.Flow.source;
+    debug : Eio.Debug.t;
+  >
+  (** The common set of features provided by all traditional operating systems (BSDs, Linux, Mac, Windows).
+
+      You can use the functions in {!Eio.Stdenv} to access these fields if you prefer. *)
+end
+
 (** API for Eio backends only. *)
 module Private : sig
   type _ Effect.t += 

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -281,19 +281,7 @@ let net = object
   method getnameinfo = Eio_unix.getnameinfo
 end
 
-type stdenv = <
-  stdin  : source;
-  stdout : sink;
-  stderr : sink;
-  net : Eio.Net.t;
-  domain_mgr : Eio.Domain_manager.t;
-  clock : Eio.Time.clock;
-  mono_clock : Eio.Time.Mono.t;
-  fs : Eio.Fs.dir Eio.Path.t;
-  cwd : Eio.Fs.dir Eio.Path.t;
-  secure_random : Eio.Flow.source;
-  debug : Eio.Debug.t;
->
+type stdenv = Eio_unix.Stdenv.base
 
 let domain_mgr ~run_event_loop = object
   inherit Eio.Domain_manager.t

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -42,19 +42,7 @@ end
 type source = Eio_unix.source
 type sink   = Eio_unix.sink
 
-type stdenv = <
-  stdin  : source;
-  stdout : sink;
-  stderr : sink;
-  net : Eio.Net.t;
-  domain_mgr : Eio.Domain_manager.t;
-  clock : Eio.Time.clock;
-  mono_clock : Eio.Time.Mono.t;
-  fs : Eio.Fs.dir Eio.Path.t;
-  cwd : Eio.Fs.dir Eio.Path.t;
-  secure_random : Eio.Flow.source;
-  debug : Eio.Debug.t;
->
+type stdenv = Eio_unix.Stdenv.base
 
 (**/**)
 val get_fd : <Eio_unix.Resource.t; ..> -> fd

--- a/lib_eio_posix/eio_posix.ml
+++ b/lib_eio_posix/eio_posix.ml
@@ -16,27 +16,15 @@
 
 module Low_level = Low_level
 
-type stdenv = <
-  stdin  : <Eio.Flow.source; Eio_unix.Resource.t>;
-  stdout : <Eio.Flow.sink; Eio_unix.Resource.t>;
-  stderr : <Eio.Flow.sink; Eio_unix.Resource.t>;
-  net : Eio.Net.t;
-  domain_mgr : Eio.Domain_manager.t;
-  clock : Eio.Time.clock;
-  mono_clock : Eio.Time.Mono.t;
-  fs : Eio.Fs.dir Eio.Path.t;
-  cwd : Eio.Fs.dir Eio.Path.t;
-  secure_random : Eio.Flow.source;
-  debug : Eio.Debug.t;
->
+type stdenv = Eio_unix.Stdenv.base
 
 let run main =
   (* SIGPIPE makes no sense in a modern application. *)
   Sys.(set_signal sigpipe Signal_ignore);
   Sys.(set_signal sigchld (Signal_handle (fun (_:int) -> Children.handle_sigchld ())));
-  let stdin = (Flow.of_fd Eio_unix.Fd.stdin :> <Eio.Flow.source; Eio_unix.Resource.t>) in
-  let stdout = (Flow.of_fd Eio_unix.Fd.stdout :> <Eio.Flow.sink; Eio_unix.Resource.t>) in
-  let stderr = (Flow.of_fd Eio_unix.Fd.stderr :> <Eio.Flow.sink; Eio_unix.Resource.t>) in
+  let stdin = (Flow.of_fd Eio_unix.Fd.stdin :> Eio_unix.source) in
+  let stdout = (Flow.of_fd Eio_unix.Fd.stdout :> Eio_unix.sink) in
+  let stderr = (Flow.of_fd Eio_unix.Fd.stderr :> Eio_unix.sink) in
   Domain_mgr.run_event_loop main @@ object (_ : stdenv)
     method stdin = stdin
     method stdout = stdout

--- a/lib_eio_posix/eio_posix.mli
+++ b/lib_eio_posix/eio_posix.mli
@@ -1,19 +1,7 @@
 (** Fallback Eio backend for POSIX systems. *)
 
-type stdenv = <
-  stdin  : <Eio.Flow.source; Eio_unix.Resource.t>;
-  stdout : <Eio.Flow.sink; Eio_unix.Resource.t>;
-  stderr : <Eio.Flow.sink; Eio_unix.Resource.t>;
-  net : Eio.Net.t;
-  domain_mgr : Eio.Domain_manager.t;
-  clock : Eio.Time.clock;
-  mono_clock : Eio.Time.Mono.t;
-  fs : Eio.Fs.dir Eio.Path.t;
-  cwd : Eio.Fs.dir Eio.Path.t;
-  secure_random : Eio.Flow.source;
-  debug : Eio.Debug.t;
->
-(** An extended version of {!Eio.Stdenv.t} with some extra features available on POSIX systems. *)
+type stdenv = Eio_unix.Stdenv.base
+(** The type of the standard set of resources available on POSIX systems. *)
 
 val run : (stdenv -> 'a) -> 'a
 (** [run main] runs an event loop and calls [main stdenv] inside it.

--- a/lib_main/eio_main.mli
+++ b/lib_main/eio_main.mli
@@ -1,6 +1,6 @@
 (** Select a suitable event loop for Eio. *)
 
-val run : (Eio.Stdenv.t -> 'a) -> 'a
+val run : (Eio_unix.Stdenv.base -> 'a) -> 'a
 (** [run fn] runs an event loop and then calls [fn env] within it.
 
     [env] provides access to the process's environment (file-system, network, etc).

--- a/lib_main/linux_backend.enabled.ml
+++ b/lib_main/linux_backend.enabled.ml
@@ -1,1 +1,1 @@
-let run ~fallback fn = Eio_linux.run ~fallback (fun env -> fn (env :> Eio.Stdenv.t))
+let run ~fallback fn = Eio_linux.run ~fallback (fun env -> fn (env :> Eio_unix.Stdenv.base))

--- a/lib_main/posix_backend.enabled.ml
+++ b/lib_main/posix_backend.enabled.ml
@@ -1,1 +1,1 @@
-let run ~fallback:_ fn = Eio_posix.run (fun env -> fn (env :> Eio.Stdenv.t))
+let run ~fallback:_ fn = Eio_posix.run (fun env -> fn (env :> Eio_unix.Stdenv.base))

--- a/lib_main/windows_backend.enabled.ml
+++ b/lib_main/windows_backend.enabled.ml
@@ -1,1 +1,1 @@
-let run ~fallback:_ fn = Eio_windows.run (fun env -> fn (env :> Eio.Stdenv.t))
+let run ~fallback:_ fn = Eio_windows.run (fun env -> fn (env :> Eio_unix.Stdenv.base))

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -17,7 +17,7 @@ open Eio.Std
 
 let ( / ) = Path.( / )
 
-let run (fn : Eio.Stdenv.t -> unit) =
+let run fn =
   Eio_main.run @@ fun env ->
   fn env
 

--- a/tests/network.md
+++ b/tests/network.md
@@ -8,7 +8,7 @@
 ```ocaml
 open Eio.Std
 
-let run (fn : net:Eio.Net.t -> Switch.t -> unit) =
+let run (fn : net:#Eio.Net.t -> Switch.t -> unit) =
   Eio_main.run @@ fun env ->
   let net = Eio.Stdenv.net env in
   Switch.run (fn ~net)


### PR DESCRIPTION
The old type wasn't directly useful for anything, since nothing provides exactly this set of resources, and nothing needs to consume exactly this set either. However, it is useful in Eio_unix as the set of resources that a backend needs to provide to be compatible with `Eio_main.run`.

The new type is almost the same for now, except that the standard streams include file descriptors. Other Unix-specific features can be added later, such as support for passing file descriptors over sockets or to child processes.

I called the type `base` because we might want to add a `Stdenv.linux_or_unix` subtype later for basically everything that isn't Windows. Not sure what the name should be, though.

Note that, due to the way row-polymorphism works in OCaml, we can't e.g. have `Net.connect` return an `Eio_unix.socket` subtype of `Eio.Net.socket`. But we can add a new function (e.g. `connect_unix`) that returns a richer socket type.