### PR TITLE
Make MDX tests idempotent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _build
+_opam
+.ocamlformat
 .*.swp
 *.install

--- a/README.md
+++ b/README.md
@@ -780,6 +780,16 @@ To append to the string part, it's convenient to use the `/` operator:
 let ( / ) = Eio.Path.( / )
 ```
 
+<!--
+Cleanup previous runs due to [dune runtest --watch] not doing it
+```ocaml
+Eio_main.run @@ fun env ->
+let cwd = Eio.Stdenv.cwd env in
+["link-to-dir1"; "link-to-tmp"; "test.txt"; "dir1"]
+|> List.iter (fun p -> Eio.Path.rmtree ~missing_ok:true (cwd / p))
+```
+-->
+
 `env` provides two initial paths:
 
 - `cwd` restricts access to files beneath the current working directory.

--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -110,7 +110,7 @@ let kind ~follow t =
 let is_file t =
   kind ~follow:true t = `Regular_file
 
-let is_directory t = 
+let is_directory t =
   kind ~follow:true t = `Directory
 
 let with_open_in path fn =


### PR DESCRIPTION
At the moment, developing with `dune runtest -w` is not the most pleasant experience. The first test run will succeed, but the subsequent runs of many tests (`fs.md`, `process.md`, `README.md`) will fail with various `Already_exists` and `Not_found` errors.

This PR cleans up those leftover artifacts to ensure accurate test outcomes.

I first tried to do something more automatic, where it would detect the previous artifacts, so that we won't have to remember to invoke the cleanup function with the right paths, but the result was more brittle than this. I wanted to make sure it would work even if the test gets interrupted, so the cleanup has to happen before the test run, not after it. Please let me know if you can think of a better approach.