### PR TITLE
eio_posix: remove dsync open flag

### DIFF
--- a/lib_eio_posix/include/discover.ml
+++ b/lib_eio_posix/include/discover.ml
@@ -14,7 +14,6 @@ let () =
             "O_CLOEXEC", Int;
             "O_CREAT", Int;
             "O_DIRECTORY", Int;
-            "O_DSYNC", Int;
             "O_EXCL", Int;
             "O_NOCTTY", Int;
             "O_NOFOLLOW", Int;

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -164,7 +164,6 @@ module Open_flags = struct
   let cloexec = Config.o_cloexec
   let creat = Config.o_creat
   let directory = Config.o_directory
-  let dsync = Config.o_dsync
   let excl = Config.o_excl
   let noctty = Config.o_noctty
   let nofollow = Config.o_nofollow

--- a/lib_eio_posix/low_level.mli
+++ b/lib_eio_posix/low_level.mli
@@ -64,7 +64,6 @@ module Open_flags : sig
   val append : t
   val creat : t
   val directory : t
-  val dsync : t
   val excl : t
   val noctty : t
   val nofollow : t


### PR DESCRIPTION
FreeBSD 12 doesn't have `O_DSYNC` (though FreeBSD 13 does) and it doesn't look very useful. https://pubs.opengroup.org/onlinepubs/9699919799/help/codes.html#SIO says: "The functionality described is optional"

Reported by @hannesm.

Closes #502 (untested).