### PR TITLE
Fix handling of empty path strings

### DIFF
--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -8,7 +8,8 @@ let ( / ) (dir, p1) p2 =
   | p1, p2 -> (dir, Filename.concat p1 p2)
 
 let pp f ((t:#Fs.dir), p) =
-  Fmt.pf f "<%t:%s>" t#pp (String.escaped p)
+  if p = "" then Fmt.pf f "<%t>" t#pp
+  else Fmt.pf f "<%t:%s>" t#pp (String.escaped p)
 
 let open_in ~sw ((t:#Fs.dir), path) =
   try t#open_in ~sw path

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -397,7 +397,7 @@ class dir ~label (fd : Low_level.dir_fd) = object
     (flow fd :> <Eio.File.rw; Eio.Flow.close>)
 
   method open_dir ~sw path =
-    let fd = Low_level.openat ~sw ~seekable:false fd path
+    let fd = Low_level.openat ~sw ~seekable:false fd (if path = "" then "." else path)
         ~access:`R
         ~flags:Uring.Open_flags.(cloexec + path + directory)
         ~perm:0
@@ -409,7 +409,7 @@ class dir ~label (fd : Low_level.dir_fd) = object
 
   method read_dir path =
     Switch.run @@ fun sw ->
-    let fd = Low_level.open_dir ~sw fd path in
+    let fd = Low_level.open_dir ~sw fd (if path = "" then "." else path) in
     Low_level.read_dir fd
 
   method close =
@@ -437,8 +437,8 @@ let stdenv ~run_event_loop =
   let stdin = source Eio_unix.Fd.stdin in
   let stdout = sink Eio_unix.Fd.stdout in
   let stderr = sink Eio_unix.Fd.stderr in
-  let fs = (new dir ~label:"fs" Fs, ".") in
-  let cwd = (new dir ~label:"cwd" Cwd, ".") in
+  let fs = (new dir ~label:"fs" Fs, "") in
+  let cwd = (new dir ~label:"cwd" Cwd, "") in
   object (_ : stdenv)
     method stdin  = stdin
     method stdout = stdout

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -365,12 +365,14 @@ Reading directory entries under `cwd` and outside of `cwd`.
   Path.with_open_dir (cwd / "readdir") @@ fun tmpdir ->
   try_mkdir (tmpdir / "test-1");
   try_mkdir (tmpdir / "test-2");
+  try_read_dir tmpdir;
   try_read_dir (tmpdir / ".");
   try_read_dir (tmpdir / "..");
   try_read_dir (tmpdir / "test-3");;
 +mkdir <cwd:readdir> -> ok
 +mkdir <readdir:test-1> -> ok
 +mkdir <readdir:test-2> -> ok
++read_dir <readdir> -> ["test-1"; "test-2"]
 +read_dir <readdir:.> -> ["test-1"; "test-2"]
 +Eio.Io Fs Permission_denied _, reading directory <readdir:..>
 +Eio.Io Fs Not_found _, reading directory <readdir:test-3>


### PR DESCRIPTION
`readdir (dir, ".")` worked, but `readdir (dir, "")` didn't.

Also, improve formatting of empty paths (`<cwd:>` becomes `<cwd>`).

Fixes #559 (reported by @SGrondin).