### PR TITLE
support for creating ptys and a login_tty fork_action

### DIFF
--- a/lib_eio/unix/dune
+++ b/lib_eio/unix/dune
@@ -5,7 +5,7 @@
  (foreign_stubs
   (language c)
   (include_dirs include)
-  (names fork_action eio_unix_stubs cap))
+  (names fork_action eio_unix_stubs cap pty))
  (libraries eio eio.utils unix threads mtime.clock.os))
 
 (rule
@@ -18,7 +18,8 @@
         %{dep:.eio_unix.objs/byte/eio_unix__Fd.cmt}
         %{dep:.eio_unix.objs/byte/eio_unix__Private.cmt}
         %{dep:.eio_unix.objs/byte/eio_unix__Cap.cmt}
-        %{dep:.eio_unix.objs/byte/eio_unix__Fork_action.cmt}))))
+        %{dep:.eio_unix.objs/byte/eio_unix__Fork_action.cmt}
+        %{dep:.eio_unix.objs/byte/eio_unix__Pty.cmt}))))
 
 (rule
  (package eio)

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -28,6 +28,7 @@ module Ipaddr = Net.Ipaddr
 
 module Process = Process
 module Net = Net
+module Pty = Pty
 module Cap = Cap
 module Pi = Pi
 

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -66,6 +66,9 @@ val pipe : Switch.t -> [< source_ty] r * [< sink_ty] r
 module Process = Process
 (** Spawning child processes with extra control. *)
 
+module Pty = Pty
+(** Creating and controlling pseudoterminals. *)
+
 module Cap = Cap
 (** Capsicum security. *)
 

--- a/lib_eio/unix/fork_action.c
+++ b/lib_eio/unix/fork_action.c
@@ -13,6 +13,11 @@
 #include <string.h>
 #include <errno.h>
 
+#ifndef _WIN32
+#include <sys/ioctl.h>      /* TIOCSCTTY, for login_tty */
+#include <termios.h>
+#endif
+
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
 #include <caml/memory.h>
@@ -302,4 +307,25 @@ static void action_setgid(int errors, value v_config) {
 
 CAMLprim value eio_unix_fork_setgid(value v_unit) {
   return Val_fork_fn(action_setgid);
+}
+
+static void action_login_tty(int errors, value v_config) {
+  #ifdef _WIN32
+  eio_unix_fork_error(errors, "login_tty", ENOSYS);
+  _exit(1);
+  #else
+  int fd = Int_val(Field(v_config, 1));
+  if (setsid() == -1) {
+    eio_unix_fork_error(errors, "setsid", errno);
+    _exit(1);
+  }
+  if (ioctl(fd, TIOCSCTTY, 0) == -1) {
+    eio_unix_fork_error(errors, "ioctl(TIOCSCTTY)", errno);
+    _exit(1);
+  }
+  #endif
+}
+
+CAMLprim value eio_unix_login_tty(value v_unit) {
+  return Val_fork_fn(action_login_tty);
 }

--- a/lib_eio/unix/fork_action.ml
+++ b/lib_eio/unix/fork_action.ml
@@ -84,6 +84,13 @@ let action_setgid = action_setgid ()
 let setgid gid = {
   run = fun k -> k (Obj.repr (action_setgid, gid)) }
 
+external action_login_tty : unit -> fork_fn = "eio_unix_login_tty"
+let action_login_tty = action_login_tty ()
+let login_tty fd = {
+  run = fun k ->
+    Fd.use_exn "login_tty" fd @@ fun fd ->
+    k (Obj.repr (action_login_tty, fd)) }
+
 external error_of_code : int -> Unix.error = "eio_unix_error_of_code"
 
 let report_spawn_error msg =

--- a/lib_eio/unix/fork_action.mli
+++ b/lib_eio/unix/fork_action.mli
@@ -71,6 +71,13 @@ val setuid : int -> t
 val setgid : int -> t
 (** [setgid gid] sets the group ID to [gid]. *)
 
+val login_tty : Fd.t -> t
+(** [login_tty tty] makes [tty] the controlling terminal of the child.
+
+    It starts a new session and makes [tty] the session's controlling terminal.
+    It does not duplicate it to the child's stdin/stdout/stderr; use {!inherit_fds} for that.
+    [tty] is typically the terminal-device end of a pair returned by {!Eio_unix.Pty.open_pty}. *)
+
 val report_spawn_error : string -> 'a
 (** [report_spawn_error msg] raises an exception describing a failed spawn.
 

--- a/lib_eio/unix/primitives.h
+++ b/lib_eio/unix/primitives.h
@@ -2,6 +2,10 @@
 #define CAML_NAME_SPACE
 #define _GNU_SOURCE
 #include <caml/mlvalues.h>
+CAMLprim value eio_unix_open_pty(value);
+CAMLprim value eio_unix_get_pty_peer(value);
+CAMLprim value eio_unix_get_winsize(value);
+CAMLprim value eio_unix_set_winsize(value, value);
 CAMLprim value eio_unix_make_string_array(value);
 CAMLprim value eio_unix_fork_execve(value);
 CAMLprim value eio_unix_fork_chdir(value);
@@ -10,6 +14,7 @@ CAMLprim value eio_unix_fork_dups(value);
 CAMLprim value eio_unix_fork_setpgid(value);
 CAMLprim value eio_unix_fork_setuid(value);
 CAMLprim value eio_unix_fork_setgid(value);
+CAMLprim value eio_unix_login_tty(value);
 CAMLprim value eio_unix_error_of_code(value);
 CAMLprim value eio_unix_cap_enter(value);
 CAMLprim value eio_unix_readlinkat(value, value, value);

--- a/lib_eio/unix/process.ml
+++ b/lib_eio/unix/process.ml
@@ -97,6 +97,7 @@ module Pi = struct
       ?pgid:int ->
       ?uid:int ->
       ?gid:int ->
+      ?login_tty:Fd.t ->
       env:string array ->
       fds:(int * Fd.t * Fork_action.blocking) list ->
       executable:string ->
@@ -124,6 +125,7 @@ module Make_mgr (X : sig
     ?pgid:int ->
     ?uid:int ->
     ?gid:int ->
+    ?login_tty:Fd.t ->
     env:string array ->
     fds:(int * Fd.t * Fork_action.blocking) list ->
     executable:string ->
@@ -156,12 +158,12 @@ end) = struct
   let spawn_unix = X.spawn_unix
 end
 
-let spawn_unix ~sw (Eio.Resource.T (v, ops)) ?cwd ?pgid ?uid ?gid ~fds ?env ?executable args =
+let spawn_unix ~sw (Eio.Resource.T (v, ops)) ?cwd ?pgid ?uid ?gid ?login_tty ~fds ?env ?executable args =
   let module X = (val (Eio.Resource.get ops Pi.Mgr_unix)) in
   let executable = get_executable executable ~args in
   let env = get_env env in
   translate_execve_error ~executable @@ fun () ->
-  X.spawn_unix v ~sw ?cwd ?pgid ?uid ?gid ~fds ~env ~executable args
+  X.spawn_unix v ~sw ?cwd ?pgid ?uid ?gid ?login_tty ~fds ~env ~executable args
 
 let sigchld = Eio.Condition.create ()
 

--- a/lib_eio/unix/process.mli
+++ b/lib_eio/unix/process.mli
@@ -23,6 +23,7 @@ module Pi : sig
       ?pgid:int ->
       ?uid:int ->
       ?gid:int ->
+      ?login_tty:Fd.t ->
       env:string array ->
       fds:(int * Fd.t * Fork_action.blocking) list ->
       executable:string ->
@@ -48,6 +49,7 @@ module Make_mgr (X : sig
     ?pgid:int ->
     ?uid:int ->
     ?gid:int ->
+    ?login_tty:Fd.t ->
     env:string array ->
     fds:(int * Fd.t * Fork_action.blocking) list ->
     executable:string ->
@@ -62,6 +64,7 @@ val spawn_unix :
     ?pgid:int ->
     ?uid:int ->
     ?gid:int ->
+    ?login_tty:Fd.t ->
     fds:(int * Fd.t * Fork_action.blocking) list ->
     ?env:string array ->
     ?executable:string ->
@@ -71,7 +74,10 @@ val spawn_unix :
 
     The arguments are as for {!Eio.Process.spawn},
     except that it takes a list of FD mappings for {!Private.Fork_action.inherit_fds}
-    directly, rather than just flows for the standard streams. *)
+    directly, rather than just flows for the standard streams.
+
+    @param login_tty If given, the child starts a new session with this terminal
+                     device as its controlling terminal and stdin/stdout/stderr. *)
 
 val sigchld : Eio.Condition.t
 (** {b If} an Eio backend installs a SIGCHLD handler, the handler will broadcast on this condition.

--- a/lib_eio/unix/pty.c
+++ b/lib_eio/unix/pty.c
@@ -1,0 +1,135 @@
+/* Pseudoterminal support for Eio_unix.Pty. */
+
+#include "primitives.h" /* Defines _GNU_SOURCEfor posix_openpt. */
+
+#include <string.h>
+#include <errno.h>
+
+#ifndef _WIN32
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#endif
+
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/fail.h>
+#include <caml/unixsupport.h>
+
+/* Returns [pty_fd], opened close-on-exec. */
+CAMLprim value eio_unix_open_pty(value v_unit) {
+#ifdef _WIN32
+  caml_unix_error(EOPNOTSUPP, "open_pty", Nothing);
+#else
+  CAMLparam1(v_unit);
+
+#if defined(__OpenBSD__)
+  /* OpenBSD posix_openpt accepts only O_RDWR | O_NOCTTY,
+     so request close-on-exec separately via fcntl.
+     https://man.openbsd.org/posix_openpt.3 */
+  int pty_fd = posix_openpt(O_RDWR | O_NOCTTY);
+  if (pty_fd < 0)
+    caml_uerror("posix_openpt", Nothing);
+  if (fcntl(pty_fd, F_SETFD, FD_CLOEXEC) < 0) {
+    int e = errno;
+    close(pty_fd);
+    errno = e;
+    caml_uerror("posix_openpt.fcntl", Nothing);
+  }
+#else
+  int pty_fd = posix_openpt(O_RDWR | O_NOCTTY | O_CLOEXEC);
+  if (pty_fd < 0)
+    caml_uerror("posix_openpt", Nothing);
+#endif  /* __OpenBSD__ */
+
+  CAMLreturn(Val_int(pty_fd));
+#endif  /* _WIN32 */
+}
+
+/* Returns [(tty_fd, name)], opened close-on-exec. */
+CAMLprim value eio_unix_get_pty_peer(value v_pty) {
+#ifdef _WIN32
+  caml_unix_error(EOPNOTSUPP, "TIOCGPTPEER", Nothing);
+#else
+  CAMLparam1(v_pty);
+  CAMLlocal2(v_name, v_ret);
+  int pty_fd = Int_val(v_pty);
+
+  if (grantpt(pty_fd) < 0)
+    caml_uerror("grantpt", Nothing);
+
+  if (unlockpt(pty_fd) < 0)
+    caml_uerror("unlockpt", Nothing);
+
+  {
+#if defined(__OpenBSD__)
+    char *name = ptsname(pty_fd);
+    if (name == NULL)
+      caml_uerror("ptsname", Nothing);
+    v_name = caml_copy_string(name);
+#else
+    char namebuf[256];
+    int err = ptsname_r(pty_fd, namebuf, sizeof namebuf);
+    if (err != 0) {
+      errno = err;
+      caml_uerror("ptsname_r", Nothing);
+    }
+    v_name = caml_copy_string(namebuf);
+#endif
+  }
+
+  int tty_fd;
+#ifdef TIOCGPTPEER
+  tty_fd = ioctl(pty_fd, TIOCGPTPEER, O_RDWR | O_NOCTTY | O_CLOEXEC);
+  if (tty_fd < 0)
+    caml_uerror("ioctl(TIOCGPTPEER)", Nothing);
+#else
+  tty_fd = open(String_val(v_name), O_RDWR | O_NOCTTY | O_CLOEXEC);
+  if (tty_fd < 0)
+    caml_uerror("open", v_name);
+#endif
+
+  v_ret = caml_alloc_tuple(2);
+  Store_field(v_ret, 0, Val_int(tty_fd));
+  Store_field(v_ret, 1, v_name);
+  CAMLreturn(v_ret);
+#endif
+}
+
+CAMLprim value eio_unix_get_winsize(value v_fd) {
+#ifdef _WIN32
+  caml_unix_error(EOPNOTSUPP, "get_window_size", Nothing);
+#else
+  CAMLparam1(v_fd);
+  CAMLlocal1(v_ws);
+  struct winsize w;
+  if (ioctl(Int_val(v_fd), TIOCGWINSZ, &w) < 0)
+    caml_uerror("get_window_size", Nothing);
+  v_ws = caml_alloc_tuple(4);
+  Store_field(v_ws, 0, Val_int(w.ws_row));
+  Store_field(v_ws, 1, Val_int(w.ws_col));
+  Store_field(v_ws, 2, Val_int(w.ws_xpixel));
+  Store_field(v_ws, 3, Val_int(w.ws_ypixel));
+  CAMLreturn(v_ws);
+#endif
+}
+
+CAMLprim value eio_unix_set_winsize(value v_fd, value v_ws) {
+#ifdef _WIN32
+  caml_unix_error(EOPNOTSUPP, "set_window_size", Nothing);
+#else
+  CAMLparam2(v_fd, v_ws);
+  struct winsize w;
+  memset(&w, 0, sizeof w);
+  w.ws_row    = Int_val(Field(v_ws, 0));
+  w.ws_col    = Int_val(Field(v_ws, 1));
+  w.ws_xpixel = Int_val(Field(v_ws, 2));
+  w.ws_ypixel = Int_val(Field(v_ws, 3));
+  if (ioctl(Int_val(v_fd), TIOCSWINSZ, &w) < 0)
+    caml_uerror("set_window_size", Nothing);
+  CAMLreturn(Val_unit);
+#endif
+}

--- a/lib_eio/unix/pty.ml
+++ b/lib_eio/unix/pty.ml
@@ -1,0 +1,40 @@
+open Eio.Std
+
+type t = {
+  pty : [Types.source_ty | Types.sink_ty] r;
+  tty : Fd.t;
+  name : string;
+}
+
+external create : unit -> Unix.file_descr = "eio_unix_open_pty"
+
+(* Not domain-safe on platforms without [ptsname_r] *)
+external get_pty_peer : Unix.file_descr -> Unix.file_descr * string = "eio_unix_get_pty_peer"
+
+let open_pty ~sw () =
+  let pty_fd = create () in
+  Unix.set_nonblock pty_fd;
+  let pty = Net.import_socket_stream ~sw ~close_unix:true pty_fd in
+  let tty_fd, name = get_pty_peer pty_fd in
+  let tty = Fd.of_unix ~sw ~blocking:true ~seekable:false ~close_unix:true tty_fd in
+  { pty; tty; name }
+
+let pty t = Resource.fd t.pty
+let tty t = t.tty
+let name t = t.name
+
+let source t = (t.pty :> Types.source_ty r)
+let sink t = (t.pty :> Types.sink_ty r)
+
+type winsize = {
+  rows : int;
+  cols : int;
+  xpixel : int;
+  ypixel : int;
+}
+
+external get_winsize : Unix.file_descr -> winsize = "eio_unix_get_winsize"
+external set_winsize : Unix.file_descr -> winsize -> unit = "eio_unix_set_winsize"
+
+let get_window_size fd = Fd.use_exn "get_window_size" fd get_winsize
+let set_window_size fd ws = Fd.use_exn "set_window_size" fd (fun fd -> set_winsize fd ws)

--- a/lib_eio/unix/pty.ml
+++ b/lib_eio/unix/pty.ml
@@ -38,3 +38,27 @@ external set_winsize : Unix.file_descr -> winsize -> unit = "eio_unix_set_winsiz
 
 let get_window_size fd = Fd.use_exn "get_window_size" fd get_winsize
 let set_window_size fd ws = Fd.use_exn "set_window_size" fd (fun fd -> set_winsize fd ws)
+
+module Tc = struct
+  let getattr fd = Fd.use_exn "tcgetattr" fd Unix.tcgetattr
+
+  let setattr fd when_ attr =
+    Fd.use_exn "tcsetattr" fd (fun fd ->
+        match when_ with
+        | Unix.TCSANOW -> Unix.tcsetattr fd when_ attr
+        | TCSADRAIN | TCSAFLUSH ->
+          Thread_pool.run_in_systhread ~label:"tcsetattr"
+            (fun () -> Unix.tcsetattr fd when_ attr))
+
+  let sendbreak fd duration =
+    Fd.use_exn "tcsendbreak" fd (fun fd ->
+        Thread_pool.run_in_systhread ~label:"tcsendbreak"
+          (fun () -> Unix.tcsendbreak fd duration))
+
+  let drain fd =
+    Fd.use_exn "tcdrain" fd (fun fd ->
+        Thread_pool.run_in_systhread ~label:"tcdrain" (fun () -> Unix.tcdrain fd))
+
+  let flush fd queue = Fd.use_exn "tcflush" fd (fun fd -> Unix.tcflush fd queue)
+  let flow fd action = Fd.use_exn "tcflow" fd (fun fd -> Unix.tcflow fd action)
+end

--- a/lib_eio/unix/pty.mli
+++ b/lib_eio/unix/pty.mli
@@ -57,3 +57,38 @@ val set_window_size : Fd.t -> winsize -> unit
     the foreground process group attached to the terminal.
 
     @raise Unix.Unix_error if [fd] is not a terminal. *)
+
+(** Terminal attributes control.
+    These raise [Unix.Unix_error] if [fd] is not a terminal. *)
+module Tc : sig
+  val getattr : Fd.t -> Unix.terminal_io
+  (** [getattr fd] returns the current terminal attributes of [fd].
+      See {!Unix.tcgetattr}. *)
+
+  val setattr : Fd.t -> Unix.setattr_when -> Unix.terminal_io -> unit
+  (** [setattr fd when_ attr] sets the terminal attributes of [fd].
+
+      With [TCSADRAIN] or [TCSAFLUSH] the change waits for pending output to
+      drain in the current fiber.
+      See {!Unix.tcsetattr}. *)
+
+  val sendbreak : Fd.t -> int -> unit
+  (** [sendbreak fd duration] sends a break condition on [fd].
+
+      This blocks the current fiber while the break is transmitted.
+      See {!Unix.tcsendbreak}. *)
+
+  val drain : Fd.t -> unit
+  (** [drain fd] waits until all output written to [fd] has been transmitted.
+
+      This blocks the current fiber until the output drains.
+      See {!Unix.tcdrain}. *)
+
+  val flush : Fd.t -> Unix.flush_queue -> unit
+  (** [flush fd queue] discards pending input and/or output on [fd].
+      See {!Unix.tcflush}. *)
+
+  val flow : Fd.t -> Unix.flow_action -> unit
+  (** [flow fd action] suspends or resumes transmission/reception on [fd].
+      See {!Unix.tcflow}. *)
+end

--- a/lib_eio/unix/pty.mli
+++ b/lib_eio/unix/pty.mli
@@ -1,0 +1,59 @@
+(** Pseudoterminal (PTY) support.
+
+    A pseudoterminal is a pair of connected file descriptors emulating a
+    terminal. The {e pseudoterminal device} is used by a controlling program
+    such as a terminal emulator, while the {e terminal device} is used by
+    a child process as its controlling terminal. *)
+
+open Eio.Std
+
+type t
+(** A connected pseudoterminal pair. *)
+
+val open_pty : sw:Switch.t -> unit -> t
+(** [open_pty ~sw ()] allocates a new pseudoterminal pair.
+
+    Both file descriptors are closed when [sw] finishes. The {!pty} end
+    is non-blocking; the {!tty} end is blocking and so suitable as the
+    child's controlling terminal.
+
+    Not a multi-domain-safe function on some platforms without reentrant
+    [ptsname] support.
+
+    @raise Unix.Unix_error if the pseudoterminal cannot be created. *)
+
+val pty : t -> Fd.t
+(** [pty t] is the pseudoterminal-device end. *)
+
+val tty : t -> Fd.t
+(** [tty t] is the terminal-device end. *)
+
+val name : t -> string
+(** [name t] is the path of the terminal device. *)
+
+val source : t -> Types.source_ty r
+(** [source t] reads the output the child writes to terminal. *)
+
+val sink : t -> Types.sink_ty r
+(** [sink t] writes input for the child to read from its terminal. *)
+
+(** Terminal window dimensions. *)
+type winsize = {
+  rows : int;     (** Height of the terminal in character rows. *)
+  cols : int;     (** Width of the terminal in character columns. *)
+  xpixel : int;   (** Width in pixels ([0] if unknown). *)
+  ypixel : int;   (** Height in pixels ([0] if unknown). *)
+}
+
+val get_window_size : Fd.t -> winsize
+(** [get_window_size fd] returns the window size of terminal [fd].
+
+    @raise Unix.Unix_error if [fd] is not a terminal. *)
+
+val set_window_size : Fd.t -> winsize -> unit
+(** [set_window_size fd ws] sets the window size of terminal [fd].
+
+    Setting it on the {!pty} end updates the terminal and delivers [SIGWINCH] to
+    the foreground process group attached to the terminal.
+
+    @raise Unix.Unix_error if [fd] is not a terminal. *)

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -225,11 +225,22 @@ module Process_mgr = struct
   module T = struct
     type t = unit 
     
-    let spawn_unix () ~sw ?cwd ?pgid ?uid ?gid ~env ~fds ~executable args =
-      let actions = Low_level.Process.Fork_action.[
-          Eio_unix.Private.Fork_action.inherit_fds fds;
-          execve executable ~argv:(Array.of_list args) ~env
-      ] in
+    let spawn_unix () ~sw ?cwd ?pgid ?uid ?gid ?login_tty ~env ~fds ~executable args =
+      let login_tty_action, fds = match login_tty with
+        | None -> [], fds
+        | Some tty ->
+          let fds = [
+            0, tty, `Blocking;
+            1, tty, `Blocking;
+            2, tty, `Blocking;
+          ] @ fds in
+          [Eio_unix.Private.Fork_action.login_tty tty], fds
+      in
+      let actions = Low_level.Process.Fork_action.(
+          login_tty_action @
+          [ Eio_unix.Private.Fork_action.inherit_fds fds;
+            execve executable ~argv:(Array.of_list args) ~env ]
+      ) in
       let actions = match pgid with
         | None -> actions
         | Some pgid -> Eio_unix.Private.Fork_action.setpgid pgid :: actions

--- a/lib_eio_posix/process.ml
+++ b/lib_eio_posix/process.ml
@@ -23,11 +23,22 @@ module Impl = struct
   module T = struct
     type t = unit
 
-    let spawn_unix () ~sw ?cwd ?pgid ?uid ?gid ~env ~fds ~executable args =
-      let actions = Low_level.Process.Fork_action.[
-          inherit_fds fds;
-          execve executable ~argv:(Array.of_list args) ~env
-      ] in
+    let spawn_unix () ~sw ?cwd ?pgid ?uid ?gid ?login_tty ~env ~fds ~executable args =
+      let login_tty_action, fds = match login_tty with
+        | None -> [], fds
+        | Some tty ->
+          let fds = [
+            0, tty, `Blocking;
+            1, tty, `Blocking;
+            2, tty, `Blocking;
+          ] @ fds in
+          [Eio_unix.Private.Fork_action.login_tty tty], fds
+      in
+      let actions = Low_level.Process.Fork_action.(
+          login_tty_action @
+          [ Eio_unix.Private.Fork_action.inherit_fds fds;
+            execve executable ~argv:(Array.of_list args) ~env ]
+      ) in
       let actions = match pgid with
         | None -> actions
         | Some pgid -> Low_level.Process.Fork_action.setpgid pgid :: actions

--- a/tests/pty.md
+++ b/tests/pty.md
@@ -41,6 +41,25 @@ The window size can be set on either end and read back:
 - : Pty.winsize = {Pty.rows = 24; cols = 80; xpixel = 0; ypixel = 0}
 ```
 
+## Terminal attributes
+
+Terminal attributes can be manipulted via `Pty.Tc`. Here we change a setting
+through the draining path, drain and flush the queues, resume output, and read
+the new value back. This exercises some of the fiber blocking logic:
+
+```ocaml
+# run @@ fun _env ->
+  Switch.run @@ fun sw ->
+  let tty = Pty.tty (Pty.open_pty ~sw ()) in
+  let attr = Pty.Tc.getattr tty in
+  Pty.Tc.setattr tty Unix.TCSADRAIN { attr with c_echo = false };
+  Pty.Tc.drain tty;
+  Pty.Tc.flush tty Unix.TCIOFLUSH;
+  Pty.Tc.flow tty Unix.TCOON;
+  (Pty.Tc.getattr tty).c_echo;;
+- : bool = false
+```
+
 ## Spawning a child on a pseudoterminal
 
 Passing the terminal-device end as `login_tty` makes it the child's controlling
@@ -88,9 +107,8 @@ Here we turn off the terminal's input echo, send it a line, and read the respons
 # run @@ fun env ->
   Switch.run @@ fun sw ->
   let t = Pty.open_pty ~sw () in
-  Eio_unix.Fd.use_exn "tty" (Pty.tty t) (fun fd ->
-    let attr = Unix.tcgetattr fd in
-    Unix.tcsetattr fd Unix.TCSANOW { attr with c_echo = false });
+  let attr = Pty.Tc.getattr (Pty.tty t) in
+  Pty.Tc.setattr (Pty.tty t) Unix.TCSANOW { attr with c_echo = false };
   let _child =
     Eio_unix.Process.spawn_unix ~sw env#process_mgr
       ~login_tty:(Pty.tty t)

--- a/tests/pty.md
+++ b/tests/pty.md
@@ -1,0 +1,153 @@
+# Setting up the environment
+
+```ocaml
+# #require "eio_main";;
+```
+
+```ocaml
+open Eio.Std
+
+module Pty = Eio_unix.Pty
+
+let () = Eio.Exn.Backend.show := false
+
+let run fn =
+  Eio_main.run @@ fun env ->
+  fn env
+```
+
+## Opening a pseudoterminal
+
+A new pair has a terminal-device name and two distinct file descriptors:
+
+```ocaml
+# run @@ fun _env ->
+  Switch.run @@ fun sw ->
+  let t = Pty.open_pty ~sw () in
+  String.starts_with ~prefix:"/dev/" (Pty.name t);;
+- : bool = true
+```
+
+## Window size
+
+The window size can be set on either end and read back:
+
+```ocaml
+# run @@ fun _env ->
+  Switch.run @@ fun sw ->
+  let t = Pty.open_pty ~sw () in
+  Pty.set_window_size (Pty.pty t) { rows = 24; cols = 80; xpixel = 0; ypixel = 0 };
+  Pty.get_window_size (Pty.tty t);;
+- : Pty.winsize = {Pty.rows = 24; cols = 80; xpixel = 0; ypixel = 0}
+```
+
+## Spawning a child on a pseudoterminal
+
+Passing the terminal-device end as `login_tty` makes it the child's controlling
+terminal and stdin/stdout/stderr, so the child sees all three as a tty:
+
+```ocaml
+# run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let t = Pty.open_pty ~sw () in
+  let child =
+    Eio_unix.Process.spawn_unix ~sw env#process_mgr
+      ~login_tty:(Pty.tty t)
+      ~fds:[]
+      ["sh"; "-c"; "[ -t 0 ] && [ -t 1 ] && [ -t 2 ]"]
+  in
+  Eio.Process.await child;;
+- : Eio.Process.exit_status = `Exited 0
+```
+
+Output the child writes to its terminal can be read back from the `pty` end.
+The child ends with a blocking `read` so that it keeps the terminal end open until
+we have consumed its output, since some BSD-derived systems discard output
+as soon as the last terminal-side fd is closed. Linux seems to preserve the
+output however. The trailing `read` is released when the switch exits.
+
+```ocaml
+# run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let t = Pty.open_pty ~sw () in
+  let _child =
+    Eio_unix.Process.spawn_unix ~sw env#process_mgr
+      ~login_tty:(Pty.tty t)
+      ~fds:[]
+      ["sh"; "-c"; "for i in 1 2 3; do echo \"line $i\"; done; read keep_open"]
+  in
+  let r = Eio.Buf_read.of_flow (Pty.source t) ~max_size:1024 in
+  Eio.Buf_read.lines r |> Seq.take 3 |> List.of_seq;;
+- : string list = ["line 1"; "line 2"; "line 3"]
+```
+
+Input can be sent to the child by writing to the `pty` end with {!Pty.sink}.
+Here we turn off the terminal's input echo, send it a line, and read the response:
+
+```ocaml
+# run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let t = Pty.open_pty ~sw () in
+  Eio_unix.Fd.use_exn "tty" (Pty.tty t) (fun fd ->
+    let attr = Unix.tcgetattr fd in
+    Unix.tcsetattr fd Unix.TCSANOW { attr with c_echo = false });
+  let _child =
+    Eio_unix.Process.spawn_unix ~sw env#process_mgr
+      ~login_tty:(Pty.tty t)
+      ~fds:[]
+      ["sh"; "-c"; "read line; echo \"reply: $line\"; read keep_open"]
+  in
+  Eio.Flow.copy_string "hello\n" (Pty.sink t);
+  let r = Eio.Buf_read.of_flow (Pty.source t) ~max_size:1024 in
+  Eio.Buf_read.line r;;
+- : string = "reply: hello"
+```
+
+With echo left on, the terminal echoes the input back to the `pty` end as well:
+
+```ocaml
+# run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let t = Pty.open_pty ~sw () in
+  let _child =
+    Eio_unix.Process.spawn_unix ~sw env#process_mgr
+      ~login_tty:(Pty.tty t)
+      ~fds:[]
+      ["sh"; "-c"; "read line; echo \"reply: $line\"; read keep_open"]
+  in
+  Eio.Flow.copy_string "hello\n" (Pty.sink t);
+  let r = Eio.Buf_read.of_flow (Pty.source t) ~max_size:1024 in
+  Eio.Buf_read.lines r |> Seq.take 2 |> List.of_seq;;
+- : string list = ["hello"; "reply: hello"]
+```
+
+Without a controlling terminal, the same check fails:
+
+```ocaml
+# run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let devnull = Eio_unix.Fd.of_unix ~sw ~blocking:true ~close_unix:true
+      (Unix.openfile "/dev/null" [O_RDWR] 0) in
+  let child =
+    Eio_unix.Process.spawn_unix ~sw env#process_mgr
+      ~fds:[ 0, devnull, `Blocking; 1, devnull, `Blocking; 2, devnull, `Blocking ]
+      ["sh"; "-c"; "[ -t 0 ]"]
+  in
+  Eio.Process.await child;;
+- : Eio.Process.exit_status = `Exited 1
+```
+
+Detect if the user tries to set the standard streams manually:
+
+```ocaml
+# run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let t = Pty.open_pty ~sw () in
+  let devnull = Eio_unix.Fd.of_unix ~sw ~blocking:true ~close_unix:true
+      (Unix.openfile "/dev/null" [O_RDWR] 0) in
+  Eio_unix.Process.spawn_unix ~sw env#process_mgr
+    ~login_tty:(Pty.tty t)
+    ~fds:[ 0, devnull, `Blocking ]
+    ["sh"; "-c"; "exit 0"];;
+Exception: Invalid_argument "FD 0 assigned twice!".
+```


### PR DESCRIPTION
Add pseudoterminal support and a login_tty fork action (layered over #854 commits)

Adds Eio_unix.Pty for creating pseudoterminals and a login_tty fork action for running a child on one. Pseudoterminals are created with posix_openpt so both ends are close-on-exec.  If available, the terminal-device is opened via TIOCGPTPEER (Linux) and falls back to opening ptsname otehrwise (macOS etc).

login_tty is a fork action that starts a new session, makes the terminal device the controlling terminal, and dups it onto the child's stdin/stdout/stderr. It's exposed via Eio_unix.Process.spawn_unix as a ?login_tty argument.

Based on review feedback in this PR from @talex5, @patricoferris and @RyanGibb.