### PR TITLE
Add Eio_unix.Net module

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,14 +704,13 @@ The `Eio.Io` type is extensible, so libraries can also add additional top-level 
 For example, this HTTP GET function adds the URL to any IO error:
 
 ```ocaml
-# let get ~net ~host ~path =
-    try
-      Eio.Net.with_tcp_connect net ~host ~service:"http" @@ fun _flow ->
-      "..."
-    with Eio.Io _ as ex ->
-      let bt = Printexc.get_raw_backtrace () in
-      Eio.Exn.reraise_with_context ex bt "fetching http://%s/%s" host path;;
-val get : net:#Eio.Net.t -> host:string -> path:string -> string = <fun>
+let get ~net ~host ~path =
+  try
+    Eio.Net.with_tcp_connect net ~host ~service:"http" @@ fun _flow ->
+    "..."
+  with Eio.Io _ as ex ->
+    let bt = Printexc.get_raw_backtrace () in
+    Eio.Exn.reraise_with_context ex bt "fetching http://%s/%s" host path;;
 ```
 
 If we test it using a mock network that returns a timeout,

--- a/lib_eio/mock/net.ml
+++ b/lib_eio/mock/net.ml
@@ -38,7 +38,7 @@ let make label =
 
     method datagram_socket ~reuse_addr:_ ~reuse_port:_ ~sw addr =
       (match addr with
-      | `Udp _ as saddr -> traceln "%s: datagram_socket %a" label Eio.Net.Sockaddr.pp saddr
+      | #Eio.Net.Sockaddr.datagram as saddr -> traceln "%s: datagram_socket %a" label Eio.Net.Sockaddr.pp saddr
       | `UdpV4 -> traceln "%s: datagram_socket UDPv4" label
       | `UdpV6 -> traceln "%s: datagram_socket UDPv6" label
       );

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -143,6 +143,7 @@ module Sockaddr = struct
 
   type datagram = [
     | `Udp of Ipaddr.v4v6 * int
+    | `Unix of string
   ]
 
   type t = [ stream | datagram ]
@@ -158,9 +159,10 @@ end
 
 class virtual socket = object (_ : #Generic.t)
   method probe _ = None
+  method virtual close : unit
 end
 
-class virtual stream_socket = object
+class virtual stream_socket = object (_ : #socket)
   inherit Flow.two_way
 end
 
@@ -193,7 +195,7 @@ let accept_fork ~sw (t : #listening_socket) ~on_error handle =
 
 class virtual datagram_socket = object
   inherit socket
-  method virtual send : Sockaddr.datagram -> Cstruct.t -> unit
+  method virtual send : ?dst:Sockaddr.datagram -> Cstruct.t list -> unit
   method virtual recv : Cstruct.t -> Sockaddr.datagram * int
 end
 

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -91,6 +91,7 @@ module Sockaddr : sig
 
   type datagram = [
     | `Udp of Ipaddr.v4v6 * int
+    | `Unix of string
   ]
   (** Socket addresses that are message-oriented. *)
 
@@ -103,6 +104,7 @@ end
 
 class virtual socket : object
   inherit Generic.t
+  method virtual close : unit
 end
 
 class virtual stream_socket : object
@@ -112,7 +114,7 @@ end
 
 class virtual datagram_socket : object
   inherit socket
-  method virtual send : Sockaddr.datagram -> Cstruct.t -> unit
+  method virtual send : ?dst:Sockaddr.datagram -> Cstruct.t list -> unit
   method virtual recv : Cstruct.t -> Sockaddr.datagram * int
 end
 
@@ -267,9 +269,10 @@ val datagram_socket :
       @param reuse_addr Set the {!Unix.SO_REUSEADDR} socket option.
       @param reuse_port Set the {!Unix.SO_REUSEPORT} socket option. *)
 
-val send : #datagram_socket -> Sockaddr.datagram -> Cstruct.t -> unit
-(** [send sock addr buf] sends the data in [buf] to the address [addr] using the 
-    the datagram socket [sock]. *)
+val send : #datagram_socket -> ?dst:Sockaddr.datagram -> Cstruct.t list -> unit
+(** [send sock buf] sends the data in [buf] using the the datagram socket [sock].
+
+    @param dst If [sock] isn't connected, this provides the destination. *)
 
 val recv : #datagram_socket -> Cstruct.t -> Sockaddr.datagram * int
 (** [recv sock buf] receives data from the socket [sock] putting it in [buf]. The number of bytes received is 

--- a/lib_eio/unix/net.ml
+++ b/lib_eio/unix/net.ml
@@ -1,0 +1,69 @@
+open Eio.Std
+
+module Ipaddr = struct
+  let to_unix : _ Eio.Net.Ipaddr.t -> Unix.inet_addr = Obj.magic
+  let of_unix : Unix.inet_addr -> _ Eio.Net.Ipaddr.t = Obj.magic
+end
+
+let sockaddr_to_unix = function
+  | `Unix path -> Unix.ADDR_UNIX path
+  | `Tcp (host, port) | `Udp (host, port) ->
+    let host = Ipaddr.to_unix host in
+    Unix.ADDR_INET (host, port)
+
+let sockaddr_of_unix_stream = function
+  | Unix.ADDR_UNIX path -> `Unix path
+  | Unix.ADDR_INET (host, port) ->
+    let host = Ipaddr.of_unix host in
+    `Tcp (host, port)
+
+let sockaddr_of_unix_datagram = function
+  | Unix.ADDR_UNIX path -> `Unix path
+  | Unix.ADDR_INET (host, port) ->
+    let host = Ipaddr.of_unix host in
+    `Udp (host, port)
+
+class virtual stream_socket = object (_ : <Resource.t; ..>)
+  inherit Eio.Net.stream_socket
+end
+
+class virtual datagram_socket = object (_ : <Resource.t; ..>)
+  inherit Eio.Net.datagram_socket
+end
+
+let getnameinfo (sockaddr : Eio.Net.Sockaddr.t) =
+  let options =
+    match sockaddr with
+    | `Unix _ | `Tcp _ -> []
+    | `Udp _ -> [Unix.NI_DGRAM]
+  in
+  let sockaddr = sockaddr_to_unix sockaddr in
+  Private.run_in_systhread (fun () ->
+    let Unix.{ni_hostname; ni_service} = Unix.getnameinfo sockaddr options in
+    (ni_hostname, ni_service))
+
+class virtual t = object
+  inherit Eio.Net.t
+
+  method getnameinfo = getnameinfo
+end
+
+[@@@alert "-unstable"]
+
+type _ Effect.t +=
+  | Import_socket_stream : Switch.t * bool * Unix.file_descr -> stream_socket Effect.t
+  | Import_socket_datagram : Switch.t * bool * Unix.file_descr -> datagram_socket Effect.t
+  | Socketpair_stream : Switch.t * Unix.socket_domain * int ->
+      (stream_socket * stream_socket) Effect.t
+  | Socketpair_datagram : Switch.t * Unix.socket_domain * int ->
+      (datagram_socket * datagram_socket) Effect.t
+
+let import_socket_stream ~sw ~close_unix fd = Effect.perform (Import_socket_stream (sw, close_unix, fd))
+
+let import_socket_datagram ~sw ~close_unix fd = Effect.perform (Import_socket_datagram (sw, close_unix, fd))
+
+let socketpair_stream ~sw ?(domain=Unix.PF_UNIX) ?(protocol=0) () =
+  Effect.perform (Socketpair_stream (sw, domain, protocol))
+
+let socketpair_datagram ~sw ?(domain=Unix.PF_UNIX) ?(protocol=0) () =
+  Effect.perform (Socketpair_datagram (sw, domain, protocol))

--- a/lib_eio/unix/net.mli
+++ b/lib_eio/unix/net.mli
@@ -1,0 +1,93 @@
+open Eio.Std
+
+(** {2 Types}
+
+    These extend the types in {!Eio.Net} with support for file descriptors. *)
+
+class virtual stream_socket : object (<Resource.t; ..>)
+  inherit Eio.Net.stream_socket
+end
+
+class virtual datagram_socket : object (<Resource.t; ..>)
+  inherit Eio.Net.datagram_socket
+end
+
+class virtual t : object
+  inherit Eio.Net.t
+
+  method getnameinfo : Eio.Net.Sockaddr.t -> (string * string)
+end
+
+(** {2 Unix address conversions}
+
+    Note: OCaml's {!Unix.sockaddr} type considers e.g. TCP port 80 and UDP port
+    80 to be the same thing, whereas Eio regards them as separate addresses
+    that just happen to have the same representation (a host address and a port
+    number), so we have separate "of_unix" functions for each. *)
+
+val sockaddr_to_unix : [< Eio.Net.Sockaddr.stream | Eio.Net.Sockaddr.datagram] -> Unix.sockaddr
+val sockaddr_of_unix_stream : Unix.sockaddr -> Eio.Net.Sockaddr.stream
+val sockaddr_of_unix_datagram : Unix.sockaddr -> Eio.Net.Sockaddr.datagram
+
+(** Convert between Eio.Net.Ipaddr and Unix.inet_addr. *)
+module Ipaddr : sig
+  (** Internally, these are actually the same type, so these are just casts. *)
+
+  val to_unix : [< `V4 | `V6] Eio.Net.Ipaddr.t -> Unix.inet_addr
+  val of_unix : Unix.inet_addr -> Eio.Net.Ipaddr.v4v6
+end
+
+(** {2 Creating or importing sockets} *)
+
+val import_socket_stream : sw:Switch.t -> close_unix:bool -> Unix.file_descr -> stream_socket
+(** [import_socket_stream ~sw ~close_unix:true fd] is an Eio flow that uses [fd].
+
+    It can be cast to e.g. {!source} for a one-way flow.
+    The socket object will be closed when [sw] finishes.
+
+    The [close_unix] and [sw] arguments are passed to {!Fd.of_unix}. *)
+
+val import_socket_datagram : sw:Switch.t -> close_unix:bool -> Unix.file_descr -> datagram_socket
+(** [import_socket_datagram ~sw ~close_unix:true fd] is an Eio datagram socket that uses [fd].
+
+    The socket object will be closed when [sw] finishes.
+
+    The [close_unix] and [sw] arguments are passed to {!Fd.of_unix}. *)
+
+val socketpair_stream :
+  sw:Switch.t ->
+  ?domain:Unix.socket_domain ->
+  ?protocol:int ->
+  unit ->
+  stream_socket * stream_socket
+(** [socketpair_stream ~sw ()] returns a connected pair of flows, such that writes to one can be read by the other.
+
+    This creates OS-level resources using [socketpair(2)].
+    Note that, like all FDs created by Eio, they are both marked as close-on-exec by default. *)
+
+val socketpair_datagram :
+  sw:Switch.t ->
+  ?domain:Unix.socket_domain ->
+  ?protocol:int ->
+  unit ->
+  datagram_socket * datagram_socket
+(** [socketpair_datagram ~sw ()] returns a connected pair of flows, such that writes to one can be read by the other.
+
+    This creates OS-level resources using [socketpair(2)].
+    Note that, like all FDs created by Eio, they are both marked as close-on-exec by default. *)
+
+(** {2 Private API for backends} *)
+
+val getnameinfo : Eio.Net.Sockaddr.t -> (string * string)
+(** [getnameinfo sockaddr] returns domain name and service for [sockaddr]. *)
+
+type _ Effect.t +=
+  | Import_socket_stream :
+      Switch.t * bool * Unix.file_descr -> stream_socket Effect.t       (** See {!import_socket_stream} *)
+  | Import_socket_datagram :
+      Switch.t * bool * Unix.file_descr -> datagram_socket Effect.t     (** See {!import_socket_datagram} *)
+  | Socketpair_stream : Eio.Switch.t * Unix.socket_domain * int ->
+      (stream_socket * stream_socket) Effect.t                    (** See {!socketpair_stream} *)
+  | Socketpair_datagram : Eio.Switch.t * Unix.socket_domain * int ->
+      (datagram_socket * datagram_socket) Effect.t                (** See {!socketpair_datagram} *)
+[@@alert "-unstable"]

--- a/lib_eio/unix/private.ml
+++ b/lib_eio/unix/private.ml
@@ -7,8 +7,6 @@ type _ Effect.t +=
   | Await_readable : Unix.file_descr -> unit Effect.t
   | Await_writable : Unix.file_descr -> unit Effect.t
   | Get_monotonic_clock : Eio.Time.Mono.t Effect.t
-  | Socket_of_fd : Switch.t * bool * Unix.file_descr -> socket Effect.t
-  | Socketpair : Switch.t * Unix.socket_domain * Unix.socket_type * int -> (socket * socket) Effect.t
   | Pipe : Switch.t -> (source * sink) Effect.t
 
 let await_readable fd = Effect.perform (Await_readable fd)
@@ -18,3 +16,13 @@ let pipe sw = Effect.perform (Pipe sw)
 
 module Rcfd = Rcfd
 module Fork_action = Fork_action
+
+let run_in_systhread fn =
+  let f fiber enqueue =
+    match Eio.Private.Fiber_context.get_error fiber with
+    | Some err -> enqueue (Error err)
+    | None ->
+      let _t : Thread.t = Thread.create (fun () -> enqueue (try Ok (fn ()) with exn -> Error exn)) () in
+      ()
+  in
+  Effect.perform (Eio.Private.Effects.Suspend f)

--- a/lib_eio/unix/types.ml
+++ b/lib_eio/unix/types.ml
@@ -1,3 +1,2 @@
 type source = < Eio.Flow.source;  Resource.t; Eio.Flow.close >
 type sink   = < Eio.Flow.sink;    Resource.t; Eio.Flow.close >
-type socket = < Eio.Flow.two_way; Resource.t; Eio.Flow.close >

--- a/lib_eio_linux/eio_linux.mli
+++ b/lib_eio_linux/eio_linux.mli
@@ -199,7 +199,7 @@ module Low_level : sig
   val shutdown : fd -> Unix.shutdown_command -> unit
   (** Like {!Unix.shutdown}. *)
 
-  val send_msg : fd -> ?fds:fd list -> ?dst:Unix.sockaddr -> Cstruct.t list -> unit
+  val send_msg : fd -> ?fds:fd list -> ?dst:Unix.sockaddr -> Cstruct.t list -> int
   (** [send_msg socket bufs] is like [writev socket bufs], but also allows setting the destination address
       (for unconnected sockets) and attaching FDs (for Unix-domain sockets). *)
 

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -243,7 +243,7 @@ let send_msg fd ?(fds=[]) ?dst buf =
   let res = Sched.enter (enqueue_send_msg fd ~fds ~dst buf) in
   if res < 0 then (
     raise @@ Err.wrap (Uring.error_of_errno res) "send_msg" ""
-  )
+  ) else res
 
 let recv_msg fd buf =
   Fd.use_exn "recv_msg" fd @@ fun fd ->
@@ -428,8 +428,8 @@ let getaddrinfo ~service node =
       (Unix.SOCK_STREAM | SOCK_DGRAM),
       Unix.ADDR_INET (inet_addr,port) -> (
         match ai_protocol with
-        | 6 -> Some (`Tcp (Eio_unix.Ipaddr.of_unix inet_addr, port))
-        | 17 -> Some (`Udp (Eio_unix.Ipaddr.of_unix inet_addr, port))
+        | 6 -> Some (`Tcp (Eio_unix.Net.Ipaddr.of_unix inet_addr, port))
+        | 17 -> Some (`Udp (Eio_unix.Net.Ipaddr.of_unix inet_addr, port))
         | _ -> None)
     | _ -> None
   in

--- a/lib_eio_linux/tests/fd_passing.md
+++ b/lib_eio_linux/tests/fd_passing.md
@@ -21,7 +21,10 @@ Sending a file descriptor over a Unix domain socket:
   let r = Eio_unix.Fd.of_unix ~sw ~seekable:false ~close_unix:true r in
   let w = Eio_unix.Fd.of_unix ~sw ~seekable:false ~close_unix:true w in
   Fiber.both
-    (fun () -> Eio_linux.Low_level.send_msg w [Cstruct.of_string "x"] ~fds:[Eio_unix.Resource.fd_opt fd |> Option.get])
+    (fun () ->
+       let sent = Eio_linux.Low_level.send_msg w [Cstruct.of_string "x"] ~fds:[Eio_unix.Resource.fd_opt fd |> Option.get] in
+       assert (sent = 1)
+    )
     (fun () ->
        let buf = Cstruct.of_string "?" in
        let addr, got, fds = Eio_linux.Low_level.recv_msg_with_fds ~sw r ~max_fds:10 [buf] in

--- a/lib_eio_posix/domain_mgr.ml
+++ b/lib_eio_posix/domain_mgr.ml
@@ -20,6 +20,20 @@ open Eio.Std
 
 module Fd = Eio_unix.Fd
 
+let socketpair k ~sw ~domain ~ty ~protocol ~wrap =
+  let open Effect.Deep in
+  match
+    let unix_a, unix_b = Unix.socketpair ~cloexec:true domain ty protocol in
+    let a = Fd.of_unix ~sw ~blocking:false ~close_unix:true unix_a in
+    let b = Fd.of_unix ~sw ~blocking:false ~close_unix:true unix_b in
+    Unix.set_nonblock unix_a;
+    Unix.set_nonblock unix_b;
+    (wrap a, wrap b)
+  with
+  | r -> continue k r
+  | exception Unix.Unix_error (code, name, arg) ->
+    discontinue k (Err.wrap code name arg)
+
 (* Run an event loop in the current domain, using [fn x] as the root fiber. *)
 let run_event_loop fn x =
   Sched.with_sched @@ fun sched ->
@@ -28,23 +42,23 @@ let run_event_loop fn x =
     effc = fun (type a) (e : a Effect.t) : ((a, Sched.exit) continuation -> Sched.exit) option ->
       match e with
       | Eio_unix.Private.Get_monotonic_clock -> Some (fun k -> continue k (Time.mono_clock : Eio.Time.Mono.t))
-      | Eio_unix.Private.Socket_of_fd (sw, close_unix, unix_fd) -> Some (fun k ->
+      | Eio_unix.Net.Import_socket_stream (sw, close_unix, unix_fd) -> Some (fun k ->
           let fd = Fd.of_unix ~sw ~blocking:false ~close_unix unix_fd in
           Unix.set_nonblock unix_fd;
-          continue k (Flow.of_fd fd :> Eio_unix.socket)
+          continue k (Flow.of_fd fd :> Eio_unix.Net.stream_socket)
         )
-      | Eio_unix.Private.Socketpair (sw, domain, ty, protocol) -> Some (fun k ->
-          match
-            let unix_a, unix_b = Unix.socketpair ~cloexec:true domain ty protocol in
-            let a = Fd.of_unix ~sw ~blocking:false ~close_unix:true unix_a in
-            let b = Fd.of_unix ~sw ~blocking:false ~close_unix:true unix_b in
-            Unix.set_nonblock unix_a;
-            Unix.set_nonblock unix_b;
-            (Flow.of_fd a :> Eio_unix.socket), (Flow.of_fd b :> Eio_unix.socket)
-          with
-          | r -> continue k r
-          | exception Unix.Unix_error (code, name, arg) ->
-              discontinue k (Err.wrap code name arg)
+      | Eio_unix.Net.Import_socket_datagram (sw, close_unix, unix_fd) -> Some (fun k ->
+          let fd = Fd.of_unix ~sw ~blocking:false ~close_unix unix_fd in
+          Unix.set_nonblock unix_fd;
+          continue k (Net.datagram_socket fd)
+        )
+      | Eio_unix.Net.Socketpair_stream (sw, domain, protocol) -> Some (fun k ->
+          socketpair k ~sw ~domain ~protocol ~ty:Unix.SOCK_STREAM
+            ~wrap:(fun fd -> (Flow.of_fd fd :> Eio_unix.Net.stream_socket))
+        )
+      | Eio_unix.Net.Socketpair_datagram (sw, domain, protocol) -> Some (fun k ->
+          socketpair k ~sw ~domain ~protocol ~ty:Unix.SOCK_DGRAM
+            ~wrap:(fun fd -> Net.datagram_socket fd)
         )
       | Eio_unix.Private.Pipe sw -> Some (fun k ->
           match

--- a/lib_eio_posix/flow.ml
+++ b/lib_eio_posix/flow.ml
@@ -63,7 +63,7 @@ let shutdown fd cmd =
     | `All -> Unix.SHUTDOWN_ALL
   with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
 
-let of_fd fd = object (_ : <Eio_unix.socket; Eio.File.rw>)
+let of_fd fd = object (_ : <Eio_unix.Net.stream_socket; Eio.File.rw>)
   method fd = fd
 
   method read_methods = []

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -79,13 +79,16 @@ let accept ~sw sock =
 let shutdown sock cmd =
   Fd.use_exn "shutdown" sock (fun fd -> Unix.shutdown fd cmd)
 
-let send_msg fd ~dst buf =
+external eio_send_msg : Unix.file_descr -> Unix.sockaddr option -> Cstruct.t array -> int = "caml_eio_posix_send_msg"
+external eio_recv_msg : Unix.file_descr -> Cstruct.t array -> Unix.sockaddr * int = "caml_eio_posix_recv_msg"
+
+let send_msg fd ?dst buf =
   Fd.use_exn "send_msg" fd @@ fun fd ->
-  do_nonblocking Write (fun fd -> Unix.sendto fd buf 0 (Bytes.length buf) [] dst) fd
+  do_nonblocking Write (fun fd -> eio_send_msg fd dst buf) fd
 
 let recv_msg fd buf =
   Fd.use_exn "recv_msg" fd @@ fun fd ->
-  do_nonblocking Read (fun fd -> Unix.recvfrom fd buf 0 (Bytes.length buf) []) fd
+  do_nonblocking Read (fun fd -> eio_recv_msg fd buf) fd
 
 external eio_getrandom : Cstruct.buffer -> int -> int -> int = "caml_eio_posix_getrandom"
 

--- a/lib_eio_posix/low_level.mli
+++ b/lib_eio_posix/low_level.mli
@@ -31,8 +31,8 @@ val accept : sw:Switch.t -> fd -> fd * Unix.sockaddr
 
 val shutdown : fd -> Unix.shutdown_command -> unit
 
-val recv_msg : fd -> bytes -> int * Unix.sockaddr
-val send_msg : fd -> dst:Unix.sockaddr -> bytes -> int
+val recv_msg : fd -> Cstruct.t array -> Unix.sockaddr * int
+val send_msg : fd -> ?dst:Unix.sockaddr -> Cstruct.t array -> int
 
 val getrandom : Cstruct.t -> unit
 

--- a/lib_eio_windows/flow.ml
+++ b/lib_eio_windows/flow.ml
@@ -57,7 +57,7 @@ let shutdown fd cmd =
     | `All -> Unix.SHUTDOWN_ALL
   with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
 
-let of_fd fd = object (_ : <Eio_unix.socket; Eio.File.rw>)
+let of_fd fd = object (_ : <Eio_unix.Net.stream_socket; Eio.File.rw>)
   method fd = fd
 
   method read_methods = []

--- a/lib_eio_windows/low_level.ml
+++ b/lib_eio_windows/low_level.ml
@@ -82,9 +82,13 @@ let accept ~sw sock =
 let shutdown sock cmd =
   Fd.use_exn "shutdown" sock (fun fd -> Unix.shutdown fd cmd)
 
-let send_msg fd ~dst buf =
+let send_msg fd ?dst buf =
   Fd.use_exn "send_msg" fd @@ fun fd ->
-  do_nonblocking Write (fun fd -> Unix.sendto fd buf 0 (Bytes.length buf) [] dst) fd
+  do_nonblocking Write (fun fd ->
+      match dst with
+      | Some dst -> Unix.sendto fd buf 0 (Bytes.length buf) [] dst
+      | None -> Unix.send fd buf 0 (Bytes.length buf) []
+    ) fd
 
 let recv_msg fd buf =
   Fd.use_exn "recv_msg" fd @@ fun fd ->

--- a/lib_eio_windows/low_level.mli
+++ b/lib_eio_windows/low_level.mli
@@ -30,7 +30,7 @@ val accept : sw:Switch.t -> fd -> fd * Unix.sockaddr
 val shutdown : fd -> Unix.shutdown_command -> unit
 
 val recv_msg : fd -> bytes -> int * Unix.sockaddr
-val send_msg : fd -> dst:Unix.sockaddr -> bytes -> int
+val send_msg : fd -> ?dst:Unix.sockaddr -> bytes -> int
 
 val getrandom : Cstruct.t -> unit
 

--- a/lib_eio_windows/net.ml
+++ b/lib_eio_windows/net.ml
@@ -23,9 +23,9 @@ let listening_socket ~hook fd = object
     let client, client_addr = Err.run (Low_level.accept ~sw) fd in
     let client_addr = match client_addr with
       | Unix.ADDR_UNIX path         -> `Unix path
-      | Unix.ADDR_INET (host, port) -> `Tcp (Eio_unix.Ipaddr.of_unix host, port)
+      | Unix.ADDR_INET (host, port) -> `Tcp (Eio_unix.Net.Ipaddr.of_unix host, port)
     in
-    let flow = (Flow.of_fd client :> <Eio.Flow.two_way; Eio.Flow.close>) in
+    let flow = (Flow.of_fd client :> Eio.Net.stream_socket) in
     flow, client_addr
 
   method! probe : type a. a Eio.Generic.ty -> a option = function
@@ -34,29 +34,23 @@ let listening_socket ~hook fd = object
 end
 
 (* todo: would be nice to avoid copying between bytes and cstructs here *)
-let udp_socket sock = object
-  inherit Eio.Net.datagram_socket
+let datagram_socket sock = object
+  inherit Eio_unix.Net.datagram_socket
 
   method close = Fd.close sock
 
-  method send sockaddr buf =
-    let addr = match sockaddr with
-      | `Udp (host, port) ->
-        let host = Eio_unix.Ipaddr.to_unix host in
-        Unix.ADDR_INET (host, port)
-    in
-    let sent = Err.run (Low_level.send_msg sock ~dst:addr) (Cstruct.to_bytes buf) in
-    assert (sent = Cstruct.length buf)
+  method fd = sock
+
+  method send ?dst buf =
+    let dst = Option.map Eio_unix.Net.sockaddr_to_unix dst in
+    let sent = Err.run (Low_level.send_msg sock ?dst) (Bytes.unsafe_of_string (Cstruct.copyv buf)) in
+    assert (sent = Cstruct.lenv buf)
 
   method recv buf =
     let b = Bytes.create (Cstruct.length buf) in
     let recv, addr = Err.run (Low_level.recv_msg sock) b in
     Cstruct.blit_from_bytes b 0 buf 0 recv;
-    match addr with
-    | Unix.ADDR_INET (inet, port) ->
-      `Udp (Eio_unix.Ipaddr.of_unix inet, port), recv
-    | Unix.ADDR_UNIX _ ->
-      raise (Failure "Expected INET UDP socket address but got Unix domain socket address.")
+    Eio_unix.Net.sockaddr_of_unix_datagram addr, recv
 end
 
 (* https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml *)
@@ -67,8 +61,8 @@ let getaddrinfo ~service node =
       (Unix.SOCK_STREAM | SOCK_DGRAM),
       Unix.ADDR_INET (inet_addr,port) -> (
         match ai_protocol with
-        | 6 -> Some (`Tcp (Eio_unix.Ipaddr.of_unix inet_addr, port))
-        | 17 -> Some (`Udp (Eio_unix.Ipaddr.of_unix inet_addr, port))
+        | 6 -> Some (`Tcp (Eio_unix.Net.Ipaddr.of_unix inet_addr, port))
+        | 17 -> Some (`Udp (Eio_unix.Net.Ipaddr.of_unix inet_addr, port))
         | _ -> None)
     | _ -> None
   in
@@ -94,7 +88,7 @@ let listen ~reuse_addr ~reuse_port ~backlog ~sw (listen_addr : Eio.Net.Sockaddr.
       );
       Unix.SOCK_STREAM, Unix.ADDR_UNIX path, true
     | `Tcp (host, port)  ->
-      let host = Eio_unix.Ipaddr.to_unix host in
+      let host = Eio_unix.Net.Ipaddr.to_unix host in
       Unix.SOCK_STREAM, Unix.ADDR_INET (host, port), false
   in
   let sock = Low_level.socket ~sw (socket_domain_of listen_addr) socket_type 0 in
@@ -123,21 +117,20 @@ let connect ~sw connect_addr =
     match connect_addr with
     | `Unix path         -> Unix.SOCK_STREAM, Unix.ADDR_UNIX path
     | `Tcp (host, port)  ->
-      let host = Eio_unix.Ipaddr.to_unix host in
+      let host = Eio_unix.Net.Ipaddr.to_unix host in
       Unix.SOCK_STREAM, Unix.ADDR_INET (host, port)
   in
   let sock = Low_level.socket ~sw (socket_domain_of connect_addr) socket_type 0 in
   try
     Low_level.connect sock addr;
-    (Flow.of_fd sock :> <Eio.Flow.two_way; Eio.Flow.close>)
+    (Flow.of_fd sock :> Eio.Net.stream_socket)
   with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
 
-let datagram_socket ~reuse_addr ~reuse_port ~sw saddr =
+let create_datagram_socket ~reuse_addr ~reuse_port ~sw saddr =
   let sock = Low_level.socket ~sw (socket_domain_of saddr) Unix.SOCK_DGRAM 0 in
   begin match saddr with
-    | `Udp (host, port) ->
-      let host = Eio_unix.Ipaddr.to_unix host in
-      let addr = Unix.ADDR_INET (host, port) in
+    | `Udp _ | `Unix _ as saddr ->
+      let addr = Eio_unix.Net.sockaddr_to_unix saddr in
       Fd.use_exn "datagram_socket" sock (fun fd ->
           if reuse_addr then
             Unix.setsockopt fd Unix.SO_REUSEADDR true;
@@ -147,14 +140,13 @@ let datagram_socket ~reuse_addr ~reuse_port ~sw saddr =
         )
     | `UdpV4 | `UdpV6 -> ()
   end;
-  udp_socket sock
+  (datagram_socket sock :> Eio.Net.datagram_socket)
 
 let v = object
-  inherit Eio.Net.t
+  inherit Eio_unix.Net.t
 
   method listen = listen
   method connect = connect
-  method datagram_socket = datagram_socket
+  method datagram_socket = create_datagram_socket
   method getaddrinfo = getaddrinfo
-  method getnameinfo = Eio_unix.getnameinfo
 end

--- a/lib_eio_windows/test/test_net.ml
+++ b/lib_eio_windows/test/test_net.ml
@@ -53,7 +53,7 @@ let run_dgram addr ~net sw msg =
     (fun () ->
       let e = Eio.Net.datagram_socket ~sw net e1 in
       traceln "Sending data from %a to %a" Eio.Net.Sockaddr.pp e1 Eio.Net.Sockaddr.pp e2;
-      Eio.Net.send e e2 (Cstruct.of_string msg))
+      Eio.Net.send e ~dst:e2 [Cstruct.of_string msg])
 
 let test_udp env addr () =
   Eio.Switch.run @@ fun sw ->
