### PR TITLE
Windows vendor stubs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,8 +52,7 @@ jobs:
       - run: | 
           opam pin -yn eio.dev .
           opam pin -yn eio_windows.dev .
-          opam install ocamlfind.1.9.5 kcas alcotest mdx crowbar dscheck -y
-          opam install eio eio_windows --deps-only
+          opam install eio eio_windows --deps-only --with-test
       - run: opam exec -- dune build
       - run: opam exec -- dune runtest
       - run: opam exec -- dune exec -- ./examples/net/main.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
       - run: | 
           opam pin -yn eio.dev .
           opam pin -yn eio_windows.dev .
-          opam install ocamlfind.1.9.5 kcas alcotest mdx crowbar -y
+          opam install ocamlfind.1.9.5 kcas alcotest mdx crowbar dscheck -y
           opam install eio eio_windows --deps-only
       - run: opam exec -- dune build
       - run: opam exec -- dune runtest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
           opam pin -yn eio_windows.dev .
           opam install ocamlfind.1.9.5 kcas alcotest mdx crowbar -y
           opam install eio eio_windows --deps-only
+      - run: opam exec -- dune build
       - run: opam exec -- dune runtest
       - run: opam exec -- dune exec -- ./examples/net/main.exe
   docker:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,9 +47,7 @@ jobs:
           ocaml-compiler: ocaml.5.0.0,ocaml-option-mingw
           opam-repositories: |
             dra27: https://github.com/dra27/opam-repository.git#windows-5.0
-            duniverse: git+https://github.com/dune-universe/opam-overlays
             normal: https://github.com/ocaml/opam-repository.git
-            default: https://github.com/ocaml-opam/opam-repository-mingw.git#opam2
       # --with-version=dev is not available, and --with-test also tries running tests for packages (like MDX) which fail...
       - run: | 
           opam pin -yn eio.dev .

