### PR TITLE
Add Flow.read_all

### DIFF
--- a/lib_eio/eio.ml
+++ b/lib_eio/eio.ml
@@ -12,8 +12,13 @@ module Lazy = Lazy
 module Pool = Pool
 module Exn = Exn
 module Resource = Resource
-module Flow = Flow
 module Buf_read = Buf_read
+module Flow = struct
+  include Flow
+
+  let read_all flow =
+    Buf_read.(parse_exn take_all) flow ~max_size:max_int
+end
 module Buf_write = Buf_write
 module Net = Net
 module Process = Process

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -60,7 +60,12 @@ module Std = Std
 module Resource = Resource
 
 (** Byte streams. *)
-module Flow = Flow
+module Flow : sig
+  include module type of Flow
+
+  val read_all : _ source -> string
+  (** [read_all src] is a convenience wrapper to read an entire flow efficiently. *)
+end
 
 (** Buffered input and parsing *)
 module Buf_read = Buf_read

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -61,10 +61,14 @@ module Resource = Resource
 
 (** Byte streams. *)
 module Flow : sig
-  include module type of Flow
+  include module type of Flow (** @inline *)
+
+  (** {2 Convenience wrappers} *)
 
   val read_all : _ source -> string
-  (** [read_all src] is a convenience wrapper to read an entire flow efficiently. *)
+  (** [read_all src] is a convenience wrapper to read an entire flow.
+
+      It is the same as [Buf_read.(parse_exn take_all) src ~max_size:max_int] *)
 end
 
 (** Buffered input and parsing *)

--- a/tests/buf_reader.md
+++ b/tests/buf_reader.md
@@ -241,7 +241,8 @@ Exception: End_of_file.
 
 ```ocaml
 # let bflow = R.of_flow mock_flow ~max_size:100 |> R.as_flow;;
-val bflow : Eio.Flow.source_ty Eio.Std.r = Eio__.Resource.T (<poly>, <abstr>)
+val bflow : Eio__Flow.source_ty Eio.Std.r =
+  Eio__.Resource.T (<poly>, <abstr>)
 # next := ["foo"; "bar"]; read bflow 2;;
 +mock_flow returning 3 bytes
 +Read "fo"

--- a/tests/flow.md
+++ b/tests/flow.md
@@ -108,6 +108,22 @@ Copying from src using `Read_source_buffer`:
 - : unit = ()
 ```
 
+## read_all
+
+```ocaml
+# run @@ fun () ->
+  let each = String.init 256 Char.chr in
+  let data = List.init 40 (fun _ -> Cstruct.of_string each) in
+  let got = Eio.Flow.read_all (mock_source data) in
+  traceln "Input length: %d\nOutput length: %d\nEqual: %b"
+    (Cstruct.lenv data) (String.length got) (String.equal got (Cstruct.copyv data));
+  ;;
++Input length: 10240
++Output length: 10240
++Equal: true
+- : unit = ()
+```
+
 ## write
 
 ```ocaml


### PR DESCRIPTION
This is really basic, but it's something that I've found useful to have.

When I first started experimenting with Eio, the only slight pain point I encountered at the very beginning was trying to understand how Flows, Files, Fs, Flow.Buf_read, etc, worked together. Having this simple function would have helped me understand it all.

It can also be useful for debugging.