### PR TITLE
Add File.stat benchmark

### DIFF
--- a/bench/bench_fstat.ml
+++ b/bench/bench_fstat.ml
@@ -1,0 +1,26 @@
+open Eio.Std
+
+let ( / ) = Eio.Path.( / )
+
+let n_stat = 100000
+
+let run_fiber file =
+  for _ = 1 to n_stat do
+    let info = (Eio.File.stat file).kind in
+    assert (info = `Regular_file)
+  done
+
+let run env =
+  Eio.Path.with_open_out ~create:(`If_missing 0o600) (env#cwd / "test-stat") @@ fun file ->
+  [1; 10] |> List.map (fun par ->
+      let t0 = Unix.gettimeofday () in
+      Switch.run (fun sw ->
+          for _  = 1 to par do
+            Fiber.fork ~sw (fun () -> run_fiber file)
+          done
+        );
+      let t1 = Unix.gettimeofday () in
+      let stat_per_s = float (n_stat * par) /. (t1 -. t0) in
+      let label = Printf.sprintf "n=%d fibers=%d" n_stat par in
+      Metric.create label (`Float stat_per_s) "stat/s" "Call fstat on an open file"
+    )

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -9,6 +9,7 @@ let benchmarks = [
   "Stream", Bench_stream.run;
   "HTTP", Bench_http.run;
   "Eio_unix.Fd", Bench_fd.run;
+  "File.stat", Bench_fstat.run;
 ]
 
 let usage_error () =


### PR DESCRIPTION
This tests the performance of checking the kind of a single open file in a loop (there is a more complex benchmark in #599 that tests `Path.stat`).

I get (stat/s - higher is better):
```
posix   2,078,950   2,245,319
linux   2,332,099   2,528,603
```

Both implementations are blocking and currently just call `Unix.LargeFile.fstat`, so unclear why the uring backend is faster!

Part of #450.