### PR TITLE
Eio.Process.pp_status should be polymorphic

### DIFF
--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -18,7 +18,7 @@ type status = [
   | `Stopped of int     (** Process was stopped (paused) by the given signal. *)
 ]
 
-val pp_status : status Fmt.t
+val pp_status : [< status] Fmt.t
 
 type error =
   | Executable_not_found of string      (** The requested executable does not exist. *)


### PR DESCRIPTION
Otherwise, you can't print an exit status.