### PR TITLE
Mark eio_windows as only available on Windows

### DIFF
--- a/eio_windows.opam
+++ b/eio_windows.opam
@@ -30,3 +30,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os-family = "windows"]

--- a/eio_windows.opam.template
+++ b/eio_windows.opam.template
@@ -1,0 +1,1 @@
+available: [os-family = "windows"]


### PR DESCRIPTION
It does install on other platforms, due to the `(allow_empty)` work-around for https://github.com/ocaml/dune/issues/6938, but that's a bit confusing.