### PR TITLE
Allow windows users to run dune build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
       - run: | 
           opam pin -yn eio.dev .
           opam pin -yn eio_windows.dev .
-          opam install ocamlfind.1.9.5 kcas alcotest mdx crowbar -y
+          opam install ocamlfind.1.9.5 kcas alcotest mdx crowbar dscheck -y
           opam install eio eio_windows --deps-only
       - run: opam exec -- dune build
       - run: opam exec -- dune runtest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
           opam pin -yn eio_windows.dev .
           opam install ocamlfind.1.9.5 kcas alcotest mdx crowbar -y
           opam install eio eio_windows --deps-only
+      - run: opam exec -- dune build
       - run: opam exec -- dune runtest
       - run: opam exec -- dune exec -- ./examples/net/main.exe
   docker:

--- a/dune-project
+++ b/dune-project
@@ -46,6 +46,7 @@
   (uring (>= 0.5))))
 (package
  (name eio_posix)
+ (allow_empty)
  (synopsis "Eio implementation for POSIX systems")
  (description "An Eio implementation for most Unix-like platforms")
  (depends

--- a/lib_eio_posix/dune
+++ b/lib_eio_posix/dune
@@ -11,4 +11,5 @@
 
 (rule
  (targets config.ml)
+ (enabled_if (= %{os_type} "Unix"))
  (action (run ./include/discover.exe)))


### PR DESCRIPTION
This allows someone on windows to run `dune build` from the root of the project and it just builds what should work on Windows. Added that into CI also to protect against breaking it.