### PR TITLE
Fix test dependency on kcas

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -28,7 +28,6 @@
   (domain-local-await (>= 0.1.0))
   (crowbar (and (>= 0.2) :with-test))
   (mtime (>= 2.0.0))
-  (kcas (and (>= 0.3.0) :with-test))
   (mdx (and (>= 2.2.0) :with-test))
   (alcotest (and (>= 1.4.0) :with-test))
   (dscheck (and (>= 0.1.0) :with-test))))
@@ -67,6 +66,7 @@
  (description "Selects an appropriate Eio backend for the current platform.")
  (depends
   (mdx (and (>= 2.2.0) :with-test))
+  (kcas (and (>= 0.3.0) :with-test))
   (eio_linux (and (= :version) (= :os "linux")))
   (eio_posix (and (= :version) (<> :os "windows")))
   (eio_windows (and (= :version) (= :os "windows")))))

--- a/eio.opam
+++ b/eio.opam
@@ -21,7 +21,6 @@ depends: [
   "domain-local-await" {>= "0.1.0"}
   "crowbar" {>= "0.2" & with-test}
   "mtime" {>= "2.0.0"}
-  "kcas" {>= "0.3.0" & with-test}
   "mdx" {>= "2.2.0" & with-test}
   "alcotest" {>= "1.4.0" & with-test}
   "dscheck" {>= "0.1.0" & with-test}

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.7"}
   "mdx" {>= "2.2.0" & with-test}
+  "kcas" {>= "0.3.0" & with-test}
   "eio_linux" {= version & os = "linux"}
   "eio_posix" {= version & os != "windows"}
   "eio_windows" {= version & os = "windows"}


### PR DESCRIPTION
The README file is tested by `eio_main`, not `eio`.