### PR TITLE
ignore ENOTCONN errors on socket shutdown

### DIFF
--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -166,8 +166,7 @@ let flow fd =
         aux (Eio.Flow.read_methods src)
 
     method shutdown cmd =
-      FD.use_exn "shutdown" fd @@ fun fd ->
-      Unix.shutdown fd @@ match cmd with
+      Low_level.shutdown fd @@ match cmd with
       | `Receive -> Unix.SHUTDOWN_RECEIVE
       | `Send -> Unix.SHUTDOWN_SEND
       | `All -> Unix.SHUTDOWN_ALL

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -385,9 +385,12 @@ let rename old_dir old_path new_dir new_path =
   with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
 
 let shutdown socket command =
-  Fd.use_exn "shutdown" socket @@ fun fd ->
-  try Unix.shutdown fd command
-  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+  try
+    Fd.use_exn "shutdown" socket @@ fun fd ->
+    Unix.shutdown fd command
+  with
+  | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
+  | Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
 
 let accept ~sw fd =
   Ctf.label "accept";

--- a/lib_eio_posix/flow.ml
+++ b/lib_eio_posix/flow.ml
@@ -61,7 +61,9 @@ let shutdown fd cmd =
     | `Receive -> Unix.SHUTDOWN_RECEIVE
     | `Send -> Unix.SHUTDOWN_SEND
     | `All -> Unix.SHUTDOWN_ALL
-  with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+  with
+  | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
+  | Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
 
 let of_fd fd = object (_ : <Eio_unix.Net.stream_socket; Eio.File.rw>)
   method fd = fd

--- a/lib_eio_windows/flow.ml
+++ b/lib_eio_windows/flow.ml
@@ -55,7 +55,9 @@ let shutdown fd cmd =
     | `Receive -> Unix.SHUTDOWN_RECEIVE
     | `Send -> Unix.SHUTDOWN_SEND
     | `All -> Unix.SHUTDOWN_ALL
-  with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+  with
+  | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
+  | Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
 
 let of_fd fd = object (_ : <Eio_unix.Net.stream_socket; Eio.File.rw>)
   method fd = fd


### PR DESCRIPTION
macOS can return ENOTCONN occasionally even if the other side did a graceful shutdown.  This changes all the backends to ignore ENOTCONN; even though it's unlikely to show up on Linux, there's still not much point throwing the exception from a shutdown on any of the platforms.

Fixes #521