### PR TITLE
Add Eio.Path.native

### DIFF
--- a/lib_eio/fs.ml
+++ b/lib_eio/fs.ml
@@ -9,6 +9,7 @@ type error =
   | Not_found of Exn.Backend.t
   | Permission_denied of Exn.Backend.t
   | File_too_large
+  | Not_native of string          (** Raised by {!Path.native_exn}. *)
 
 type Exn.err += E of error
 
@@ -24,6 +25,7 @@ let () =
           | Not_found e -> Fmt.pf f "Not_found %a" Exn.Backend.pp e
           | Permission_denied e -> Fmt.pf f "Permission_denied %a" Exn.Backend.pp e
           | File_too_large -> Fmt.pf f "File_too_large"
+          | Not_native m -> Fmt.pf f "Not_native %S" m
         end;
         true
       | _ -> false
@@ -62,6 +64,7 @@ module Pi = struct
     val rmdir : t -> path -> unit
     val rename : t -> path -> _ dir -> path -> unit
     val pp : t Fmt.t
+    val native : t -> string -> string option
   end
 
   type (_, _, _) Resource.pi +=

--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -12,6 +12,15 @@ let pp f (Resource.T (t, ops), p) =
   if p = "" then Fmt.pf f "<%a>" X.pp t
   else Fmt.pf f "<%a:%s>" X.pp t (String.escaped p)
 
+let native (Resource.T (t, ops), p) =
+  let module X = (val (Resource.get ops Fs.Pi.Dir)) in
+  X.native t p
+
+let native_exn t =
+  match native t with
+  | Some p -> p
+  | None -> raise (Fs.err (Not_native (Fmt.str "%a" pp t)))
+
 let open_in ~sw t =
   let (Resource.T (dir, ops), path) = t in
   let module X = (val (Resource.get ops Fs.Pi.Dir)) in

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -23,6 +23,9 @@
     {[
       Eio.Path.load (fs / "/etc/passwd")
     ]}
+
+    In Eio, the directory separator is always "/", even on Windows.
+    Use {!native} to convert to a native path.
 *)
 
 open Std
@@ -40,6 +43,23 @@ val ( / ) : 'a t -> string -> 'a t
 
 val pp : _ t Fmt.t
 (** [pp] formats a [_ t] as "<label:path>", suitable for logging. *)
+
+val native : _ t -> string option
+(** [native t] returns a path that can be used to refer to [t] with the host
+    platform's native string-based file-system APIs, if available.
+    This is intended for interoperability with non-Eio libraries.
+
+    This does not check for confinement (the resulting path might not be accessible
+    via [t] itself). Also, if a directory was opened with {!open_dir} and later
+    renamed, this might use the old name.
+
+    Using strings as paths is not secure if components in the path can be
+    replaced by symlinks while the path is being used. For example, if you
+    try to write to "/home/mal/output.txt" just as mal replaces "output.txt"
+    with a symlink to "/etc/passwd". *)
+
+val native_exn : _ t -> string
+(** Like {!native}, but raise a suitable exception if the path is not a native path. *)
 
 (** {1 Reading files} *)
 

--- a/lib_eio_posix/fs.ml
+++ b/lib_eio_posix/fs.ml
@@ -161,6 +161,21 @@ end = struct
     Eio.Resource.T (d, Handler.v)
 
   let pp f t = Fmt.string f (String.escaped t.label)
+
+  let native_internal t path =
+    if Filename.is_relative path then (
+      let p =
+        if t.dir_path = "." then path
+        else Filename.concat t.dir_path path
+      in
+      if p = "" then "."
+      else if p = "." then p
+      else if Filename.is_implicit p then "./" ^ p
+      else p
+    ) else path
+
+  let native t path =
+    Some (native_internal t path)
 end
 and Handler : sig
   val v : (Dir.t, [`Dir | `Close]) Eio.Resource.handler

--- a/lib_eio_windows/fs.ml
+++ b/lib_eio_windows/fs.ml
@@ -169,6 +169,9 @@ end = struct
     Eio.Resource.T (d, Handler.v)
 
   let pp f t = Fmt.string f (String.escaped t.label)
+
+  let native _t _path =
+    failwith "TODO: Windows native"
 end
 and Handler : sig
   val v : (Dir.t, [`Dir | `Close]) Eio.Resource.handler


### PR DESCRIPTION
This is useful when interacting with non-Eio libraries, for spawning sub-processes, and for displaying paths to users.

Fixes #513.