### PR TITLE
Adopt OCaml Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,15 @@
+# Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct
+[enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
+
+To report any violations, please contact:
+
+* Patrick Ferris <patrick [at] sirref [dot] org>
+* Sudha Parimala <sudha [at] tarides [dot] com>
+* Thomas Leonard <thomasleonard [at] tarides [dot] com>
+* Vesa Karvonen <vesa [at] tarides [dot] com>


### PR DESCRIPTION
This code of conduct lives in [ocaml/code-of-conduct](https://github.com/ocaml/code-of-conduct) and has been discussed in [this thread](https://discuss.ocaml.org/t/ocaml-community-code-of-conduct/10494).

It has been adopted by the OCaml compiler in [ocaml/ocaml#11761](https://github.com/ocaml/ocaml/pull/11761) and many platform tools. After a discussion with maintainers, we propose adopting it for Eio.

cc @talex5 @polytypic @patricoferris.