### PR TITLE
Add `listening_socket#listening_addr`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v0.14
+
+New features / API changes:
+
+- Add `Net.listening_addr` (@mefyl #555).
+
 ## v0.13
 
 New features / API changes:

--- a/lib_eio/mock/eio_mock.mli
+++ b/lib_eio/mock/eio_mock.mli
@@ -132,8 +132,11 @@ module Net : sig
 
   val on_getnameinfo : t -> (string * string) Handler.actions -> unit
 
-  val listening_socket : string -> listening_socket
-  (** [listening_socket label] can be configured to provide mock connections. *)
+  val listening_socket :
+    ?listening_addr:Eio.Net.Sockaddr.stream -> string -> listening_socket
+  (** [listening_socket label] can be configured to provide mock connections.
+
+      If [listening_addr] is not provided, a dummy value will be reported. *)
 
   val on_accept :
     listening_socket ->

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -218,6 +218,7 @@ module Pi = struct
 
     val accept : t -> sw:Switch.t -> tag stream_socket_ty r * Sockaddr.stream
     val close : t -> unit
+    val listening_addr : t -> Sockaddr.stream
   end
 
   type (_, _, _) Resource.pi +=
@@ -276,6 +277,10 @@ let accept_fork ~sw (t : [> 'a listening_socket_ty] r) ~on_error handle =
              on_error (Exn.add_context ex "handling connection from %a" Sockaddr.pp addr)
          )
     )
+
+let listening_addr (type tag) (Resource.T (t, ops) : [> tag listening_socket_ty] r) =
+  let module X = (val (Resource.get ops Pi.Listening_socket)) in
+  X.listening_addr t
 
 let send (Resource.T (t, ops)) ?dst bufs =
   let module X = (val (Resource.get ops Pi.Datagram_socket)) in

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -167,6 +167,8 @@ val listen :
 
     The new socket will be closed when [sw] finishes, unless closed manually first.
 
+    On platforms that support this, passing port [0] will bind to a random port.
+
     For (non-abstract) Unix domain sockets, the path will be removed afterwards.
 
     @param backlog The number of pending connections that can be queued up (see listen(2)).
@@ -204,6 +206,8 @@ val accept_fork :
 
                     [on_error] is not called for {!Cancel.Cancelled} exceptions,
                     which do not need to be reported. *)
+
+val listening_addr : [> 'tag listening_socket_ty] r -> Sockaddr.stream
 
 (** {2 Running Servers} *)
 
@@ -327,6 +331,7 @@ module Pi : sig
 
     val accept : t -> sw:Switch.t -> tag stream_socket_ty r * Sockaddr.stream
     val close : t -> unit
+    val listening_addr : t -> Sockaddr.stream
   end
 
   val listening_socket :

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -235,6 +235,10 @@ module Listening_socket = struct
     in
     let flow = (flow client :> _ Eio.Net.stream_socket) in
     flow, client_addr
+
+  let listening_addr fd =
+    Eio_unix.Fd.use_exn "listening_addr" fd
+      (fun fd -> Eio_unix.Net.sockaddr_of_unix_stream (Unix.getsockname fd))
 end
 
 let listening_handler = Eio_unix.Pi.listening_socket_handler (module Listening_socket)

--- a/lib_eio_posix/net.ml
+++ b/lib_eio_posix/net.ml
@@ -36,6 +36,10 @@ module Listening_socket = struct
     in
     let flow = (Flow.of_fd client :> _ Eio.Net.stream_socket) in
     flow, client_addr
+
+  let listening_addr { fd; _ } =
+    Eio_unix.Fd.use_exn "listening_addr" fd
+      (fun fd -> Eio_unix.Net.sockaddr_of_unix_stream (Unix.getsockname fd))
 end
 
 let listening_handler = Eio_unix.Pi.listening_socket_handler (module Listening_socket)

--- a/lib_eio_windows/net.ml
+++ b/lib_eio_windows/net.ml
@@ -36,6 +36,10 @@ module Listening_socket = struct
     in
     let flow = (Flow.of_fd client :> _ Eio.Net.stream_socket) in
     flow, client_addr
+
+  let listening_addr { fd; _ } =
+    Eio_unix.Fd.use_exn "listening_addr" fd
+      (fun fd -> Eio_unix.Net.sockaddr_of_unix_stream (Unix.getsockname fd))
 end
 
 let listening_handler = Eio_unix.Pi.listening_socket_handler (module Listening_socket)


### PR DESCRIPTION
This adds the ability to retrieve the address a socket is listening on. More than just a convenience, this is required to let the OS pick a random free port by passing `0` and then determine what port was actually picked.

The actual implementation returns `None` if the socket was closed, while the mock always returns `None` - I'm unsure whether this is an issue as I'm only just starting to dip my toes in eio.