### PR TITLE
Allow calling close more than once

### DIFF
--- a/lib_eio/core/switch.ml
+++ b/lib_eio/core/switch.ml
@@ -14,6 +14,8 @@ type hook =
 
 let null_hook = Null
 
+(* todo: would be good to make this thread-safe. While a switch can only be turned off from its own domain,
+   we might want to allow closing something explicitly from any domain, and that needs to remove the hook. *)
 let remove_hook = function
   | Null -> ()
   | Hook (id, n) ->

--- a/lib_eio/flow.ml
+++ b/lib_eio/flow.ml
@@ -3,11 +3,8 @@ type shutdown_command = [ `Receive | `Send | `All ]
 type read_method = ..
 type read_method += Read_source_buffer of ((Cstruct.t list -> int) -> unit)
 
-class type close = object
-  method close : unit
-end
-
-let close (t : #close) = t#close
+class type close = Generic.close
+let close = Generic.close
 
 class virtual source = object (_ : <Generic.t; ..>)
   method probe _ = None

--- a/lib_eio/flow.mli
+++ b/lib_eio/flow.mli
@@ -111,9 +111,7 @@ val shutdown : #two_way -> shutdown_command -> unit
     Flows are usually attached to switches and closed automatically when the switch
     finishes. However, it can be useful to close them sooner manually in some cases. *)
 
-class type close = object
-  method close : unit
-end
+class type close = Generic.close
 
 val close : #close -> unit
-(** [close t] marks the flow as closed. It can no longer be used after this. *)
+(** Alias of {!Generic.close}. *)

--- a/lib_eio/fs.ml
+++ b/lib_eio/fs.ml
@@ -53,8 +53,7 @@ class virtual dir = object (_ : #Generic.t)
   method virtual rename : path -> dir -> path -> unit
   method virtual pp : Format.formatter -> unit
 end
-and virtual dir_with_close = object
+and virtual dir_with_close = object (_ : <Generic.close; ..>)
   (* This dummy class avoids an "Error: The type < .. > is not an object type" error from the compiler. *)
   inherit dir
-  method virtual close : unit
 end

--- a/lib_eio/generic.ml
+++ b/lib_eio/generic.ml
@@ -5,3 +5,9 @@ class type t = object
 end
 
 let probe (t : #t) ty = t#probe ty
+
+class type close = object
+  method close : unit
+end
+
+let close (t : #close) = t#close

--- a/lib_eio/generic.mli
+++ b/lib_eio/generic.mli
@@ -9,3 +9,22 @@ val probe : #t -> 'a ty -> 'a option
 (** [probe t feature] checks whether [t] supports [feature].
     This is mostly for internal use.
     For example, {!Eio_unix.FD.peek_opt} uses this to get the underlying Unix file descriptor from a flow. *)
+
+(** {2 Closing}
+
+    Resources are usually attached to switches and closed automatically when the switch
+    finishes. However, it can be useful to close them sooner in some cases. *)
+
+class type close = object
+  method close : unit
+end
+
+val close : #close -> unit
+(** [close t] marks the resource as closed. It can no longer be used after this.
+
+    If [t] is already closed then this does nothing (it does not raise an exception).
+
+    Note: if an operation is currently in progress when this is called then it is not
+    necessarily cancelled, and any underlying OS resource (such as a file descriptor)
+    might not be closed immediately if other operations are using it. Closing a resource
+    only prevents new operations from starting. *)

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -165,10 +165,9 @@ class virtual stream_socket = object (_ : #socket)
   inherit Flow.two_way
 end
 
-class virtual listening_socket = object
+class virtual listening_socket = object (_ : <Generic.close; ..>)
   inherit socket
   method virtual accept : sw:Switch.t -> <stream_socket; Flow.close> * Sockaddr.stream
-  method virtual close : unit
 end
 
 type connection_handler = stream_socket -> Sockaddr.stream -> unit
@@ -245,7 +244,7 @@ let getaddrinfo_datagram ?service t hostname =
 
 let getnameinfo (t:#t) sockaddr = t#getnameinfo sockaddr
 
-let close = Flow.close
+let close = Generic.close
 
 let with_tcp_connect ?(timeout=Time.Timeout.none) ~host ~service t f =
   Switch.run @@ fun sw ->

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -117,10 +117,9 @@ class virtual datagram_socket : object
   method virtual recv : Cstruct.t -> Sockaddr.datagram * int
 end
 
-class virtual listening_socket : object
+class virtual listening_socket : object (<Generic.close; ..>)
   inherit socket
   method virtual accept : sw:Switch.t -> <stream_socket; Flow.close> * Sockaddr.stream
-  method virtual close : unit
 end
 
 class virtual t : object
@@ -301,5 +300,6 @@ val getnameinfo : #t -> Sockaddr.t -> (string * string)
     port specified in [sockaddr], e.g. 'ftp', 'http', 'https', etc. *)
 
 (** {2 Closing} *)
-val close : <close: unit; ..> -> unit
-(** [close t] marks the socket as closed. It can no longer be used after this. *)
+
+val close : #Generic.close -> unit
+(** Alias of {!Generic.close}. *)

--- a/lib_eio/unix/fd.ml
+++ b/lib_eio/unix/fd.ml
@@ -22,11 +22,9 @@ let use_exn op t f =
 let close t =
   Switch.remove_hook t.release_hook;
   if t.close_unix then (
-    if not (Rcfd.close t.fd) then raise (err_closed "close")
+    ignore (Rcfd.close t.fd : bool)
   ) else (
-    match Rcfd.remove t.fd with
-    | Some _ -> ()
-    | None -> raise (err_closed "close")
+    ignore (Rcfd.remove t.fd : Unix.file_descr option)
   )
 
 let remove t =

--- a/lib_eio/unix/fd.mli
+++ b/lib_eio/unix/fd.mli
@@ -38,7 +38,7 @@ val close : t -> unit
 
     The wrapped FD will be closed once all current users of the FD have finished (unless [close_unix = false]).
 
-    @raise Invalid_argument if [t] is closed by another fiber first. *)
+    Has no effect if [t] is already closed. *)
 
 val remove : t -> Unix.file_descr option
 (** [remove t] marks [t] as closed, so that {!use} can no longer be used to start new operations.


### PR DESCRIPTION
Previously, some resources raised an exception if you tried to close them more than once, while others ignored it. Document that calling close on a closed resource does nothing.

This is useful for `accept_fork`, which always tries to close the socket at the end, but would like to allow the user to close it sooner if they wish.

Closes #323 (requested by @anmonteiro). It should also allow #537 to be reverted, simplifying #522.

I also moved the definition of `close` to `Generic`, since it's not specific to flows, and documented that it doesn't necessarily cancel in-progress operations.

(it used to be important to avoid double-closes, since there could be a race if two domains closed at once, but that's fixed now)