### PR TITLE
Add stress test for spawning processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all bench
+.PHONY: all bench stress
 
 all:
 	dune build @runtest @all
@@ -23,6 +23,10 @@ dscheck:
 	dune exec -- ./lib_eio/tests/dscheck/test_sync.exe
 	dune exec -- ./lib_eio/tests/dscheck/test_semaphore.exe
 	dune exec -- ./lib_eio/tests/dscheck/test_cells.exe
+
+stress:
+	dune exec -- ./stress/stress_proc.exe
+	dune exec -- ./stress/stress_semaphore.exe
 
 docker:
 	docker build -t eio .

--- a/stress/dune
+++ b/stress/dune
@@ -1,3 +1,3 @@
 (executables
-  (names stress_semaphore)
+  (names stress_semaphore stress_proc)
   (libraries eio_main))

--- a/stress/stress_proc.ml
+++ b/stress/stress_proc.ml
@@ -1,0 +1,26 @@
+open Eio.Std
+
+let n_rounds = 100
+let n_procs_per_round = 100
+
+let main mgr =
+  let echo n = Eio.Process.parse_out mgr Eio.Buf_read.line ["sh"; "-c"; "echo " ^ string_of_int n] in
+  let t0 = Unix.gettimeofday () in
+  for i = 1 to n_rounds do
+    Switch.run @@ fun sw ->
+    for j = 1 to n_procs_per_round do
+      Fiber.fork ~sw (fun () ->
+          let result = echo j in
+          assert (int_of_string result = j);
+          (* traceln "OK: %d" j *)
+        )
+    done;
+    if false then traceln "Finished round %d/%d" i n_rounds
+  done;
+  let t1 = Unix.gettimeofday () in
+  let n_procs = n_rounds * n_procs_per_round in
+  traceln "Finished process stress test: ran %d processes in %.2fs" n_procs (t1 -. t0)
+
+let () =
+  Eio_main.run @@ fun env ->
+  main env#process_mgr


### PR DESCRIPTION
This spawns 10,000 subprocesses (100 at a time) running `sh -c 'echo N'` and checks they each give the correct output.

Interestingly, the eio_posix backend is slightly faster than eio_linux:

```
$ EIO_BACKEND=posix dune exec -- ./stress/stress_proc.exe
+Finished process stress test: ran 10000 processes in 2.75s

$ EIO_BACKEND=linux dune exec -- ./stress/stress_proc.exe
+Finished process stress test: ran 10000 processes in 3.31s
```

Someone might like to run that under magic-trace and find out why, as part of #450.