### PR TITLE
eio_posix: probe for existence of some flags

### DIFF
--- a/lib_eio_posix/include/discover.ml
+++ b/lib_eio_posix/include/discover.ml
@@ -1,11 +1,29 @@
 module C = Configurator.V1
 
+let optional_flags = [
+  "O_DSYNC";
+  "O_RESOLVE_BENEATH";
+  "O_PATH";
+]
+
 let () =
   C.main ~name:"discover" (fun c ->
-      let defs =
-        C.C_define.import c ~c_flags:["-D_LARGEFILE64_SOURCE"]
+      let c_flags = ["-D_LARGEFILE64_SOURCE"] in
+      let includes = ["sys/types.h"; "sys/stat.h"; "fcntl.h"] in
+      let extra_flags, missing_defs =
+        C.C_define.import c ~c_flags ~includes
+          C.C_define.Type.(List.map (fun name -> name, Switch) optional_flags)
+        |> List.partition_map (function
+            | name, C.C_define.Value.Switch true -> Left (name, C.C_define.Type.Int)
+            | name, Switch false ->
+              Right (Printf.sprintf "let %s = None" (String.lowercase_ascii name))
+            | _ -> assert false
+          )
+      in
+      let present_defs =
+        C.C_define.import c ~c_flags
           ~includes:["sys/types.h"; "sys/stat.h"; "fcntl.h"]
-          C.C_define.Type.[
+          C.C_define.Type.(extra_flags @ [
             "O_RDONLY", Int;
             "O_RDWR", Int;
             "O_WRONLY", Int;
@@ -14,7 +32,6 @@ let () =
             "O_CLOEXEC", Int;
             "O_CREAT", Int;
             "O_DIRECTORY", Int;
-            "O_DSYNC", Int;
             "O_EXCL", Int;
             "O_NOCTTY", Int;
             "O_NOFOLLOW", Int;
@@ -23,12 +40,15 @@ let () =
             "O_TRUNC", Int;
 
             "AT_FDCWD", Int;
-          ]
+          ])
         |> List.map (function
+            | name, C.C_define.Value.Int v when List.mem name optional_flags ->
+              Printf.sprintf "let %s = Some 0x%x" (String.lowercase_ascii name) v
             | name, C.C_define.Value.Int v ->
               Printf.sprintf "let %s = 0x%x" (String.lowercase_ascii name) v
             | _ -> assert false
           )
       in
+      let defs = present_defs @ missing_defs in
       C.Flags.write_lines "config.ml" defs
     )

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -171,6 +171,8 @@ module Open_flags = struct
   let nonblock = Config.o_nonblock
   let sync = Config.o_sync
   let trunc = Config.o_trunc
+  let resolve_beneath = Config.o_resolve_beneath
+  let path = Config.o_path
 
   let empty = 0
   let ( + ) = ( lor )

--- a/lib_eio_posix/low_level.mli
+++ b/lib_eio_posix/low_level.mli
@@ -64,12 +64,14 @@ module Open_flags : sig
   val append : t
   val creat : t
   val directory : t
-  val dsync : t
+  val dsync : t option
   val excl : t
   val noctty : t
   val nofollow : t
   val sync : t
   val trunc : t
+  val resolve_beneath : t option
+  val path : t option
 
   val empty : t
   val ( + ) : t -> t -> t


### PR DESCRIPTION
FreeBSD 12 didn't have `O_DSYNC`. Also, add `O_RESOLVE_BENEATH` and `O_PATH` if available.

Should fix #502.