--- a/dune-project
+++ b/dune-project
@@ -46,6 +46,7 @@
   (uring (>= 0.5))))
 (package
  (name eio_posix)
+ (allow_empty)
  (synopsis "Eio implementation for POSIX systems")
  (description "An Eio implementation for most Unix-like platforms")
  (depends

--- a/dune-project
+++ b/dune-project
@@ -46,7 +46,7 @@
   (uring (>= 0.5))))
 (package
  (name eio_posix)
- (allow_empty)
+ (allow_empty)  ; Work-around for dune bug #6938
  (synopsis "Eio implementation for POSIX systems")
  (description "An Eio implementation for most Unix-like platforms")
  (depends
@@ -61,7 +61,6 @@
  (allow_empty)  ; Work-around for dune bug #6938
  (depends
   (eio (= :version))
-  (cstruct-unix (= dev))
   (kcas (and (>= 0.3.0) :with-test))
   (alcotest (and (>= 1.4.0) :with-test))))
 (package

--- a/eio_windows.opam
+++ b/eio_windows.opam
@@ -32,6 +32,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
 pin-depends: [
+  # With Fdopen's patch, the only thing we need from opam-repo-mingw
+  [ "ocamlbuild.dev" "git+https://github.com/patricoferris/ocamlbuild#b72c0dfdd6f1066d50da4b924b8196237696f66b" ]
   # Removes base bytes for crowbar
   [ "ocplib-endian.dev" "git+https://github.com/Leonidas-from-XIV/ocplib-endian#fda4d5525063c8444020be369c63de23d39c246e" ]
   # Needed for the cstruct read and writes without copying

--- a/eio_windows.opam
+++ b/eio_windows.opam
@@ -11,7 +11,6 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.7"}
   "eio" {= version}
-  "cstruct-unix" {= "dev"}
   "kcas" {>= "0.3.0" & with-test}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}
@@ -34,9 +33,4 @@ dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
 pin-depends: [
   # With Fdopen's patch, the only thing we need from opam-repo-mingw
   [ "ocamlbuild.dev" "git+https://github.com/patricoferris/ocamlbuild#b72c0dfdd6f1066d50da4b924b8196237696f66b" ]
-  # Removes base bytes for crowbar
-  [ "ocplib-endian.dev" "git+https://github.com/Leonidas-from-XIV/ocplib-endian#fda4d5525063c8444020be369c63de23d39c246e" ]
-  # Needed for the cstruct read and writes without copying
-  [ "cstruct.dev" "git+https://github.com/djs55/ocaml-cstruct#471ca03b49b3a372945fcf13c89e0447a8bd3932" ]
-  [ "cstruct-unix.dev" "git+https://github.com/djs55/ocaml-cstruct#471ca03b49b3a372945fcf13c89e0447a8bd3932" ]
 ]

--- a/eio_windows.opam.template
+++ b/eio_windows.opam.template
@@ -1,4 +1,6 @@
 pin-depends: [
+  # With Fdopen's patch, the only thing we need from opam-repo-mingw
+  [ "ocamlbuild.dev" "git+https://github.com/patricoferris/ocamlbuild#b72c0dfdd6f1066d50da4b924b8196237696f66b" ]
   # Removes base bytes for crowbar
   [ "ocplib-endian.dev" "git+https://github.com/Leonidas-from-XIV/ocplib-endian#fda4d5525063c8444020be369c63de23d39c246e" ]
   # Needed for the cstruct read and writes without copying

--- a/eio_windows.opam.template
+++ b/eio_windows.opam.template
@@ -1,9 +1,4 @@
 pin-depends: [
   # With Fdopen's patch, the only thing we need from opam-repo-mingw
   [ "ocamlbuild.dev" "git+https://github.com/patricoferris/ocamlbuild#b72c0dfdd6f1066d50da4b924b8196237696f66b" ]
-  # Removes base bytes for crowbar
-  [ "ocplib-endian.dev" "git+https://github.com/Leonidas-from-XIV/ocplib-endian#fda4d5525063c8444020be369c63de23d39c246e" ]
-  # Needed for the cstruct read and writes without copying
-  [ "cstruct.dev" "git+https://github.com/djs55/ocaml-cstruct#471ca03b49b3a372945fcf13c89e0447a8bd3932" ]
-  [ "cstruct-unix.dev" "git+https://github.com/djs55/ocaml-cstruct#471ca03b49b3a372945fcf13c89e0447a8bd3932" ]
 ]

--- a/lib_eio_posix/dune
+++ b/lib_eio_posix/dune
@@ -11,4 +11,5 @@
 
 (rule
  (targets config.ml)
+ (enabled_if (= %{os_type} "Unix"))
  (action (run ./include/discover.exe)))

--- a/lib_eio_windows/dune
+++ b/lib_eio_windows/dune
@@ -6,8 +6,8 @@
  (foreign_stubs
   (language c)
   (include_dirs ../lib_eio/unix/include)
-  (names eio_windows_stubs))
- (libraries eio eio.unix eio.utils fmt cstruct-unix))
+  (names eio_windows_stubs eio_windows_cstruct_stubs))
+ (libraries eio eio.unix eio.utils fmt))
 
 (rule
  (targets config.ml)

--- a/lib_eio_windows/eio_windows_cstruct_stubs.c
+++ b/lib_eio_windows/eio_windows_cstruct_stubs.c
@@ -1,0 +1,149 @@
+/* From mirage/ocaml-cstruct
+Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+Copyright (c) 2012 Pierre Chambart
+Copyright (c) Christiano F. Haesbaert <haesbaert@haesbaert.org>
+Copyright (c) Citrix Inc
+Copyright (c) David Sheets <sheets@alum.mit.edu>
+Copyright (c) Drup <drupyog@zoho.com>
+Copyright (c) Hannes Mehnert <hannes@mehnert.org>
+Copyright (c) Jeremy Yallop <yallop@gmail.com>
+Copyright (c) Mindy Preston <meetup@yomimono.org>
+Copyright (c) Nicolas Ojeda Bar <n.oje.bar@gmail.com>
+Copyright (c) Richard Mortier <mort@cantab.net>
+Copyright (c) Rudi Grinberg <rudi.grinberg@gmail.com>
+Copyright (c) Thomas Gazagnaire <thomas@gazagnaire.com>
+Copyright (c) Thomas Leonard <talex5@gmail.com>
+Copyright (c) Vincent Bernardoff <vb@luminar.eu.org>
+Copyright (c) pqwy <david@numm.org>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/custom.h>
+#include <caml/callback.h>
+#include <caml/alloc.h>
+#include <caml/unixsupport.h>
+#include <caml/bigarray.h>
+#include <caml/threads.h>
+#include <caml/fail.h>
+
+#include <stdio.h>
+#include <errno.h>
+
+CAMLprim value eio_windows_cstruct_read(value val_fd, value val_c)
+{
+  CAMLparam2(val_fd, val_c);
+  CAMLlocal3(val_buf, val_ofs, val_len);
+  uint8_t *buf;
+  size_t len;
+  ssize_t n = 0;
+  int win32err = 0;
+  SOCKET s;
+  HANDLE h;
+  DWORD numread;
+  int ok;
+
+  val_buf = Field(val_c, 0);
+  val_ofs = Field(val_c, 1);
+  val_len = Field(val_c, 2);
+
+  buf = (uint8_t *)Caml_ba_data_val(val_buf) + Long_val(val_ofs);
+  len = (size_t)Long_val(val_len);
+
+  switch (Descr_kind_val(val_fd))
+  {
+  case KIND_SOCKET:
+    s = Socket_val(val_fd);
+
+    caml_release_runtime_system();
+    n = recv(s, buf, len, 0);
+    win32err = WSAGetLastError();
+    caml_acquire_runtime_system();
+
+    if (n == SOCKET_ERROR)
+    {
+      win32_maperr(win32err);
+      uerror("stub_cstruct_read", Nothing);
+    }
+    break;
+  case KIND_HANDLE:
+    h = Handle_val(val_fd);
+    caml_release_runtime_system();
+    ok = ReadFile(h, buf, len, &numread, NULL);
+    win32err = GetLastError();
+    n = numread;
+    caml_acquire_runtime_system();
+
+    if (!ok)
+    {
+      win32_maperr(win32err);
+      uerror("stub_cstruct_read", Nothing);
+    }
+    break;
+  default:
+    caml_failwith("unknown Descr_kind_val");
+  }
+
+  CAMLreturn(Val_int(n));
+}
+
+CAMLprim value eio_windows_cstruct_write(value val_fd, value val_c)
+{
+  CAMLparam2(val_fd, val_c);
+  CAMLlocal3(val_buf, val_ofs, val_len);
+  val_buf = Field(val_c, 0);
+  val_ofs = Field(val_c, 1);
+  val_len = Field(val_c, 2);
+  void *buf = (char *)Caml_ba_data_val(val_buf) + Long_val(val_ofs);
+  size_t len = Long_val(val_len);
+  ssize_t n = 0;
+
+  int win32err = 0;
+  switch (Descr_kind_val(val_fd))
+  {
+  case KIND_SOCKET:
+    SOCKET s = Socket_val(val_fd);
+
+    caml_release_runtime_system();
+    n = send(s, buf, len, 0);
+    win32err = WSAGetLastError();
+    caml_acquire_runtime_system();
+
+    if (n == SOCKET_ERROR)
+    {
+      win32_maperr(win32err);
+      unix_error(errno, "stub_cstruct_write", Nothing);
+    }
+    break;
+  case KIND_HANDLE:
+    HANDLE h = Handle_val(val_fd);
+    DWORD numwritten;
+    caml_release_runtime_system();
+    int ok = WriteFile(h, buf, len, &numwritten, NULL);
+    win32err = GetLastError();
+
+    n = numwritten;
+    caml_acquire_runtime_system();
+
+    if (!ok)
+    {
+      win32_maperr(win32err);
+      uerror("stub_cstruct_write", Nothing);
+    }
+    break;
+  default:
+    caml_failwith("unknown Descr_kind_val");
+  }
+
+  CAMLreturn(Val_int(n));
+}

--- a/lib_eio_windows/unix_cstruct.ml
+++ b/lib_eio_windows/unix_cstruct.ml
@@ -1,0 +1,42 @@
+(* See the end of the file for the license *)
+external stub_write : Unix.file_descr -> Cstruct.t -> int = "eio_windows_cstruct_write"
+
+let rec write fd buf =
+  if Cstruct.length buf > 0 then begin
+    let n = stub_write fd buf in
+    write fd @@ Cstruct.shift buf n
+  end
+
+let writev fd bufs = List.iter (write fd) bufs
+
+external read : Unix.file_descr -> Cstruct.t -> int = "eio_windows_cstruct_read"
+
+(* From mirage/ocaml-cstruct
+Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+Copyright (c) 2012 Pierre Chambart
+Copyright (c) Christiano F. Haesbaert <haesbaert@haesbaert.org>
+Copyright (c) Citrix Inc
+Copyright (c) David Sheets <sheets@alum.mit.edu>
+Copyright (c) Drup <drupyog@zoho.com>
+Copyright (c) Hannes Mehnert <hannes@mehnert.org>
+Copyright (c) Jeremy Yallop <yallop@gmail.com>
+Copyright (c) Mindy Preston <meetup@yomimono.org>
+Copyright (c) Nicolas Ojeda Bar <n.oje.bar@gmail.com>
+Copyright (c) Richard Mortier <mort@cantab.net>
+Copyright (c) Rudi Grinberg <rudi.grinberg@gmail.com>
+Copyright (c) Thomas Gazagnaire <thomas@gazagnaire.com>
+Copyright (c) Thomas Leonard <talex5@gmail.com>
+Copyright (c) Vincent Bernardoff <vb@luminar.eu.org>
+Copyright (c) pqwy <david@numm.org>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. *)


### PR DESCRIPTION
Building on #529 

This PR handles most of the external pins that the windows backend needed:

 - The small number of cstruct stubs we needed are now vendored directly in `eio_windows`. We should probably also bring the `send` and `recv` stubs along but `eio_posix` could uses those, so perhaps a follow-up PR for that would be nice.
 - Turns out most of our woes stemmed back to not having [a patch for ocamlbuild from opam-repository-mingw](https://github.com/fdopen/opam-repository-mingw/blob/opam2/packages/ocamlbuild/ocamlbuild.0.14.2/files/ocamlbuild-0.14.2.patch) which I think is the essence of this PR https://github.com/ocaml/ocamlbuild/pull/70 -- though not equal. I have the patch applied to a fork of ocamlbuild and that is now the only pin in the `eio_windows` package. The patch either needs upstreaming to ocamlbuild or ocaml/opam-repository.