### PR TITLE
Correct the backend selection for Cygwin

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -72,6 +72,6 @@
   (kcas (and (>= 0.3.0) :with-test))
   (yojson (and (>= 2.0.2) :with-test))
   (eio_linux (and (= :version) (= :os "linux")))
-  (eio_posix (and (= :version) (<> :os-family "windows")))
-  (eio_windows (and (= :version) (= :os-family "windows")))))
+  (eio_posix (and (= :version) (<> :os "win32")))
+  (eio_windows (and (= :version) (= :os "win32")))))
 (using mdx 0.2)

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -14,8 +14,8 @@ depends: [
   "kcas" {>= "0.3.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux" {= version & os = "linux"}
-  "eio_posix" {= version & os-family != "windows"}
-  "eio_windows" {= version & os-family = "windows"}
+  "eio_posix" {= version & os != "win32"}
+  "eio_windows" {= version & os = "win32"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
`os-family = "windows"` covers _both_ native Windows (`os = "win32"`) and Cygwin (`os = "cygwin"`). Cygwin _is_ a posix implementation, so it should be using `eio_posix`.

I encountered this while checking something else in opam-repository, so I haven't actually tried it with a Cygwin 5.1 switch, but if `eio_posix` isn't building on Cygwin, I would very strongly expect that to be a bug in `eio_posix` rather than that eio should actually be using `eio_windows`.