### PR TITLE
DRAFT: Sync stream select

### DIFF
--- a/bench/bench_select.ml
+++ b/bench/bench_select.ml
@@ -3,48 +3,54 @@ open Eio.Stdenv
 open Eio
 module Sync = Eio__Sync
 
-let sender_fibers = 10
+let sender_fibers = 2
 
 let message = 1234
 
-let sender ~id ~n_msgs stream =
-  for i = 1 to n_msgs do
-    traceln "Sent message #%d from %d" i id;
-    Sync.put stream message
-  done
+(* Send [n_msgs] items to streams in a round-robin way. *)
+let sender ~n_msgs streams =
+  let msgs = Seq.take n_msgs (Seq.ints 0) in
+  let streams = Seq.cycle (List.to_seq streams) in
+  let zipped = Seq.zip msgs streams in
+  ignore (Seq.iter (fun (_i, stream) ->
+      Sync.put stream message) zipped)
 
-(* Start one sender fiber for each stream, and let it send n_msgs messages. *)
+(* Start one sender fiber for each stream, and let it send n_msgs messages.
+   Each fiber sends to all streams in a round-robin way. *)
 let run_senders ~dom_mgr ?(n_msgs = 100) streams =
-  let count = ref 0 in
   Switch.run @@ fun sw ->
-    ignore @@ List.map (fun stream ->
+  ignore @@ List.iter (fun _stream ->
       Fiber.fork ~sw (fun () ->
-        let id = !count in
-        count := !count + 1;
-        Domain_manager.run dom_mgr (fun () ->
-          sender ~id ~n_msgs stream))) streams
+          Domain_manager.run dom_mgr (fun () ->
+              sender ~n_msgs streams))) streams
 
+(* Receive messages from all streams. *)
 let receiver ~n_msgs streams =
-  for i = 1 to n_msgs do
+  for _i = 1 to n_msgs do
     assert (Int.equal message (Sync.select_of_many streams));
-    traceln "Received message #%d" i
   done
 
+(* Create [n] streams. *)
 let make_streams n =
   let unfolder i = if i == 0 then None else Some (Sync.create (), i-1) in
   let seq = Seq.unfold unfolder n in
   List.of_seq seq
 
-(* Currently fails with exception from ocaml-uring/lib/uring/uring.ml:326
-    https://github.com/ocaml-multicore/ocaml-uring/blob/07482dae72c8e977e4e4e2b2c8bd137e770ee1dd/lib/uring/uring.ml#L327
-*)
 let run env =
   let dom_mgr = domain_mgr env in
+  let clock = clock env in
   let streams = make_streams sender_fibers in
-  let n_msgs = 50 in
+  let n_msgs = 10000 in
   Switch.run @@ fun sw ->
