### PR TITLE
add Eio_unix.Sockopt for setting/getting socket options

### DIFF
--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -212,7 +212,36 @@ module Sockopt = struct
     | SO_RCVTIMEO : float t
     | SO_SNDTIMEO : float t
 
+  type _ t +=
+    | TCP_CORK : bool t
+    | TCP_KEEPIDLE : int t
+    | TCP_KEEPINTVL : int t
+    | TCP_KEEPCNT : int t
+    | TCP_USER_TIMEOUT : int t
+    | TCP_MAXSEG : int t
+    | TCP_LINGER2 : int option t
+    | TCP_DEFER_ACCEPT : int t
+    | TCP_CONGESTION : string t
+    | TCP_SYNCNT : int t
+    | TCP_WINDOW_CLAMP : int t
+    | TCP_QUICKACK : bool t
+    | TCP_FASTOPEN : int t
+    | IP_FREEBIND : bool t
+    | IP_BIND_ADDRESS_NO_PORT : bool t
+    | IP_LOCAL_PORT_RANGE : (int * int) t
+    | IP_TTL : int t
+    | IP_MTU : int t
+    | IP_MTU_DISCOVER : [`Want | `Dont | `Do | `Probe] t
+
   let () =
+    let pp_mtu_discover f v =
+      Fmt.string f @@
+      match v with
+      | `Want -> "Want"
+      | `Dont -> "Dont"
+      | `Do -> "Do"
+      | `Probe -> "Probe"
+    in
     let get : type a. a t -> (string * a Fmt.t) option = function
       | SO_DEBUG -> Some ("SO_DEBUG", Fmt.bool)
       | SO_BROADCAST -> Some ("SO_BROADCAST", Fmt.bool)
@@ -230,6 +259,25 @@ module Sockopt = struct
       | SO_LINGER -> Some ("SO_LINGER", Fmt.(option ~none:(any "<none>") int))
       | SO_RCVTIMEO -> Some ("SO_RCVTIMEO", Fmt.float)
       | SO_SNDTIMEO -> Some ("SO_SNDTIMEO", Fmt.float)
+      | TCP_CORK -> Some ("TCP_CORK", Fmt.bool)
+      | TCP_KEEPIDLE -> Some ("TCP_KEEPIDLE", Fmt.int)
+      | TCP_KEEPINTVL -> Some ("TCP_KEEPINTVL", Fmt.int)
+      | TCP_KEEPCNT -> Some ("TCP_KEEPCNT", Fmt.int)
+      | TCP_USER_TIMEOUT -> Some ("TCP_USER_TIMEOUT", Fmt.int)
+      | TCP_MAXSEG -> Some ("TCP_MAXSEG", Fmt.int)
+      | TCP_LINGER2 -> Some ("TCP_LINGER2", Fmt.(option ~none:(any "<none>") int))
+      | TCP_DEFER_ACCEPT -> Some ("TCP_DEFER_ACCEPT", Fmt.int)
+      | TCP_CONGESTION -> Some ("TCP_CONGESTION", Fmt.string)
+      | TCP_SYNCNT -> Some ("TCP_SYNCNT", Fmt.int)
+      | TCP_WINDOW_CLAMP -> Some ("TCP_WINDOW_CLAMP", Fmt.int)
+      | TCP_QUICKACK -> Some ("TCP_QUICKACK", Fmt.bool)
+      | TCP_FASTOPEN -> Some ("TCP_FASTOPEN", Fmt.int)
+      | IP_FREEBIND -> Some ("IP_FREEBIND", Fmt.bool)
+      | IP_BIND_ADDRESS_NO_PORT -> Some ("IP_BIND_ADDRESS_NO_PORT", Fmt.bool)
+      | IP_LOCAL_PORT_RANGE -> Some ("IP_LOCAL_PORT_RANGE", Fmt.(Dump.pair int int))
+      | IP_TTL -> Some ("IP_TTL", Fmt.int)
+      | IP_MTU -> Some ("IP_MTU", Fmt.int)
+      | IP_MTU_DISCOVER -> Some ("IP_MTU_DISCOVER", pp_mtu_discover)
       | _ -> None
     in
     register_printer { get }

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -23,7 +23,7 @@ type error =
     (** This is a wrapper for epipe, econnreset and similar errors.
         It indicates that the flow has failed, and data may have been lost. *)
   | Connection_failure of connection_failure
