### PR TITLE
Deprecation cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1875,4 +1875,4 @@ Some background about the effects system can be found in:
 [kcas]: https://github.com/ocaml-multicore/kcas
 [Meio]: https://github.com/tarides/meio
 [Lambda Capabilities]: https://roscidus.com/blog/blog/2023/04/26/lambda-capabilities/
-[Eio.Process]: https://github.com/ocaml-multicore/eio/blob/main/lib_eio/process.ml
+[Eio.Process]: https://github.com/ocaml-multicore/eio/blob/main/lib_eio/process.mli

--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -235,14 +235,7 @@ module Fiber : sig
       The calling fiber is placed at the head of the run queue, ahead of any previous items. *)
 
   val fork_sub : sw:Switch.t -> on_error:(exn -> unit) -> (Switch.t -> unit) -> unit
-  (** [fork_sub ~sw ~on_error fn] is like [fork], but it creates a new sub-switch for the fiber.
-
-      This means that you can cancel the child switch without cancelling the parent.
-      This is a convenience function for running {!Switch.run} inside a {!fork}.
-
-      @param on_error This is called if the fiber raises an exception.
-                      If it raises in turn, the parent switch is failed.
-                      It is not called if the parent [sw] itself is cancelled. *)
+  [@@deprecated "Use Fiber.fork and Switch.run separately instead"]
 
   val fork_promise : sw:Switch.t -> (unit -> 'a) -> 'a Promise.or_exn
   (** [fork_promise ~sw fn] schedules [fn ()] to run in a new fiber and returns a promise for its result.

--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -330,18 +330,6 @@ module Fiber : sig
         @param max_fibers Maximum number of fibers to run concurrently *)
   end
 
-  val filter : ?max_fibers:int -> ('a -> bool) -> 'a list -> 'a list
-  [@@ocaml.deprecated "Use `Eio.Fiber.List.filter` instead."]
-
-  val map : ?max_fibers:int -> ('a -> 'b) -> 'a list -> 'b list
-  [@@ocaml.deprecated "Use `Eio.Fiber.List.map instead."]
-
-  val filter_map : ?max_fibers:int -> ('a -> 'b option) -> 'a list -> 'b list
-  [@@ocaml.deprecated "Use `Eio.Fiber.List.filter_map instead."]
-
-  val iter : ?max_fibers:int -> ('a -> unit) -> 'a list -> unit
-  [@@ocaml.deprecated "Use `Eio.Fiber.List.iter instead."]
-
   (** {2 Fiber-local variables}
 
       Each fiber maintains a map of additional variables associated with it,

--- a/lib_eio/core/fiber.ml
+++ b/lib_eio/core/fiber.ml
@@ -271,8 +271,6 @@ module List = struct
 
 end
 
-include List
-
 type 'a key = 'a Hmap.key
 
 let create_key () = Hmap.Key.create ()

--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -1,14 +1,11 @@
 include Eio__core
 
-module Fibre = Fiber
-
 module Debug = Private.Debug
 let traceln = Debug.traceln
 
 module Std = struct
   module Promise = Promise
   module Fiber = Fiber
-  module Fibre = Fiber
   module Switch = Switch
   let traceln = Debug.traceln
 end

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -24,10 +24,6 @@ module Promise = Eio__core.Promise
 (** A fiber is a light-weight thread. *)
 module Fiber = Eio__core.Fiber
 
-(**/**)
-module Fibre = Fiber [@@deprecated "Now spelt Fiber"]
-(**/**)
-
 (** A counting semaphore. *)
 module Semaphore = Semaphore
 
@@ -47,9 +43,6 @@ module Cancel = Eio__core.Cancel
 module Std : sig
   module Promise = Promise
   module Fiber = Fiber
-  (**/**)
-  module Fibre = Fiber [@@deprecated "Now spelt Fiber"]
-  (**/**)
   module Switch = Switch
 
   val traceln :

--- a/lib_eio/flow.ml
+++ b/lib_eio/flow.ml
@@ -107,5 +107,3 @@ class virtual two_way = object (_ : <source; sink; ..>)
 end
 
 let shutdown (t : #two_way) = t#shutdown
-
-let read = single_read

--- a/lib_eio/flow.mli
+++ b/lib_eio/flow.mli
@@ -15,9 +15,6 @@ class virtual source : object
   method virtual read_into : Cstruct.t -> int
 end
 
-val read : #source -> Cstruct.t -> int
-[@@deprecated "Use single_read if you really want this."]
-
 val single_read : #source -> Cstruct.t -> int
 (** [single_read src buf] reads one or more bytes into [buf].
 

--- a/lib_eio/fs.ml
+++ b/lib_eio/fs.ml
@@ -1,8 +1,5 @@
 (** Defines types used by file-systems. *)
 
-(** Tranditional Unix permissions. *)
-module Unix_perm = File.Unix_perm [@@deprecated "Moved to File.Unix_perm"]
-
 type path = string
 
 type error =

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -188,9 +188,6 @@ let accept_fork ~sw (t : #listening_socket) ~on_error handle =
          )
     )
 
-let accept_sub ~sw (t : #listening_socket) ~on_error handle =
-  accept_fork ~sw t ~on_error (fun flow addr -> Switch.run (fun sw -> handle ~sw flow addr))
-
 class virtual datagram_socket = object
   inherit socket
   method virtual send : Sockaddr.datagram -> Cstruct.t -> unit

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -211,14 +211,6 @@ val accept_fork :
                     If you don't want to handle connection errors,
                     use [~on_error:raise] to cancel the caller's context. *)
 
-val accept_sub :
-  sw:Switch.t ->
-  #listening_socket ->
-  on_error:(exn -> unit) ->
-  (sw:Switch.t -> stream_socket -> Sockaddr.stream -> unit) ->
-  unit
-[@@deprecated "Use accept_fork instead"]
-
 (** {2 Running Servers} *)
 
 val run_server :

--- a/lib_eio/time.mli
+++ b/lib_eio/time.mli
@@ -56,9 +56,6 @@ val with_timeout_exn : #clock -> float -> (unit -> 'a) -> 'a
 module Timeout : sig
   type t
 
-  val of_s : #clock -> float -> t
-  [@@deprecated "Use [seconds] instead, with a monotonic clock"]
-
   val v : #Mono.t -> Mtime.Span.t -> t
   (** [v clock duration] is a timeout of [duration], as measured by [clock].
       Internally, this is just the tuple [(clock, duration)]. *)

--- a/tests/fiber.md
+++ b/tests/fiber.md
@@ -218,7 +218,7 @@ Exception: Stdlib.Exit.
 Exception: Failure "simulated error".
 ```
 
-# Fiber.fork
+# Fiber.fork_promise
 
 `Fiber.fork_promise ~sw` inherits the cancellation context from `sw`, not from the current fiber:
 


### PR DESCRIPTION
This PR removes all APIs that were all already marked as deprecated in Eio 0.8.

It also makes `Fiber.fork_sub` deprecated. Originally, you needed the parent switch to create the child one, but that happens automatically now, so we don't need a special function for this.