### PR TITLE
Raise an exception instead of Failure "execve: Argument list too long"

### DIFF
--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -13,6 +13,7 @@ let pp_status ppf = function
 type error =
   | Executable_not_found of string
   | Child_error of exit_status
+  | Argument_list_too_long
 
 type Exn.err += E of error
 
@@ -25,6 +26,7 @@ let () =
       begin match e with
         | Executable_not_found e -> Fmt.pf f "Executable %S not found" e;
         | Child_error e -> Fmt.pf f "Child_error %a" pp_status e;
+        | Argument_list_too_long -> Fmt.pf f "Argument list too long"
       end;
       true
     | _ -> false

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -23,6 +23,7 @@ val pp_status : [< status] Fmt.t
 type error =
   | Executable_not_found of string      (** The requested executable does not exist. *)
   | Child_error of exit_status          (** The process exited with an error status. *)
+  | Argument_list_too_long              (** The arguments passed to the process were too large. *)
 
 type Exn.err += E of error
 

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -521,5 +521,6 @@ module Process = struct
     (* Check for errors starting the process. *)
     match read_response errors_r with
     | "" -> t                       (* Success! Execing the child closed [errors_w] and we got EOF. *)
+    | "execve: Argument list too long" -> raise (Eio.Process.err Eio.Process.Argument_list_too_long)
     | err -> failwith err
 end

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -285,5 +285,6 @@ module Process = struct
     (* Check for errors starting the process. *)
     match read_response errors_r with
     | "" -> t                       (* Success! Execing the child closed [errors_w] and we got EOF. *)
+    | "execve: Argument list too long" -> raise (Eio.Process.err Eio.Process.Argument_list_too_long)
     | err -> failwith err
 end


### PR DESCRIPTION
Fix #556