-  | Invalid_option (** Option not supported by backend. *)
+  | Invalid_option (** Socket option not supported. *)
 
 type Exn.err += E of error
 
@@ -138,6 +138,11 @@ module Sockopt : sig
 
   type _ t = ..
 
+  val pp : 'a t Fmt.t
+  val pp_binding : ('a t * 'a) Fmt.t
+
+  (** {2 Common options} *)
+
   type _ t +=
     | SO_DEBUG : bool t         (** Enable socket debugging *)
     | SO_BROADCAST : bool t     (** Permit sending of broadcast messages *)
@@ -156,8 +161,74 @@ module Sockopt : sig
     | SO_RCVTIMEO : float t     (** Receive timeout *)
     | SO_SNDTIMEO : float t     (** Send timeout *)
 
-  val pp : 'a t Fmt.t
-  val pp_binding : ('a t * 'a) Fmt.t
+  (** {2 Linux-specific options} *)
+
+  type _ t +=
+    | TCP_CORK : bool t
+    (** When enabled, partial frames are not sent out.
+        Data is only sent when the option is disabled or the buffer becomes full. *)
+    | TCP_KEEPIDLE : int t
+    (** Time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes. *)
+    | TCP_KEEPINTVL : int t
+    (** Interval (in seconds) between individual keepalive probes. *)
+    | TCP_KEEPCNT : int t
+    (** Maximum number of keepalive probes TCP should send before dropping the connection. *)
+    | TCP_USER_TIMEOUT : int t
+    (** Maximum time (in milliseconds) that transmitted data may remain unacknowledged
+        before TCP will forcibly close the connection. *)
+    | TCP_MAXSEG : int t
+    (** The maximum segment size for outgoing TCP packets. If set before connection
+        establishment, it also changes the MSS value announced to the other end. *)
+    | TCP_LINGER2 : int option t
+    (** Lifetime of orphaned FIN_WAIT2 sockets, in seconds.
+
+        On set, [None] or [Some 0] requests the system default; [Some n] with
+        [n >= 0] keeps orphaned sockets in FIN_WAIT2 for [n] seconds;
+        negative values raise {!Invalid_argument}.
+
+        On get, [Some n] is the effective timeout and [None] means
+        FIN_WAIT2 lingering has been disabled. *)
+    | TCP_DEFER_ACCEPT : int t
+    (** Allow a listener to be awakened only when data arrives on the socket.
+        Value is the maximum time in seconds to wait for data. *)
+    | TCP_CONGESTION : string t
+    (** Set the TCP congestion control algorithm to be used (e.g., "cubic", "reno").
+        Unprivileged processes are restricted to algorithms in tcp_allowed_congestion_control. *)
+    | TCP_SYNCNT : int t
+    (** Set the number of SYN retransmits that TCP should send before aborting
+        the attempt to connect. Cannot exceed 255. *)
+    | TCP_WINDOW_CLAMP : int t
+    (** Bound the size of the advertised window to this value.
+        The kernel imposes a minimum size. *)
+    | TCP_QUICKACK : bool t
+    (** Enable quickack mode if set or disable if cleared. In quickack mode,
+        acks are sent immediately rather than delayed. This flag is not permanent. *)
+    | TCP_FASTOPEN : int t
+    (** Enable Fast Open (RFC 7413) on the listener socket. The value specifies
+        the maximum length of pending SYNs (similar to backlog in listen). *)
+    | IP_FREEBIND : bool t
+    (** Allow binding to an IP address that is nonlocal or does not (yet) exist.
+        This permits listening on a socket without requiring the underlying
+        network interface to be up. *)
+    | IP_BIND_ADDRESS_NO_PORT : bool t
+    (** Inform the kernel to not reserve an ephemeral port when using bind()
+        with a port number of 0. The port will be chosen at connect() time. *)
+    | IP_LOCAL_PORT_RANGE : (int * int) t
+    (** Set the per-socket local port range as (lower_bound, upper_bound).
+        Both bounds are inclusive and must be in range 0-65535.
+        Use (0, 0) to reset to system defaults. *)
+    | IP_TTL : int t
+    (** Set or retrieve the time-to-live field used in every packet sent from this socket.
+        Valid range is 1-255. *)
+    | IP_MTU : int t
+    (** Retrieve the current known path MTU of the current socket.
+        Only valid for connected sockets. This is a read-only option. *)
+    | IP_MTU_DISCOVER : [`Want | `Dont | `Do | `Probe] t
+    (** Set or receive the Path MTU Discovery setting for a socket.
+        - [`Want]: Use per-route settings (fragment if needed)
+        - [`Dont]: Never do Path MTU Discovery
+        - [`Do]: Always do Path MTU Discovery (reject large datagrams with EMSGSIZE)
+        - [`Probe]: Set DF but ignore Path MTU (for diagnostic tools) *)
 
   (** {2 Registering printers (for backend use only)} *)
 