@@ -85,8 +85,8 @@ let test_wrap_socket pipe_or_socketpair () =
     | `Pipe -> Unix.pipe ()
     | `Socketpair -> Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0
   in
-  let source = (Eio_unix.import_socket_stream ~sw ~close_unix:true r :> Eio.Flow.source) in
-  let sink = (Eio_unix.import_socket_stream ~sw ~close_unix:true w :> Eio.Flow.sink) in
+  let source = (Eio_unix.Net.import_socket_stream ~sw ~close_unix:true r :> Eio.Flow.source) in
+  let sink = (Eio_unix.Net.import_socket_stream ~sw ~close_unix:true w :> Eio.Flow.sink) in
   let msg = "Hello" in
   Fiber.both
     (fun () -> Eio.Flow.copy_string (msg ^ "\n") sink)


### PR DESCRIPTION
- Add `Eio_unix.Net` module and move network-related items from `Eio_unix` to there.
- Replace `Eio_unix.socketpair` with `Eio_unix.Net.socketpair_{stream,datagram}`. Previously, it took a type argument (stream or datagram), but always returned a `stream_socket`.
- Move sockaddr conversions to `eio.unix` so they can be shared.
- Implement `getnameinfo` in `eio.unix` to share it by default.
- `Eio_linux.Low_level.send_msg` no longer throws away the number of bytes sent.
- Add `close` to all socket types.
- The destination in `send` is now optional, for unconnected datagram sockets.
- `send` now takes a iovec, not just a single buffer. The stream API allows this and we tested it for datagrams using that API due to the previous type confusion.
- Add `Unix_datagram` socket address type for completeness.
- Add `send_msg` and `recv_msg` stubs to Eio_posix. This avoids converting to bytes, and will be useful to add FD passing later.

I was planning to include FD passing in this FD, but it got too long so I've split that out for later.

Fixes #342.