### PR TITLE
Eio_posix: fix update to watched FDs on cancel

### DIFF
--- a/eio_windows.opam
+++ b/eio_windows.opam
@@ -30,4 +30,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
-available: [os-family = "windows"]
+#available: [os-family = "windows"]

--- a/eio_windows.opam.template
+++ b/eio_windows.opam.template
@@ -1,1 +1,1 @@
-available: [os-family = "windows"]
+#available: [os-family = "windows"]


### PR DESCRIPTION
If cancelling removes the last waiter, we need to update the set of FDs being watched.

Fixes #572.

Reported by @quernd