--- a/lib_eio_linux/eio_stubs.c
+++ b/lib_eio_linux/eio_stubs.c
@@ -16,12 +16,16 @@
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
 
 // We need caml_convert_signal_number
 #define CAML_INTERNALS
 
 #include "primitives.h"
 
+#include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
@@ -244,5 +248,49 @@ CAMLprim value caml_eio_clone3(value v_errors, value v_actions) {
   Store_field(v_result, 0, Val_long(child_pid));
   Store_field(v_result, 1, Val_int(pidfd));
 
+  CAMLreturn(v_result);
+}
+
+/* Socket option stubs for Linux-specific TCP options */
+CAMLprim value caml_eio_sockopt_int_set(value v_fd, value v_level, value v_option, value v_val) {
+  CAMLparam4(v_fd, v_level, v_option, v_val);
+  int ret;
+  int val = Int_val(v_val);
+  ret = setsockopt(Int_val(v_fd), Int_val(v_level), Int_val(v_option), &val, sizeof(val));
+  if (ret == -1) uerror("setsockopt", Nothing);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value caml_eio_sockopt_int_get(value v_fd, value v_level, value v_option) {
+  CAMLparam3(v_fd, v_level, v_option);
+  int ret;
+  int val;
+  socklen_t len = sizeof(val);
+  ret = getsockopt(Int_val(v_fd), Int_val(v_level), Int_val(v_option), &val, &len);
+  if (ret == -1) uerror("getsockopt", Nothing);
+  CAMLreturn(Val_int(val));
+}
+
+/* Socket option stubs for string options (e.g. TCP_CONGESTION) */
+CAMLprim value caml_eio_sockopt_string_set(value v_fd, value v_level, value v_option, value v_val) {
+  CAMLparam4(v_fd, v_level, v_option, v_val);
+  const char *str = String_val(v_val);
+  int ret = setsockopt(Int_val(v_fd), Int_val(v_level), Int_val(v_option),
+                       str, caml_string_length(v_val));
+  if (ret == -1) uerror("setsockopt", Nothing);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value caml_eio_sockopt_string_get(value v_fd, value v_level, value v_option) {
+  CAMLparam3(v_fd, v_level, v_option);
+  CAMLlocal1(v_result);
+  char buffer[256];
+  socklen_t len = sizeof(buffer);
+  int ret = getsockopt(Int_val(v_fd), Int_val(v_level), Int_val(v_option),
+                       buffer, &len);
+  if (ret == -1) uerror("getsockopt", Nothing);
+  if (strnlen(buffer, len) == sizeof(buffer))
+    caml_invalid_argument("getsockopt: buffer was too small!");
+  v_result = caml_copy_string(buffer);
   CAMLreturn(v_result);
 }

--- a/lib_eio_linux/err.ml
+++ b/lib_eio_linux/err.ml
@@ -5,6 +5,7 @@ let wrap code name arg =
   match code with
   | ECONNREFUSED -> Eio.Net.err (Connection_failure (Refused ex))
   | ECONNRESET | EPIPE -> Eio.Net.err (Connection_reset ex)
+  | ENOPROTOOPT -> Eio.Net.err Invalid_option
   | _ -> unclassified ex
 
 let wrap_fs code name arg =

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -327,8 +327,179 @@ let recv_msg_with_fds ~sw ~max_fds fd buf =
   let fds = Uring.Msghdr.get_fds msghdr |> Fd.of_unix_list ~sw in
   addr, res, fds
 
-let setsockopt t opt v = Err.run (Eio_unix.Net.setsockopt t opt) v
-let getsockopt t opt = Err.run (Eio_unix.Net.getsockopt t) opt
+module Sockopt = struct
+  let tcp_maxseg = 2         (* TCP_MAXSEG from netinet/tcp.h *)
+  let tcp_cork = 3           (* TCP_CORK from netinet/tcp.h *)
+  let tcp_keepidle = 4       (* TCP_KEEPIDLE *)
+  let tcp_keepintvl = 5      (* TCP_KEEPINTVL *)
+  let tcp_keepcnt = 6        (* TCP_KEEPCNT *)
+  let tcp_syncnt = 7         (* TCP_SYNCNT *)
+  let tcp_linger2 = 8        (* TCP_LINGER2 *)
+  let tcp_defer_accept = 9   (* TCP_DEFER_ACCEPT *)
+  let tcp_window_clamp = 10  (* TCP_WINDOW_CLAMP *)
+  let tcp_quickack = 12      (* TCP_QUICKACK *)
+  let tcp_congestion = 13    (* TCP_CONGESTION *)
+  let tcp_user_timeout = 18  (* TCP_USER_TIMEOUT *)
+  let tcp_fastopen = 23      (* TCP_FASTOPEN *)
+  let ipproto_tcp = 6        (* IPPROTO_TCP *)
+  let ipproto_ip = 0         (* IPPROTO_IP *)
+  let ip_freebind = 15       (* IP_FREEBIND *)
+  let ip_bind_address_no_port = 24  (* IP_BIND_ADDRESS_NO_PORT *)
+  let ip_local_port_range = 51      (* IP_LOCAL_PORT_RANGE *)
+  let ip_ttl = 2             (* IP_TTL *)
+  let ip_mtu = 14            (* IP_MTU *)
+  let ip_mtu_discover = 10   (* IP_MTU_DISCOVER *)
+end
+
+external setsockopt_int : Unix.file_descr -> int -> int -> int -> unit = "caml_eio_sockopt_int_set"
+external getsockopt_int : Unix.file_descr -> int -> int -> int = "caml_eio_sockopt_int_get"
+external setsockopt_string : Unix.file_descr -> int -> int -> string -> unit = "caml_eio_sockopt_string_set"
+external getsockopt_string : Unix.file_descr -> int -> int -> string = "caml_eio_sockopt_string_get"
+
+let getsockopt_int fd opt lvl = Fd.use_exn "getsockopt_int" fd (fun fd -> Err.run (getsockopt_int fd opt) lvl)
+let getsockopt_string fd opt lvl = Fd.use_exn "getsockopt_string" fd (fun fd -> Err.run (getsockopt_string fd opt) lvl)
+
+let setsockopt_int fd opt lvl v = Fd.use_exn "setsockopt_int" fd (fun fd -> Err.run (setsockopt_int fd opt lvl) v)
+let setsockopt_string fd opt lvl v = Fd.use_exn "setsockopt_string" fd (fun fd -> Err.run (setsockopt_string fd opt lvl) v)
+
+let setsockopt : type a. Fd.t -> a Eio.Net.Sockopt.t -> a -> unit = fun fd opt v ->
+  let open Eio.Net.Sockopt in
+  let open Sockopt in
+  match opt with
+  | TCP_CORK ->
+    setsockopt_int fd ipproto_tcp tcp_cork (if v then 1 else 0)
+  | TCP_KEEPIDLE ->
+    if v < 0 then
+      Fmt.invalid_arg "TCP_KEEPIDLE must be non-negative, got %d" v;
+    setsockopt_int fd ipproto_tcp tcp_keepidle v
+  | TCP_KEEPINTVL ->
+    if v < 0 then
+      Fmt.invalid_arg "TCP_KEEPINTVL must be non-negative, got %d" v;
+    setsockopt_int fd ipproto_tcp tcp_keepintvl v
+  | TCP_KEEPCNT ->
+    if v < 0 then
+      Fmt.invalid_arg "TCP_KEEPCNT must be non-negative, got %d" v;
+    setsockopt_int fd ipproto_tcp tcp_keepcnt v
+  | TCP_USER_TIMEOUT ->
+    if v < 0 then
+      Fmt.invalid_arg "TCP_USER_TIMEOUT must be non-negative, got %d" v;
+    setsockopt_int fd ipproto_tcp tcp_user_timeout v
+  | TCP_MAXSEG ->
+    if v < 0 then
+      Fmt.invalid_arg "TCP_MAXSEG must be non-negative, got %d" v;
+    setsockopt_int fd ipproto_tcp tcp_maxseg v
+  | TCP_LINGER2 ->
+    let v = match v with
+      | None -> 0
+      | Some n when n < 0 ->
+	Fmt.invalid_arg "TCP_LINGER2 must be non-negative, got %d" n
+      | Some n -> n
+    in
+    setsockopt_int fd ipproto_tcp tcp_linger2 v
+  | TCP_DEFER_ACCEPT ->
+    if v < 0 then
+      Fmt.invalid_arg "TCP_DEFER_ACCEPT must be non-negative, got %d" v;
+    setsockopt_int fd ipproto_tcp tcp_defer_accept v
+  | TCP_CONGESTION ->
+    setsockopt_string fd ipproto_tcp tcp_congestion v
+  | TCP_SYNCNT ->
+    if v < 1 || v > 255 then
+      Fmt.invalid_arg "TCP_SYNCNT must be between 1 and 255, got %d" v;
+    setsockopt_int fd ipproto_tcp tcp_syncnt v
+  | TCP_WINDOW_CLAMP ->
+    if v < 0 then
+      Fmt.invalid_arg "TCP_WINDOW_CLAMP must be non-negative, got %d" v;
+    setsockopt_int fd ipproto_tcp tcp_window_clamp v
+  | TCP_QUICKACK ->
+    setsockopt_int fd ipproto_tcp tcp_quickack (if v then 1 else 0)
+  | TCP_FASTOPEN ->
+    if v < 0 then
+      Fmt.invalid_arg "TCP_FASTOPEN queue length must be non-negative, got %d" v;
+    setsockopt_int fd ipproto_tcp tcp_fastopen v
+  | IP_FREEBIND ->
+    setsockopt_int fd ipproto_ip ip_freebind (if v then 1 else 0)
+  | IP_BIND_ADDRESS_NO_PORT ->
+    setsockopt_int fd ipproto_ip ip_bind_address_no_port (if v then 1 else 0)
+  | IP_LOCAL_PORT_RANGE ->
+    let (lower, upper) = v in
+    if lower < 0 || lower > 65535 then
+      Fmt.invalid_arg "IP_LOCAL_PORT_RANGE lower bound must be 0-65535, got %d" lower;
+    if upper < 0 || upper > 65535 then
+      Fmt.invalid_arg "IP_LOCAL_PORT_RANGE upper bound must be 0-65535, got %d" upper;
+    if lower <> 0 && upper <> 0 && lower > upper then
+      Fmt.invalid_arg "IP_LOCAL_PORT_RANGE lower bound (%d) must be <= upper bound (%d)" lower upper;
+    let combined = (upper lsl 16) lor lower in
+    setsockopt_int fd ipproto_ip ip_local_port_range combined
+  | IP_TTL ->
+    if v < 1 || v > 255 then
+      Fmt.invalid_arg "IP_TTL must be between 1 and 255, got %d" v;
+    setsockopt_int fd ipproto_ip ip_ttl v
+  | IP_MTU ->
+    invalid_arg "IP_MTU is a read-only socket option"
+  | IP_MTU_DISCOVER ->
+    let i = match v with
+      | `Dont -> 0
+      | `Want -> 1
+      | `Do -> 2
+      | `Probe -> 3 in
+    setsockopt_int fd ipproto_ip ip_mtu_discover i
+  | _ -> Eio_unix.Net.setsockopt fd opt v
+
+let getsockopt : type a. Fd.t -> a Eio.Net.Sockopt.t -> a = fun fd opt ->
+  let open Sockopt in
+  let open Eio.Net.Sockopt in
+  match opt with
+  | TCP_CORK ->
+    getsockopt_int fd ipproto_tcp tcp_cork <> 0
+  | TCP_KEEPIDLE ->
+    getsockopt_int fd ipproto_tcp tcp_keepidle
+  | TCP_KEEPINTVL ->
+    getsockopt_int fd ipproto_tcp tcp_keepintvl
+  | TCP_KEEPCNT ->
+    getsockopt_int fd ipproto_tcp tcp_keepcnt
+  | TCP_USER_TIMEOUT ->
+    getsockopt_int fd ipproto_tcp tcp_user_timeout
+  | TCP_MAXSEG ->
+    getsockopt_int fd ipproto_tcp tcp_maxseg
+  | TCP_LINGER2 ->
+    let v = getsockopt_int fd ipproto_tcp tcp_linger2 in
+    if v < 0 then None else Some v
+  | TCP_DEFER_ACCEPT ->
+    getsockopt_int fd ipproto_tcp tcp_defer_accept
+  | TCP_CONGESTION ->
+    getsockopt_string fd ipproto_tcp tcp_congestion
+  | TCP_SYNCNT ->
+    getsockopt_int fd ipproto_tcp tcp_syncnt
+  | TCP_WINDOW_CLAMP ->
+    getsockopt_int fd ipproto_tcp tcp_window_clamp
+  | TCP_QUICKACK ->
+    getsockopt_int fd ipproto_tcp tcp_quickack <> 0
+  | TCP_FASTOPEN ->
+    getsockopt_int fd ipproto_tcp tcp_fastopen
+  | IP_FREEBIND ->
+    getsockopt_int fd ipproto_ip ip_freebind <> 0
+  | IP_BIND_ADDRESS_NO_PORT ->
+    getsockopt_int fd ipproto_ip ip_bind_address_no_port <> 0
+  | IP_LOCAL_PORT_RANGE ->
+    let combined = getsockopt_int fd ipproto_ip ip_local_port_range in
+    let lower = combined land 0xFFFF in
+    let upper = (combined lsr 16) land 0xFFFF in
+    (lower, upper)
+  | IP_TTL ->
+    getsockopt_int fd ipproto_ip ip_ttl
+  | IP_MTU ->
+    getsockopt_int fd ipproto_ip ip_mtu
+  | IP_MTU_DISCOVER ->
+    begin
+      let i = getsockopt_int fd ipproto_ip ip_mtu_discover in
+      match i with
+      | 0 (* IP_PMTUDISC_DONT *)  -> `Dont
+      | 1 (* IP_PMTUDISC_WANT *)  -> `Want
+      | 2 (* IP_PMTUDISC_DO *)    -> `Do
+      | 3 (* IP_PMTUDISC_PROBE *) -> `Probe
+      | i -> Fmt.failwith "Unknown IP_MTU_DISCOVER value: %d" i
+    end
+  | _ -> Eio_unix.Net.getsockopt fd opt
 
 let rec openat2 ~sw ?seekable ~access ~flags ~perm ~resolve ?dir path =
   let use dir_opt =

--- a/lib_eio_linux/primitives.h
+++ b/lib_eio_linux/primitives.h
@@ -3,6 +3,10 @@
 #define _GNU_SOURCE
 #include <caml/mlvalues.h>
 CAMLprim value caml_eio_eventfd(value);
+CAMLprim value caml_eio_sockopt_int_set(value, value, value, value);
+CAMLprim value caml_eio_sockopt_int_get(value, value, value);
+CAMLprim value caml_eio_sockopt_string_set(value, value, value, value);
+CAMLprim value caml_eio_sockopt_string_get(value, value, value);
 CAMLprim value caml_eio_mkdirat(value, value, value);
 CAMLprim value caml_eio_renameat(value, value, value, value);
 CAMLprim value caml_eio_symlinkat(value, value, value);

--- a/lib_eio_linux/tests/network.md
+++ b/lib_eio_linux/tests/network.md
@@ -1,0 +1,201 @@
+# Linux-specific networking tests
+
+```ocaml
+# #require "eio_linux";;
+# #require "eio.unix";;
+# open Eio.Std;;
+```
+
+```ocaml
+let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, 0)
+
+module Sockopt = Eio.Net.Sockopt
+
+let try_getsockopt sock opt =
+  match Eio.Net.getsockopt sock opt with
+  | v -> traceln "%a" Eio.Net.Sockopt.pp_binding (opt, v)
+  | exception ex -> traceln "%a -> %a" Eio.Net.Sockopt.pp opt Fmt.exn ex
+
+let try_setsockopt ?(skip_ok=false) sock opt v : unit =
+  match Eio.Net.setsockopt sock opt v with
+  | () -> try_getsockopt sock opt
+  | exception Eio.Io (Eio.Net.E Invalid_option, _) when skip_ok ->
+    traceln "%a" Eio.Net.Sockopt.pp_binding (opt, v)
+  | exception (Unix.Unix_error(Unix.EINVAL, "setsockopt", _)) ->
+    traceln "%a -> EINVAL" Eio.Net.Sockopt.pp_binding (opt, v)
+  | exception (Invalid_argument msg) ->
+    traceln "%a -> Invalid_argument %s" Eio.Net.Sockopt.pp_binding (opt, v) msg
+```
+
+## Getting and setting socket options
+
+Set the TCP congestion-control algorithm and read it back. "reno" is always
+available, so the round-trip is deterministic; the value is returned without the
+kernel's NUL padding, so we get back exactly what was set:
+
+```ocaml
+# Eio_linux.run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let server = Eio.Net.listen env#net ~sw ~reuse_addr:true ~backlog:1 addr in
+  try_setsockopt server Sockopt.TCP_CONGESTION "reno";;
++TCP_CONGESTION = reno
+- : unit = ()
+```
+
+## Linux-specific TCP socket options
+
+Test Linux-specific TCP socket options:
+
+```ocaml
+# Eio_linux.run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let net = env#net in
+  let listen_sock = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:5 addr in
+  let listening_addr = Eio.Net.listening_addr listen_sock in
+  (* Test TCP_DEFER_ACCEPT on listening socket *)
+  Eio.Net.setsockopt listen_sock Sockopt.TCP_DEFER_ACCEPT 5;
+  let defer = Eio.Net.getsockopt listen_sock Sockopt.TCP_DEFER_ACCEPT in
+  traceln "TCP_DEFER_ACCEPT on listening socket: %s" (if defer > 0 then "enabled" else "disabled");
+
+  (* Create a TCP connection for other tests *)
+  let client = Eio.Net.connect ~sw net listening_addr in
+
+  try_setsockopt client Sockopt.TCP_CORK true;
+  try_setsockopt client Sockopt.TCP_CORK false;
+  try_setsockopt client Sockopt.TCP_KEEPIDLE 60;
+  try_setsockopt client Sockopt.TCP_KEEPINTVL 10;
+  try_setsockopt client Sockopt.TCP_KEEPCNT 5;
+  try_setsockopt client Sockopt.TCP_LINGER2 (Some 110);
+
+  (*
+  try_getsockopt client Sockopt.TCP_CONGESTION;
+  (* Try to set cubic if available - may fail based on system config *)
+  (try
+    try_setsockopt client Sockopt.TCP_CONGESTION "cubic";
+  with _ ->
+    traceln "Could not change TCP_CONGESTION (normal for unprivileged)");
+  *)
+
+  try_setsockopt client Sockopt.TCP_QUICKACK true;
+  try_setsockopt client Sockopt.TCP_SYNCNT 42;
+  try_setsockopt client Sockopt.TCP_WINDOW_CLAMP 32768;
+
+  Eio.Flow.close client;;
++TCP_DEFER_ACCEPT on listening socket: enabled
++TCP_CORK = true
++TCP_CORK = false
++TCP_KEEPIDLE = 60
++TCP_KEEPINTVL = 10
++TCP_KEEPCNT = 5
++TCP_LINGER2 = 110
++TCP_QUICKACK = true
++TCP_SYNCNT = 42
++TCP_WINDOW_CLAMP = 32768
+- : unit = ()
+```
+
+Test additional Linux socket options:
+
+```ocaml
+# Eio_linux.run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let net = env#net in
+  (* Test TCP_FASTOPEN on listening socket *)
+  let listen_sock = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:5 addr in
+  let listening_addr = Eio.Net.listening_addr listen_sock in
+  try_setsockopt listen_sock Sockopt.TCP_FASTOPEN 5;
+  (* TODO avsm: implement client support to test this properly *)
+  (* Test IP options with connection *)
+  let client_sock = Eio.Net.connect ~sw net listening_addr in
+  try_setsockopt client_sock Sockopt.IP_FREEBIND true;
+  try_setsockopt client_sock Sockopt.IP_BIND_ADDRESS_NO_PORT true;
+  Eio.Flow.close client_sock;;
++TCP_FASTOPEN = 5
++IP_FREEBIND = true
++IP_BIND_ADDRESS_NO_PORT = true
+- : unit = ()
+```
+
+## Socket option validation tests
+
+Test that invalid values are rejected properly:
+
+```ocaml
+# Eio_linux.run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let net = env#net in
+
+  (* Create a TCP socket for testing *)
+  let listen_sock = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:5 addr in
+  let listening_addr = Eio.Net.listening_addr listen_sock in
+
+  let client = Eio.Net.connect ~sw net listening_addr in
+
+  try_setsockopt client Sockopt.TCP_SYNCNT 256;
+  try_setsockopt client Sockopt.TCP_SYNCNT (-1);
+  try_setsockopt client Sockopt.TCP_SYNCNT 0;
+
+  (* Valid TCP_SYNCNT values should work *)
+  try_setsockopt client Sockopt.TCP_SYNCNT 3;
+  try_setsockopt client Sockopt.TCP_SYNCNT 6;
+
+  try_setsockopt client Sockopt.TCP_KEEPIDLE (-1);
+  try_setsockopt client Sockopt.TCP_WINDOW_CLAMP (-100);
+
+  try_setsockopt client Sockopt.TCP_LINGER2 (Some (-2));
+  Eio.Net.setsockopt client Sockopt.TCP_LINGER2 None;
+  traceln "TCP_LINGER2 accepts None for system default";
+
+  try_setsockopt client Sockopt.IP_TTL 64;
+  try_setsockopt client Sockopt.IP_TTL 0;
+  try_setsockopt client Sockopt.IP_TTL 256;
+
+  try_setsockopt client Sockopt.IP_MTU_DISCOVER `Dont;
+
+  (* Test IP_MTU (read-only, should work on connected socket) *)
+  try_getsockopt client Sockopt.IP_MTU;
+
+  (* Test that IP_MTU cannot be set *)
+  try_setsockopt client Sockopt.IP_MTU 1500;
+
+  (* Test IP_LOCAL_PORT_RANGE validation *)
+  (* Lower bound > upper bound *)
+  try_setsockopt client Sockopt.IP_LOCAL_PORT_RANGE (2000, 1000);
+
+  (* Test out of range port values *)
+  try_setsockopt client Sockopt.IP_LOCAL_PORT_RANGE (40000, 70000);
+
+  (* For IP_LOCAL_PORT_RANGE we allow skipping since its >6.3 Linux only *)
+  (* Valid port range should work *)
+  try_setsockopt client Sockopt.IP_LOCAL_PORT_RANGE (40000, 50000)
+    ~skip_ok:true;
+
+  (* Reset to system default *)
+  (try
+    Eio.Net.setsockopt client Sockopt.IP_LOCAL_PORT_RANGE (0, 0)
+   with Eio.Io (Eio.Net.E Invalid_option, _) -> ()
+  );
+  traceln "IP_LOCAL_PORT_RANGE reset";
+
+  Eio.Flow.close client;;
++TCP_SYNCNT = 256 -> Invalid_argument TCP_SYNCNT must be between 1 and 255, got 256
++TCP_SYNCNT = -1 -> Invalid_argument TCP_SYNCNT must be between 1 and 255, got -1
++TCP_SYNCNT = 0 -> Invalid_argument TCP_SYNCNT must be between 1 and 255, got 0
++TCP_SYNCNT = 3
++TCP_SYNCNT = 6
++TCP_KEEPIDLE = -1 -> Invalid_argument TCP_KEEPIDLE must be non-negative, got -1
++TCP_WINDOW_CLAMP = -100 -> Invalid_argument TCP_WINDOW_CLAMP must be non-negative, got -100
++TCP_LINGER2 = -2 -> Invalid_argument TCP_LINGER2 must be non-negative, got -2
++TCP_LINGER2 accepts None for system default
++IP_TTL = 64
++IP_TTL = 0 -> Invalid_argument IP_TTL must be between 1 and 255, got 0
++IP_TTL = 256 -> Invalid_argument IP_TTL must be between 1 and 255, got 256
++IP_MTU_DISCOVER = Dont
++IP_MTU = 65535
++IP_MTU = 1500 -> Invalid_argument IP_MTU is a read-only socket option
++IP_LOCAL_PORT_RANGE = (2000, 1000) -> Invalid_argument IP_LOCAL_PORT_RANGE lower bound (2000) must be <= upper bound (1000)
++IP_LOCAL_PORT_RANGE = (40000, 70000) -> Invalid_argument IP_LOCAL_PORT_RANGE upper bound must be 0-65535, got 70000
++IP_LOCAL_PORT_RANGE = (40000, 50000)
++IP_LOCAL_PORT_RANGE reset
+- : unit = ()
+```


### PR DESCRIPTION
There are some socket options that are Linux-specific which are quite handy to have.  This adds a Eio_unix.Sockopt module which works on Eio_unix.Fd.t values.

This is a draft PR to check on the interface: the current PR replaces the need for Unix.setsockopt and has a single simple GADT for the socket options.  Alternatively we could just expose the extended ones in the same style as upstream OCaml as a separate set of types, too.  Opinions welcome.
