### PR TITLE
Add Flow.single_write

### DIFF
--- a/lib_eio/buf_write.ml
+++ b/lib_eio/buf_write.ml
@@ -473,8 +473,8 @@ let rec await_batch t =
 let copy t flow =
   let rec aux () =
     let iovecs = await_batch t in
-    Flow.write flow iovecs;             (* todo: add a Flow.single_write and use that. *)
-    shift t (Cstruct.lenv iovecs);
+    let wrote = Flow.single_write flow iovecs in
+    shift t wrote;
     aux ()
   in
   try aux ()

--- a/lib_eio/flow.mli
+++ b/lib_eio/flow.mli
@@ -76,6 +76,9 @@ val write : _ sink -> Cstruct.t list -> unit
     - {!Buf_write} to combine multiple small writes.
     - {!copy} for bulk transfers, as it allows some extra optimizations. *)
 
+val single_write : _ sink -> Cstruct.t list -> int
+(** [single_write dst bufs] writes at least one byte from [bufs] and returns the number of bytes written. *)
+
 val copy : _ source -> _ sink -> unit
 (** [copy src dst] copies data from [src] to [dst] until end-of-file. *)
 
@@ -119,7 +122,7 @@ module Pi : sig
   module type SINK = sig
     type t
     val copy : t -> src:_ source -> unit
-    val write : t -> Cstruct.t list -> unit
+    val single_write : t -> Cstruct.t list -> int
   end
 
   module type SHUTDOWN = sig

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -165,7 +165,7 @@ module Flow = struct
 
   let read_methods = []
 
-  let write t bufs = Low_level.writev t bufs
+  let single_write t bufs = Low_level.writev_single t bufs
 
   let copy t ~src =
     match Eio_unix.Resource.fd_opt src with

--- a/lib_eio_posix/flow.ml
+++ b/lib_eio_posix/flow.ml
@@ -36,7 +36,13 @@ module Impl = struct
       }
     with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
 
-  let write t bufs =
+  let single_write t bufs =
+    try
+      Low_level.writev t (Array.of_list bufs)
+    with Unix.Unix_error (code, name, arg) ->
+      raise (Err.wrap code name arg)
+
+  let write_all t bufs =
     try
       let rec loop = function
         | [] -> ()
@@ -52,7 +58,7 @@ module Impl = struct
     try
       while true do
         let got = Eio.Flow.single_read src buf in
-        write dst [Cstruct.sub buf 0 got]
+        write_all dst [Cstruct.sub buf 0 got]
       done
     with End_of_file -> ()
 

--- a/lib_eio_windows/flow.ml
+++ b/lib_eio_windows/flow.ml
@@ -36,16 +36,21 @@ module Impl = struct
       }
     with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
 
-  let write t bufs =
+  let write_all t bufs =
     try Low_level.writev t bufs
     with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+
+  (* todo: provide a way to do a single write *)
+  let single_write t bufs =
+    write_all t bufs;
+    Cstruct.lenv bufs
 
   let copy dst ~src =
     let buf = Cstruct.create 4096 in
     try
       while true do
         let got = Eio.Flow.single_read src buf in
-        write dst [Cstruct.sub buf 0 got]
+        write_all dst [Cstruct.sub buf 0 got]
       done
     with End_of_file -> ()
 


### PR DESCRIPTION
`Flow.write` keeps writing until all the data is sent or an error occurs, but sometimes it's useful to perform only a single write operation. For example, if `Buf_write` asks to write 5 bytes and only 4 get written, we would previously do another 1-byte write. However, there may have been more data available by then.

This is also useful for error recovery, if you need to know exactly how many bytes were successfully written before the error.

Since we're making everyone update their custom sinks anyway, we might as well fix this at the same time.

Note that the `Buf_write` tests for `Read_source_buffer` were supposed to test that the target flow read the buffers directly, but since we started using `write` instead of `copy` it doesn't matter.