### PR TITLE
Remove pins for windows

### DIFF
--- a/eio_windows.opam
+++ b/eio_windows.opam
@@ -30,7 +30,3 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
-pin-depends: [
-  # With Fdopen's patch, the only thing we need from opam-repo-mingw
-  [ "ocamlbuild.dev" "git+https://github.com/patricoferris/ocamlbuild#b72c0dfdd6f1066d50da4b924b8196237696f66b" ]
-]

--- a/eio_windows.opam.template
+++ b/eio_windows.opam.template
@@ -1,4 +1,0 @@
-pin-depends: [
-  # With Fdopen's patch, the only thing we need from opam-repo-mingw
-  [ "ocamlbuild.dev" "git+https://github.com/patricoferris/ocamlbuild#b72c0dfdd6f1066d50da4b924b8196237696f66b" ]
-]


### PR DESCRIPTION
This PR removes the final pins for the windows backend using the PR to opam-repository to add the ocamlbuild patch (thanks @avsm). 