### PR TITLE
Simplify dune files with dune 3.9's build_if

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.9)
 (name eio)
 (formatting disabled)
 (generate_opam_files true)

--- a/eio.opam
+++ b/eio.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
-  "dune" {>= "3.7"}
+  "dune" {>= "3.9"}
   "ocaml" {>= "5.0.0"}
   "bigstringaf" {>= "0.9.0"}
   "cstruct" {>= "6.0.1"}

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
-  "dune" {>= "3.7"}
+  "dune" {>= "3.9"}
   "alcotest" {>= "1.4.0" & with-test}
   "eio" {= version}
   "mdx" {>= "2.2.0" & with-test}

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
-  "dune" {>= "3.7"}
+  "dune" {>= "3.9"}
   "mdx" {>= "2.2.0" & with-test}
   "kcas" {>= "0.3.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}

--- a/eio_posix.opam
+++ b/eio_posix.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
-  "dune" {>= "3.7"}
+  "dune" {>= "3.9"}
   "eio" {= version}
   "iomux" {>= "0.2"}
   "mdx" {>= "2.2.0" & with-test}

--- a/eio_windows.opam
+++ b/eio_windows.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-multicore/eio"
 doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
-  "dune" {>= "3.7"}
+  "dune" {>= "3.9"}
   "eio" {= version}
   "kcas" {>= "0.3.0" & with-test}
   "alcotest" {>= "1.4.0" & with-test}

--- a/lib_eio_linux/tests/dune
+++ b/lib_eio_linux/tests/dune
@@ -1,9 +1,3 @@
-(* -*- tuareg -*- *)
-
-let linux = List.mem ("system", "linux") Jbuild_plugin.V1.ocamlc_config
-
-let () = Jbuild_plugin.V1.send @@ if not linux then "" else {|
-
 (library
  (name eurcp_lib)
  (enabled_if (= %{system} "linux"))
@@ -31,7 +25,7 @@ let () = Jbuild_plugin.V1.send @@ if not linux then "" else {|
 (test
  (name test)
  (package eio_linux)
- (enabled_if (= %{system} "linux"))
+ (build_if (= %{system} "linux"))
  (modules test)
  (libraries alcotest eio_linux))
 
@@ -39,5 +33,3 @@ let () = Jbuild_plugin.V1.send @@ if not linux then "" else {|
   (package eio_linux)
   (enabled_if (= %{system} "linux"))
   (deps (package eio_linux)))
-
-|}

--- a/lib_eio_windows/test/dune
+++ b/lib_eio_windows/test/dune
@@ -1,13 +1,5 @@
-(* -*- tuareg -*- *)
-
-let win32 = List.mem ("os_type", "Win32") Jbuild_plugin.V1.ocamlc_config
-
-let () = Jbuild_plugin.V1.send @@ if not win32 then "" else {|
-
 (test
   (name test)
   (package eio_windows)
-  (enabled_if (= %{os_type} "Win32"))
+  (build_if (= %{os_type} "Win32"))
   (libraries alcotest kcas eio.mock eio_windows))
-
-|}


### PR DESCRIPTION
This removes the work-around added in #475.