### PR TITLE
Expose eio backend in posix, windows, and linux backends

### DIFF
--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -40,6 +40,7 @@ module Stdenv = struct
   let fs (t : <fs : #Fs.dir Path.t; ..>) = t#fs
   let cwd (t : <cwd : #Fs.dir Path.t; ..>) = t#cwd
   let debug (t : <debug : 'a; ..>) = t#debug
+  let backend_id (t: <backend_id : string; ..>) = t#backend_id
 end
 
 exception Io = Exn.Io

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -240,6 +240,12 @@ module Stdenv : sig
 
   val debug : <debug : <Debug.t; ..> as 'a; ..> -> 'a
   (** [debug t] provides privileged controls for debugging. *)
+
+  val backend_id : <backend_id:string; ..> -> string
+  (** [backend_id t] provides the name of the backend being used.
+
+      The possible values are the same as the possible values of the "EIO_BACKEND"
+      environment variable used by {!Eio_main.run}. *)
 end
 
 (** {1 Errors and Debugging} *)

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -44,5 +44,6 @@ module Stdenv = struct
     cwd : Eio.Fs.dir Eio.Path.t;
     secure_random : Eio.Flow.source;
     debug : Eio.Debug.t;
+    backend_id: string;
   >
 end

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -77,6 +77,7 @@ module Stdenv : sig
     cwd : Eio.Fs.dir Eio.Path.t;
     secure_random : Eio.Flow.source;
     debug : Eio.Debug.t;
+    backend_id : string;
   >
   (** The common set of features provided by all traditional operating systems (BSDs, Linux, Mac, Windows).
 

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -452,6 +452,7 @@ let stdenv ~run_event_loop =
     method cwd = (cwd :> Eio.Fs.dir Eio.Path.t)
     method secure_random = secure_random
     method debug = Eio.Private.Debug.v
+    method backend_id = "linux"
   end
 
 let run_event_loop (type a) ?fallback config (main : _ -> a) arg : a =

--- a/lib_eio_linux/tests/test.ml
+++ b/lib_eio_linux/tests/test.ml
@@ -150,6 +150,11 @@ let test_read_exact () =
     let got = Uring.Region.to_string chunk ~len:(String.length msg) in
     if got <> msg then Fmt.failwith "%S vs %S" got msg
 
+let test_expose_backend () =
+  Eio_linux.run @@ fun env ->
+  let backend = Eio.Stdenv.backend_id env in
+  assert (backend = "linux")
+
 let () =
   let open Alcotest in
   run "eio_linux" [
@@ -161,5 +166,6 @@ let () =
       test_case "iovec"         `Quick test_iovec;
       test_case "no_sqe"        `Quick test_no_sqe;
       test_case "read_exact"    `Quick test_read_exact;
+      test_case "expose_backend"    `Quick test_expose_backend;
     ];
   ]

--- a/lib_eio_posix/eio_posix.ml
+++ b/lib_eio_posix/eio_posix.ml
@@ -38,4 +38,5 @@ let run main =
     method cwd = ((Fs.cwd, "") :> Eio.Fs.dir Eio.Path.t)
     method fs = ((Fs.fs, "") :> Eio.Fs.dir Eio.Path.t)
     method secure_random = Flow.secure_random
+    method backend_id = "posix"
   end

--- a/lib_eio_windows/eio_windows.ml
+++ b/lib_eio_windows/eio_windows.ml
@@ -35,4 +35,5 @@ let run main =
     method fs = ((Fs.fs, "") :> Eio.Fs.dir Eio.Path.t)
     method process_mgr = failwith "process operations not supported on Windows yet"
     method secure_random = Flow.secure_random
+    method backend_id = "windows"
   end


### PR DESCRIPTION
Addition that should cover #545, allows checking the backend in use within Eio_main.