-    Fiber.fork ~sw (fun () -> run_senders ~dom_mgr ~n_msgs streams);
-    receiver ~n_msgs:(sender_fibers * n_msgs) streams;
-    []
+  Fiber.fork ~sw (fun () -> run_senders ~dom_mgr ~n_msgs streams);
+  let before = Time.now clock in
+  receiver ~n_msgs:(sender_fibers * n_msgs) streams;
+  let after = Time.now clock in
+  let elapsed = after -. before in
+  let time_per_iter = elapsed /. (Float.of_int @@ sender_fibers * n_msgs) in
+  [Metric.create
+     (Printf.sprintf "sync:true senders:%d msgs_per_sender:%d" sender_fibers n_msgs)
+     (`Float (1e9 *. time_per_iter)) "ns"
+     "Time per transmitted int"]
 
 

--- a/bench/bench_select.ml
+++ b/bench/bench_select.ml
@@ -1,0 +1,46 @@
+
+open Eio.Stdenv
+open Eio
+module Sync = Eio__Sync
+
+let sender_fibers = 10
+
+let message = 1234
+
+let sender ~id ~n_msgs stream =
+  for i = 1 to n_msgs do
+    traceln "Sent message #%d from %d" i id;
+    Sync.put stream message
+  done
+
+(* Start one sender fiber for each stream, and let it send n_msgs messages. *)
+let run_senders ~dom_mgr ?(n_msgs = 100) streams =
+  let count = ref 0 in
+  Switch.run @@ fun sw ->
+    ignore @@ List.map (fun stream ->
+      Fiber.fork ~sw (fun () ->
+        let id = !count in
+        count := !count + 1;
+        Domain_manager.run dom_mgr (fun () -> sender ~id ~n_msgs stream))) streams
+
+let receiver ~n_msgs streams =
+  for i = 1 to n_msgs do
+    assert (Int.equal message (Sync.select_of_many streams));
+    traceln "Received message #%d" i
+  done
+
+let make_streams n =
+  let unfolder i = if i == 0 then None else Some (Sync.create (), i-1) in
+  let seq = Seq.unfold unfolder n in
+  List.of_seq seq
+
+let run env =
+  let dom_mgr = domain_mgr env in
+  let streams = make_streams sender_fibers in
+  let n_msgs = 50 in
+  Switch.run @@ fun sw ->
+    Fiber.fork ~sw (fun () -> run_senders ~dom_mgr ~n_msgs streams);
+    receiver ~n_msgs:(sender_fibers * n_msgs) streams;
+    []
+
+

--- a/bench/bench_select.ml
+++ b/bench/bench_select.ml
@@ -40,11 +40,12 @@ let run env =
   let dom_mgr = domain_mgr env in
   let clock = clock env in
   let streams = make_streams sender_fibers in
+  let selector = List.map (fun s -> (s, fun i -> i)) streams in
   let n_msgs = 10000 in
   Switch.run @@ fun sw ->
   Fiber.fork ~sw (fun () -> run_senders ~dom_mgr ~n_msgs streams);
   let before = Time.now clock in
-  receiver ~n_msgs:(sender_fibers * n_msgs) streams;
+  receiver ~n_msgs:(sender_fibers * n_msgs) selector;
   let after = Time.now clock in
   let elapsed = after -. before in
   let time_per_iter = elapsed /. (Float.of_int @@ sender_fibers * n_msgs) in

--- a/bench/bench_select.ml
+++ b/bench/bench_select.ml
@@ -21,7 +21,8 @@ let run_senders ~dom_mgr ?(n_msgs = 100) streams =
       Fiber.fork ~sw (fun () ->
         let id = !count in
         count := !count + 1;
-        Domain_manager.run dom_mgr (fun () -> sender ~id ~n_msgs stream))) streams
+        Domain_manager.run dom_mgr (fun () ->
+          sender ~id ~n_msgs stream))) streams
 
 let receiver ~n_msgs streams =
   for i = 1 to n_msgs do
@@ -34,6 +35,9 @@ let make_streams n =
   let seq = Seq.unfold unfolder n in
   List.of_seq seq
 
+(* Currently fails with exception from ocaml-uring/lib/uring/uring.ml:326
+    https://github.com/ocaml-multicore/ocaml-uring/blob/07482dae72c8e977e4e4e2b2c8bd137e770ee1dd/lib/uring/uring.ml#L327
+*)
 let run env =
   let dom_mgr = domain_mgr env in
   let streams = make_streams sender_fibers in

--- a/bench/bench_select_sync.ml
+++ b/bench/bench_select_sync.ml
@@ -3,7 +3,7 @@ open Eio.Stdenv
 open Eio
 module Sync = Eio__Sync
 
-let sender_fibers = 2
+let sender_fibers = 4
 
 let message = 1234
 

--- a/lib_eio/sync.ml
+++ b/lib_eio/sync.ml
@@ -456,7 +456,7 @@ let select_of_many (type a) (ts: a t list) =
         let v = consumer_resume_cell t cell
             ~success:(fun it -> it.kp (Ok true); it.v)
             ~in_transition:(fun cell ->
-                (* TODO: Nested suspend - check if this works as planned.*)
+                (* TODO: this fails with an exception as the Suspend effect is unhandled! *)
                 Suspend.enter_unchecked (fun _ctx enqueue' ->
                     let kc v = enqueue' (Ok v); true in
                     add_to_cell t.producers (Slot kc) cell

--- a/lib_eio/sync.mli
+++ b/lib_eio/sync.mli
@@ -50,3 +50,6 @@ val balance : 'a t -> int
 
 val dump : 'a t Fmt.t
 (** [dump] formats the internal state of a channel, for testing and debugging. *)
+
+val select_of_many : 'a t list -> 'a
+(** alpha: [select_of_many] returns an element from the first sync stream to yield an item. *)

--- a/lib_eio/sync.mli
+++ b/lib_eio/sync.mli
@@ -51,5 +51,5 @@ val balance : 'a t -> int
 val dump : 'a t Fmt.t
 (** [dump] formats the internal state of a channel, for testing and debugging. *)
 
-val select_of_many : 'a t list -> 'a
+val select_of_many : ('a t * ('a -> 'b)) list -> 'b
 (** alpha: [select_of_many] returns an element from the first sync stream to yield an item. *)

--- a/tests/stream.md
+++ b/tests/stream.md
@@ -366,10 +366,12 @@ API, which is usually not exposed.
 module Sy = Eio__Sync
 # run @@ fun () -> Switch.run (fun sw ->
         let t1, t2 = (Sy.create ()), (Sy.create ()) in
+        let identity x = x in
+        let selector = [(t1, identity); (t2, identity)] in
         Fiber.fork ~sw (fun () -> Sy.put t2 "foo");
-        Fiber.fork ~sw (fun () -> traceln "%s" (Sy.select_of_many [t1; t2]));
-        Fiber.fork ~sw (fun () -> traceln "%s" (Sy.select_of_many [t1; t2]));
-        Fiber.fork ~sw (fun () -> traceln "%s" (Sy.select_of_many [t1; t2]));
+        Fiber.fork ~sw (fun () -> traceln "%s" (Sy.select_of_many selector));
+        Fiber.fork ~sw (fun () -> traceln "%s" (Sy.select_of_many selector));
+        Fiber.fork ~sw (fun () -> traceln "%s" (Sy.select_of_many selector));
         Fiber.fork ~sw (fun () -> Sy.put t2 "bar");
         Fiber.fork ~sw (fun () -> Sy.put t1 "baz");
         )

--- a/tests/stream.md
+++ b/tests/stream.md
@@ -357,3 +357,24 @@ Non-blocking take with zero-capacity stream:
 +Got None from stream
 - : unit = ()
 ```
+
+Selecting from multiple sync (0-capacity) channels. Note that this works on the internal
+API, which is usually not exposed.
+
+```ocaml
+# module Sy = Eio__Sync
+module Sy = Eio__Sync
+# run @@ fun () -> Switch.run (fun sw ->
+        let t1, t2 = (Sy.create ()), (Sy.create ()) in
+        Fiber.fork ~sw (fun () -> Sy.put t2 "foo");
+        Fiber.fork ~sw (fun () -> traceln "%s" (Sy.select_of_many [t1; t2]));
+        Fiber.fork ~sw (fun () -> traceln "%s" (Sy.select_of_many [t1; t2]));
+        Fiber.fork ~sw (fun () -> traceln "%s" (Sy.select_of_many [t1; t2]));
+        Fiber.fork ~sw (fun () -> Sy.put t2 "bar");
+        Fiber.fork ~sw (fun () -> Sy.put t1 "baz");
+        )
++foo
++bar
++baz
+- : unit = ()
+```


### PR DESCRIPTION
This is a work in progress for an implementation of `select_of_many` with the same type as the one in #585 in the `Stream.Locking` module. At some point, both implementations would need to be unified so that a mix of locking and sync streams can be selected from.

I added a simple benchmark script which exercises the logic from multiple domains (although just one fiber calling `select` at the moment). It helped find one bug already. The time-per-item is at about 4-5 µs on my machine; in comparison, the Stream benchmark for sending items on a single stream takes 4.5 µs for the same number of domains -- i.e., it takes about the same time.

Overall I've had the feeling that some approaches I've used might be controversial (eg., a spinning wait on `In_transition` cells). Also, the code is not in the nicest shape yet, it probably can be decomposed into smaller functions. I'd mainly like to hear some feedback if this is a viable route to go, like in #585. In any case, I hope my dabbling around doesn't cause too much annoyance to you all :-)