### PR TITLE
Fix eio_unix_is_blocking

### DIFF
--- a/lib_eio/unix/stubs.c
+++ b/lib_eio/unix/stubs.c
@@ -10,5 +10,5 @@ CAMLprim value eio_unix_is_blocking(value v_fd) {
   if (r == -1)
     uerror("fcntl", Nothing);
 
-  return Val_bool(r & O_NONBLOCK == 0);
+  return Val_bool((r & O_NONBLOCK) == 0);
 }


### PR DESCRIPTION
I think the stubs were previously incorrect as the `==` had higher precedence than the `&` so it was always returning `false`, I double checked with a small program:

```ocaml
external eio_is_blocking : Unix.file_descr -> bool = "eio_unix_is_blocking"

let () =
  let r, _ = Unix.pipe () in
  print_endline (string_of_bool @@ eio_is_blocking r);
  Unix.set_nonblock r;
  print_endline (string_of_bool @@ eio_is_blocking r)
```

Which printed `false false`. You can see the apple C compiler complaining about it here: https://github.com/ocaml-multicore/eio/actions/runs/4870762082/jobs/8686910729. 

Afaict old programs using `eio_posix` shouldn't actually be impacted in terms of correctness as this was more of an optimisation to see if we need to wait for an FD to be readable/writeable.