### PR TITLE
Fix MDX tests on OCaml 5.1

### DIFF
--- a/tests/stream.md
+++ b/tests/stream.md
@@ -26,7 +26,7 @@ let take t =
 
 let take_nonblocking t =
   traceln "Reading from stream";
-  traceln "Got %a from stream" Fmt.(option ~none:(unit "None") int) (S.take_nonblocking t)
+  traceln "Got %a from stream" Fmt.(option ~none:(any "None") int) (S.take_nonblocking t)
 ```
 
 # Test cases


### PR DESCRIPTION
Using `Fmt.unit` (or any deprecated function, it seems) causes blank lines to appear in the output! See: https://github.com/realworldocaml/mdx/issues/429