### PR TITLE
Add Eio.Flow.Pi.simple_copy

### DIFF
--- a/lib_eio/flow.mli
+++ b/lib_eio/flow.mli
@@ -121,8 +121,13 @@ module Pi : sig
 
   module type SINK = sig
     type t
-    val copy : t -> src:_ source -> unit
+
     val single_write : t -> Cstruct.t list -> int
+
+    val copy : t -> src:_ source -> unit
+    (** [copy t ~src] allows for optimising copy operations.
+
+        If you have no optimisations, you can use {!simple_copy} to implement this using {!single_write}. *)
   end
 
   module type SHUTDOWN = sig
@@ -146,5 +151,8 @@ module Pi : sig
     | Source : ('t, (module SOURCE with type t = 't), [> source_ty]) Resource.pi
     | Sink : ('t, (module SINK with type t = 't), [> sink_ty]) Resource.pi
     | Shutdown : ('t, (module SHUTDOWN with type t = 't), [> shutdown_ty]) Resource.pi
+
+  val simple_copy : single_write:('t -> Cstruct.t list -> int) -> 't -> src:_ source -> unit
+  (** [simple_copy ~single_write] implements {!SINK}'s [copy] API using [single_write]. *)
 end
 

--- a/lib_eio_posix/flow.ml
+++ b/lib_eio_posix/flow.ml
@@ -42,25 +42,7 @@ module Impl = struct
     with Unix.Unix_error (code, name, arg) ->
       raise (Err.wrap code name arg)
 
-  let write_all t bufs =
-    try
-      let rec loop = function
-        | [] -> ()
-        | bufs ->
-          let wrote = Low_level.writev t (Array.of_list bufs) in
-          loop (Cstruct.shiftv bufs wrote)
-      in
-      loop bufs
-    with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
-
-  let copy dst ~src =
-    let buf = Cstruct.create 4096 in
-    try
-      while true do
-        let got = Eio.Flow.single_read src buf in
-        write_all dst [Cstruct.sub buf 0 got]
-      done
-    with End_of_file -> ()
+  let copy t ~src = Eio.Flow.Pi.simple_copy ~single_write t ~src
 
   let single_read t buf =
     match Low_level.readv t [| buf |] with

--- a/lib_eio_windows/flow.ml
+++ b/lib_eio_windows/flow.ml
@@ -45,14 +45,7 @@ module Impl = struct
     write_all t bufs;
     Cstruct.lenv bufs
 
-  let copy dst ~src =
-    let buf = Cstruct.create 4096 in
-    try
-      while true do
-        let got = Eio.Flow.single_read src buf in
-        write_all dst [Cstruct.sub buf 0 got]
-      done
-    with End_of_file -> ()
+  let copy t ~src = Eio.Flow.Pi.simple_copy ~single_write t ~src
 
   let single_read t buf =
     match Low_level.read_cstruct t buf with


### PR DESCRIPTION
This provides an easy way to implement the copy API when there are no optimisations you want to try.