### PR TITLE
eio_windows: use Eio_unix.Stdenv.base type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
           opam install ocamlfind.1.9.5 kcas alcotest mdx crowbar -y
           opam install eio eio_windows --deps-only
       - run: opam exec -- dune runtest
+      - run: opam exec -- dune exec -- ./examples/net/main.exe
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/lib_eio_windows/eio_windows.ml
+++ b/lib_eio_windows/eio_windows.ml
@@ -16,24 +16,12 @@
 
 module Low_level = Low_level
 
-type stdenv = <
-  stdin  : <Eio.Flow.source; Eio_unix.Resource.t>;
-  stdout : <Eio.Flow.sink; Eio_unix.Resource.t>;
-  stderr : <Eio.Flow.sink; Eio_unix.Resource.t>;
-  net : Eio.Net.t;
-  domain_mgr : Eio.Domain_manager.t;
-  clock : Eio.Time.clock;
-  mono_clock : Eio.Time.Mono.t;
-  fs : Eio.Fs.dir Eio.Path.t;
-  cwd : Eio.Fs.dir Eio.Path.t;
-  secure_random : Eio.Flow.source;
-  debug : Eio.Debug.t;
->
+type stdenv = Eio_unix.Stdenv.base
 
 let run main =
-  let stdin = (Flow.of_fd Eio_unix.Fd.stdin :> <Eio.Flow.source; Eio_unix.Resource.t>) in
-  let stdout = (Flow.of_fd Eio_unix.Fd.stdout :> <Eio.Flow.sink; Eio_unix.Resource.t>) in
-  let stderr = (Flow.of_fd Eio_unix.Fd.stderr :> <Eio.Flow.sink; Eio_unix.Resource.t>) in
+  let stdin = (Flow.of_fd Eio_unix.Fd.stdin :> Eio_unix.source) in
+  let stdout = (Flow.of_fd Eio_unix.Fd.stdout :> Eio_unix.sink) in
+  let stderr = (Flow.of_fd Eio_unix.Fd.stderr :> Eio_unix.sink) in
   Domain_mgr.run_event_loop main @@ object (_ : stdenv)
     method stdin = stdin
     method stdout = stdout
@@ -45,5 +33,6 @@ let run main =
     method domain_mgr = Domain_mgr.v
     method cwd = failwith "file-system operations not supported on Windows yet"
     method fs = failwith "file-system operations not supported on Windows yet"
+    method process_mgr = failwith "process operations not supported on Windows yet"
     method secure_random = Flow.secure_random
   end

--- a/lib_eio_windows/eio_windows.mli
+++ b/lib_eio_windows/eio_windows.mli
@@ -1,19 +1,7 @@
 (** Fallback Eio backend for Windows using OCaml's [Unix.select]. *)
 
-type stdenv = <
-  stdin  : <Eio.Flow.source; Eio_unix.Resource.t>;
-  stdout : <Eio.Flow.sink; Eio_unix.Resource.t>;
-  stderr : <Eio.Flow.sink; Eio_unix.Resource.t>;
-  net : Eio.Net.t;
-  domain_mgr : Eio.Domain_manager.t;
-  clock : Eio.Time.clock;
-  mono_clock : Eio.Time.Mono.t;
-  fs : Eio.Fs.dir Eio.Path.t;
-  cwd : Eio.Fs.dir Eio.Path.t;
-  secure_random : Eio.Flow.source;
-  debug : Eio.Debug.t;
->
-(** An extended version of {!Eio.Stdenv.t} with some extra features available on Windows. *)
+type stdenv = Eio_unix.Stdenv.base
+(** An extended version of {!Eio.Stdenv.base} with some extra features available on Windows. *)
 
 val run : (stdenv -> 'a) -> 'a
 (** [run main] runs an event loop and calls [main stdenv] inside it.


### PR DESCRIPTION
Otherwise, it can't be used with `Eio_main.run`.

Also, get CI to test an example using `Eio_main`.