### PR TITLE
Use `Fmt.Dump.signal` to format signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,7 +918,7 @@ All process functions either return the exit status or check that it was zero (s
   let proc_mgr = Eio.Stdenv.process_mgr env in
   Eio.Process.parse_out proc_mgr Eio.Buf_read.take_all ["sh"; "-c"; "exit 3"];;
 Exception:
-Eio.Io Process Child_error Exited 3,
+Eio.Io Process Child_error Exited (code 3),
   running command: sh -c "exit 3"
 ```
 

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -6,9 +6,9 @@ type exit_status = [
 type status = [ exit_status | `Stopped of int ]
 
 let pp_status ppf = function
-  | `Exited i -> Format.fprintf ppf "Exited %i" i
-  | `Signaled i -> Format.fprintf ppf "Signalled %i" i
-  | `Stopped i -> Format.fprintf ppf "Stopped %i" i
+  | `Exited i -> Format.fprintf ppf "Exited (code %i)" i
+  | `Signaled i -> Format.fprintf ppf "Exited (signal %a)" Fmt.Dump.signal i
+  | `Stopped i -> Format.fprintf ppf "Stopped (signal %a)" Fmt.Dump.signal i
 
 type error =
   | Executable_not_found of string


### PR DESCRIPTION
Thanks to @MisterDA for letting me know about this!