### PR TITLE
Remove close from socket type

### DIFF
--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -159,7 +159,6 @@ end
 
 class virtual socket = object (_ : #Generic.t)
   method probe _ = None
-  method virtual close : unit
 end
 
 class virtual stream_socket = object (_ : #socket)

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -104,7 +104,6 @@ end
 
 class virtual socket : object
   inherit Generic.t
-  method virtual close : unit
 end
 
 class virtual stream_socket : object

--- a/lib_eio/unix/net.ml
+++ b/lib_eio/unix/net.ml
@@ -23,11 +23,11 @@ let sockaddr_of_unix_datagram = function
     let host = Ipaddr.of_unix host in
     `Udp (host, port)
 
-class virtual stream_socket = object (_ : <Resource.t; ..>)
+class virtual stream_socket = object (_ : <Resource.t; Eio.Flow.close; ..>)
   inherit Eio.Net.stream_socket
 end
 
-class virtual datagram_socket = object (_ : <Resource.t; ..>)
+class virtual datagram_socket = object (_ : <Resource.t; Eio.Flow.close; ..>)
   inherit Eio.Net.datagram_socket
 end
 

--- a/lib_eio/unix/net.mli
+++ b/lib_eio/unix/net.mli
@@ -4,11 +4,11 @@ open Eio.Std
 
     These extend the types in {!Eio.Net} with support for file descriptors. *)
 
-class virtual stream_socket : object (<Resource.t; ..>)
+class virtual stream_socket : object (<Resource.t; Eio.Flow.close; ..>)
   inherit Eio.Net.stream_socket
 end
 
-class virtual datagram_socket : object (<Resource.t; ..>)
+class virtual datagram_socket : object (<Resource.t; Eio.Flow.close; ..>)
   inherit Eio.Net.datagram_socket
 end
 

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -188,7 +188,7 @@ let listening_socket fd = object
       | Unix.ADDR_UNIX path         -> `Unix path
       | Unix.ADDR_INET (host, port) -> `Tcp (Eio_unix.Net.Ipaddr.of_unix host, port)
     in
-    let flow = (flow client :> Eio.Net.stream_socket) in
+    let flow = (flow client :> <Eio.Net.stream_socket; Eio.Flow.close>) in
     flow, client_addr
 
   method! probe : type a. a Eio.Generic.ty -> a option = function
@@ -211,7 +211,7 @@ let connect ~sw connect_addr =
   let sock_unix = Unix.socket ~cloexec:true (socket_domain_of connect_addr) Unix.SOCK_STREAM 0 in
   let sock = FD.of_unix ~sw ~seekable:false ~close_unix:true sock_unix in
   Low_level.connect sock addr;
-  (flow sock :> Eio.Net.stream_socket)
+  (flow sock :> <Eio.Net.stream_socket; Eio.Flow.close>)
 
 let net = object
   inherit Eio_unix.Net.t
@@ -270,7 +270,7 @@ let net = object
       Unix.bind sock_unix addr
     | `UdpV4 | `UdpV6 -> ()
     end;
-    (datagram_socket sock :> Eio.Net.datagram_socket)
+    (datagram_socket sock :> <Eio.Net.datagram_socket; Eio.Flow.close>)
 
   method getaddrinfo = Low_level.getaddrinfo
 end

--- a/lib_eio_posix/net.ml
+++ b/lib_eio_posix/net.ml
@@ -25,7 +25,7 @@ let listening_socket ~hook fd = object
       | Unix.ADDR_UNIX path         -> `Unix path
       | Unix.ADDR_INET (host, port) -> `Tcp (Eio_unix.Net.Ipaddr.of_unix host, port)
     in
-    let flow = (Flow.of_fd client :> Eio.Net.stream_socket) in
+    let flow = (Flow.of_fd client :> <Eio.Net.stream_socket; Eio.Flow.close>) in
     flow, client_addr
 
   method! probe : type a. a Eio.Generic.ty -> a option = function
@@ -118,7 +118,7 @@ let connect ~sw connect_addr =
   let sock = Low_level.socket ~sw (socket_domain_of connect_addr) socket_type 0 in
   try
     Low_level.connect sock addr;
-    (Flow.of_fd sock :> Eio.Net.stream_socket)
+    (Flow.of_fd sock :> <Eio.Net.stream_socket; Eio.Flow.close>)
   with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
 
 let create_datagram_socket ~reuse_addr ~reuse_port ~sw saddr =
@@ -135,7 +135,7 @@ let create_datagram_socket ~reuse_addr ~reuse_port ~sw saddr =
         )
     | `UdpV4 | `UdpV6 -> ()
   end;
-  (datagram_socket sock :> Eio.Net.datagram_socket)
+  (datagram_socket sock :> <Eio.Net.datagram_socket; Eio.Flow.close>)
 
 let v = object
   inherit Eio_unix.Net.t

--- a/lib_eio_windows/net.ml
+++ b/lib_eio_windows/net.ml
@@ -25,7 +25,7 @@ let listening_socket ~hook fd = object
       | Unix.ADDR_UNIX path         -> `Unix path
       | Unix.ADDR_INET (host, port) -> `Tcp (Eio_unix.Net.Ipaddr.of_unix host, port)
     in
-    let flow = (Flow.of_fd client :> Eio.Net.stream_socket) in
+    let flow = (Flow.of_fd client :> <Eio.Net.stream_socket; Eio.Flow.close>) in
     flow, client_addr
 
   method! probe : type a. a Eio.Generic.ty -> a option = function
@@ -123,7 +123,7 @@ let connect ~sw connect_addr =
   let sock = Low_level.socket ~sw (socket_domain_of connect_addr) socket_type 0 in
   try
     Low_level.connect sock addr;
-    (Flow.of_fd sock :> Eio.Net.stream_socket)
+    (Flow.of_fd sock :> <Eio.Net.stream_socket; Eio.Flow.close>)
   with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
 
 let create_datagram_socket ~reuse_addr ~reuse_port ~sw saddr =
@@ -140,7 +140,7 @@ let create_datagram_socket ~reuse_addr ~reuse_port ~sw saddr =
         )
     | `UdpV4 | `UdpV6 -> ()
   end;
-  (datagram_socket sock :> Eio.Net.datagram_socket)
+  (datagram_socket sock :> <Eio.Net.datagram_socket; Eio.Flow.close>)
 
 let v = object
   inherit Eio_unix.Net.t


### PR DESCRIPTION
Sockets created by `accept_fork` can't be closed manually currently, so revert the part of #516 that said they could.

We might want to revisit this later, but for now put things back how they were.

Reported by @avsm.