### PR TITLE
Add `Process.run ?is_success` to control definition of success

### DIFF
--- a/tests/process.md
+++ b/tests/process.md
@@ -148,6 +148,28 @@ Eio.Io Process Child_error Exited (code 3),
   running command: bash -c "exit 3" "" foo
 ```
 
+Exit code success can be determined by is_success (Process.run):
+
+```ocaml
+# run @@ fun mgr env ->
+  Process.run ~is_success:(Int.equal 3) mgr ["bash"; "-c"; "exit 3"];;
+- : unit = ()
+
+# run @@ fun mgr env ->
+  Process.run ~is_success:(Int.equal 3) mgr ["bash"; "-c"; "exit 0"];;
+Exception:
+Eio.Io Process Child_error Exited (code 0),
+  running command: bash -c "exit 0"
+```
+
+Exit code success can be determined by is_success (Process.parse_out):
+
+```ocaml
+# run @@ fun mgr env ->
+  Process.parse_out ~is_success:(Int.equal 5) mgr Eio.Buf_read.line ["sh"; "-c"; "echo 123; exit 5"];;
+- : string = "123"
+```
+
 The default environment:
 
 ```ocaml


### PR DESCRIPTION
## Motivation

Some programs (ab)use exit codes in unconventional ways.

As an example I recently ran into: the `npm outdated` command checks a project's NPM dependencies and prints a status report (outdated, deprecations, etc).

But the exit code is 1 if any dependencies are in need of an update! While it **successfully** generated a status report, it still returned `1`. Different return codes may indicate "true failures". I disagree with the design of this command, I'm [not the only one](https://github.com/npm/rfcs/issues/473) and [it's causing issues](https://github.com/nodejs/help/issues/4188).

Regardless, this command is far from alone. Plenty of other programs behave in a similar way. Also, I may want to consider certain exit codes to be errors/success _depending_ on the `stdout` output of the command, for example.

## Suggestion

I suggest adding the following optional argument to `Eio.Process.run`: `?is_success:(int -> bool)`

Since it runs after the process has exited, the user is able to inspect the output of `stdout` and `stderr` to make a decision.

> #### But why not just call `Eio.Process.spawn` instead?

`Eio.Process.run` is a nicer interface, I wouldn't want to lose on (or have to recreate its) error handling. Most importantly though, `Process.spawn` is a leaky abstraction while `Process.run` is not. I don't have to stop and dig into Eio internals to use `Process.run`, I can quickly invoke it without breaking mental focus.

Adding `is_success` minimizes the number of use cases that require `Process.spawn` and (in my opinion) is a nice addition to `Process.run` that doesn't significantly increase complexity for the users nor maintainers.

<sub>PR suggestions > Issue suggestions, am I right? 😄 </sub>