### PR TITLE
Don't run Windows discover script on other platforms

### DIFF
--- a/lib_eio_windows/dune
+++ b/lib_eio_windows/dune
@@ -11,4 +11,5 @@
 
 (rule
  (targets config.ml)
+ (enabled_if (= %{os_type} "Win32"))
  (action (run ./include/discover.exe)))


### PR DESCRIPTION
Otherwise, `dune build` will try to run it and fail.