### PR TITLE
eio_linux tests: skip fixed buffer test if not available

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,6 @@
   (crowbar (and (>= 0.2) :with-test))
   (mtime (>= 2.0.0))
   (mdx (and (>= 2.2.0) :with-test))
-  (alcotest (and (>= 1.4.0) :with-test))
   (dscheck (and (>= 0.1.0) :with-test))))
 (package
  (name eio_linux)
@@ -37,7 +36,7 @@
  (description "An Eio implementation for Linux using io-uring.")
  (allow_empty)  ; Work-around for dune bug #6938
  (depends
-  (alcotest (and (>= 1.4.0) :with-test))
+  (alcotest (and (>= 1.7.0) :with-test))
   (eio (= :version))
   (mdx (and (>= 2.2.0) :with-test))
   (logs (>= 0.7.0))
@@ -62,7 +61,7 @@
  (depends
   (eio (= :version))
   (kcas (and (>= 0.3.0) :with-test))
-  (alcotest (and (>= 1.4.0) :with-test))))
+  (alcotest (and (>= 1.7.0) :with-test))))
 (package
  (name eio_main)
  (synopsis "Effect-based direct-style IO mainloop for OCaml")

--- a/eio.opam
+++ b/eio.opam
@@ -22,7 +22,6 @@ depends: [
   "crowbar" {>= "0.2" & with-test}
   "mtime" {>= "2.0.0"}
   "mdx" {>= "2.2.0" & with-test}
-  "alcotest" {>= "1.4.0" & with-test}
   "dscheck" {>= "0.1.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
-  "alcotest" {>= "1.4.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
   "eio" {= version}
   "mdx" {>= "2.2.0" & with-test}
   "logs" {>= "0.7.0"}

--- a/eio_windows.opam
+++ b/eio_windows.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.9"}
   "eio" {= version}
   "kcas" {>= "0.3.0" & with-test}
-  "alcotest" {>= "1.4.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/lib_eio_linux/tests/test.ml
+++ b/lib_eio_linux/tests/test.ml
@@ -139,7 +139,7 @@ let test_read_exact () =
     ~resolve:Uring.Resolve.empty
     "test.data"
   in
-  Eio_linux.Low_level.with_chunk ~fallback:(fun () -> assert false) @@ fun chunk ->
+  Eio_linux.Low_level.with_chunk ~fallback:Alcotest.skip @@ fun chunk ->
   (* Try to read one byte too far. If it's not updating the file offset, it will
      succeed. *)
   let len = String.length msg + 1 in


### PR DESCRIPTION
This test frequently causes CI failures because the build machines are often low on memory and refuse to provide a fixed buffer. Just skip the test in that case.