### PR TITLE
Fix some MDX problems on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# To work around MDX issues
+README.md text eol=lf

--- a/README.md
+++ b/README.md
@@ -842,7 +842,8 @@ let try_mkdir path =
 The checks also apply to following symlinks:
 
 ```ocaml
-# Unix.symlink "dir1" "link-to-dir1"; Unix.symlink "/tmp" "link-to-tmp";;
+# Unix.symlink "dir1" "link-to-dir1";
+  Unix.symlink (Filename.get_temp_dir_name ()) "link-to-tmp";;
 - : unit = ()
 
 # Eio_main.run @@ fun env ->

--- a/lib_eio_windows/dune
+++ b/lib_eio_windows/dune
@@ -1,12 +1,13 @@
 (library
  (name eio_windows)
  (public_name eio_windows)
- (library_flags :standard -ccopt -lbcrypt -ccopt -lntdll)
+ (library_flags :standard -cclib -lbcrypt -cclib -lntdll)
  (enabled_if (= %{os_type} "Win32"))
  (foreign_stubs
   (language c)
   (include_dirs ../lib_eio/unix/include)
   (names eio_windows_stubs eio_windows_cstruct_stubs))
+ (c_library_flags :standard -lbcrypt -lntdll)
  (libraries eio eio.unix eio.utils fmt))
 
 (rule


### PR DESCRIPTION
- The `c_library_flags` are required to allow the stubs to be loaded dynamically by MDX.
- The Windows `dune` file now uses `-cclib`, as the `-l` options are for the linker rather than the compiler.

This PR is just the parts of @polytypic's #589 that don't affect other systems or require an unreleased version of MDX.