### PR TITLE
Don't call `accept_fork`'s error handler on cancellation

### DIFF
--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -182,6 +182,9 @@ let accept_fork ~sw (t : #listening_socket) ~on_error handle =
        Fiber.fork ~sw (fun () ->
            match child_started := true; handle (flow :> stream_socket) addr with
            | x -> Flow.close flow; x
+           | exception (Cancel.Cancelled _ as ex) ->
+             Flow.close flow;
+             raise ex
            | exception ex ->
              Flow.close flow;
              on_error (Exn.add_context ex "handling connection from %a" Sockaddr.pp addr)

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -208,8 +208,12 @@ val accept_fork :
     @param on_error Called if [connection_handler] raises an exception.
                     This is typically a good place to log the error and continue.
                     If the exception is an {!Eio.Io} error then the caller's address is added to it.
+
                     If you don't want to handle connection errors,
-                    use [~on_error:raise] to cancel the caller's context. *)
+                    use [~on_error:raise] to cancel the caller's context.
+
+                    [on_error] is not called for {!Cancel.Cancelled} exceptions,
+                    which do not need to be reported. *)
 
 (** {2 Running Servers} *)
 


### PR DESCRIPTION
This typically happens when the server is shutting down and wants to stop all connection handlers. There is no need to have each connection fiber log this; they just need to stop.