### PR TITLE
Add Path.stat

### DIFF
--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -433,6 +433,9 @@ module Exn : sig
       This is similar to {!Fmt.exn}, but can do a better job on {!Io} exceptions
       because it can format them directly without having to convert to a string first. *)
 
+  val pp_err : err Fmt.t
+  (** [pp_err] formats an error code. *)
+
   (** Extensible backend-specific exceptions. *)
   module Backend : sig
     type t = ..

--- a/lib_eio/file.ml
+++ b/lib_eio/file.ml
@@ -16,6 +16,16 @@ module Stat = struct
     | `Socket
   ]
 
+  let pp_kind ppf = function
+    | `Unknown -> Fmt.string ppf "unknown"
+    | `Fifo -> Fmt.string ppf "fifo"
+    | `Character_special -> Fmt.string ppf "character special file"
+    | `Directory -> Fmt.string ppf "directory"
+    | `Block_device -> Fmt.string ppf "block device"
+    | `Regular_file -> Fmt.string ppf "regular file"
+    | `Symbolic_link -> Fmt.string ppf "symbolic link"
+    | `Socket -> Fmt.string ppf "socket"
+
   type t = {
     dev : Int64.t;
     ino : Int64.t;
@@ -30,6 +40,22 @@ module Stat = struct
     mtime : float;
     ctime : float;
   }
+
+  let pp ppf t =
+    Fmt.record [
+      Fmt.field "dev" (fun t -> t.dev) Fmt.int64;
+      Fmt.field "ino" (fun t -> t.ino) Fmt.int64;
+      Fmt.field "kind" (fun t -> t.kind) pp_kind;
+      Fmt.field "perm" (fun t -> t.perm) (fun ppf i -> Fmt.pf ppf "0o%o" i);
+      Fmt.field "nlink" (fun t -> t.nlink) Fmt.int64;
+      Fmt.field "uid" (fun t -> t.uid) Fmt.int64;
+      Fmt.field "gid" (fun t -> t.gid) Fmt.int64;
+      Fmt.field "rdev" (fun t -> t.rdev) Fmt.int64;
+      Fmt.field "size" (fun t -> t.size) Optint.Int63.pp;
+      Fmt.field "atime" (fun t -> t.atime) Fmt.float;
+      Fmt.field "mtime" (fun t -> t.mtime) Fmt.float;
+      Fmt.field "ctime" (fun t -> t.ctime) Fmt.float;
+    ] ppf t 
 end
 
 type ro_ty = [`File | Flow.source_ty | Resource.close_ty]

--- a/lib_eio/file.mli
+++ b/lib_eio/file.mli
@@ -21,6 +21,9 @@ module Stat : sig
   ]
   (** Kind of file from st_mode. **)
 
+  val pp_kind : kind Fmt.t
+  (** Pretty printer for {! kind}. *)
+
   type t = {
     dev : Int64.t;
     ino : Int64.t;
@@ -36,6 +39,9 @@ module Stat : sig
     ctime : float;
   }
   (** Like stat(2). *)
+
+  val pp : t Fmt.t
+  (** Pretty printer for {! t}. *)
 end
 
 type ro_ty = [`File | Flow.source_ty | Resource.close_ty]

--- a/lib_eio/fs.ml
+++ b/lib_eio/fs.ml
@@ -42,8 +42,8 @@ type create = [
 
 type dir_ty = [`Dir]
 type 'a dir = ([> dir_ty] as 'a) r
-
 (** Note: use the functions in {!Path} to access directories. *)
+
 module Pi = struct
   module type DIR = sig
     type t
@@ -60,6 +60,7 @@ module Pi = struct
     val mkdir : t -> perm:File.Unix_perm.t -> path -> unit
     val open_dir : t -> sw:Switch.t -> path -> [`Close | dir_ty] r
     val read_dir : t -> path -> string list
+    val stat : t -> follow:bool -> string -> File.Stat.t
     val unlink : t -> path -> unit
     val rmdir : t -> path -> unit
     val rename : t -> path -> _ dir -> path -> unit

--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -61,6 +61,14 @@ let read_dir t =
     let bt = Printexc.get_raw_backtrace () in
     Exn.reraise_with_context ex bt "reading directory %a" pp t
 
+let stat ~follow t =
+  let (Resource.T (dir, ops), path) = t in
+  let module X = (val (Resource.get ops Fs.Pi.Dir)) in
+  try X.stat ~follow dir path
+  with Exn.Io _ as ex ->
+    let bt = Printexc.get_raw_backtrace () in
+    Exn.reraise_with_context ex bt "examining %a" pp t
+
 let with_open_in path fn =
   Switch.run @@ fun sw -> fn (open_in ~sw path)
 

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -128,6 +128,14 @@ val read_dir : _ t -> string list
 
     Note: The special Unix entries "." and ".." are not included in the results. *)
 
+(** {2 Metadata} *)
+
+val stat : follow:bool -> _ t -> File.Stat.t
+(** [stat ~follow t] returns metadata about the file [t].
+
+    If [t] is a symlink, the information returned is about the target if [follow = true],
+    otherwise it is about the link itself. *)
+
 (** {1 Other} *)
 
 val unlink : _ t -> unit

--- a/lib_eio_posix/flow.ml
+++ b/lib_eio_posix/flow.ml
@@ -2,38 +2,41 @@ open Eio.Std
 
 module Fd = Eio_unix.Fd
 
+let float_of_time s ns =
+  let s = Int64.to_float s in
+  let f = s +. (float ns /. 1e9) in
+  (* It's possible that we might round up to the next second.
+     Since some algorithms only care about the seconds part,
+     make sure the integer part is always [s]: *)
+  if floor f = s then f
+  else Float.pred f
+
+let eio_of_stat x =
+  { Eio.File.Stat.
+    dev    = Low_level.dev x;
+    ino    = Low_level.ino x;
+    kind   = Low_level.kind x;
+    perm   = Low_level.perm x;
+    nlink  = Low_level.nlink x;
+    uid    = Low_level.uid x;
+    gid    = Low_level.gid x;
+    rdev   = Low_level.rdev x;
+    size   = Low_level.size x |> Optint.Int63.of_int64;
+    atime  = float_of_time (Low_level.atime_sec x) (Low_level.atime_nsec x);
+    mtime  = float_of_time (Low_level.mtime_sec x) (Low_level.mtime_nsec x);
+    ctime  = float_of_time (Low_level.ctime_sec x) (Low_level.ctime_nsec x);
+  }
+
 module Impl = struct
   type tag = [`Generic | `Unix]
 
   type t = Eio_unix.Fd.t
 
-  let float_of_time s ns =
-    let s = Int64.to_float s in
-    let f = s +. (float ns /. 1e9) in
-    (* It's possible that we might round up to the next second.
-       Since some algorithms only care about the seconds part,
-       make sure the integer part is always [s]: *)
-    if floor f = s then f
-    else Float.pred f
-
   let stat t =
     try
       let x = Low_level.create_stat () in
       Low_level.fstat ~buf:x t;
-      { Eio.File.Stat.
-        dev    = Low_level.dev x;
-        ino    = Low_level.ino x;
-        kind   = Low_level.kind x;
-        perm   = Low_level.perm x;
-        nlink  = Low_level.nlink x;
-        uid    = Low_level.uid x;
-        gid    = Low_level.gid x;
-        rdev   = Low_level.rdev x;
-        size   = Low_level.size x |> Optint.Int63.of_int64;
-        atime  = float_of_time (Low_level.atime_sec x) (Low_level.atime_nsec x);
-        mtime  = float_of_time (Low_level.mtime_sec x) (Low_level.mtime_nsec x);
-        ctime  = float_of_time (Low_level.ctime_sec x) (Low_level.ctime_nsec x);
-      }
+      eio_of_stat x
     with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
 
   let single_write t bufs =

--- a/lib_eio_posix/fs.ml
+++ b/lib_eio_posix/fs.ml
@@ -137,6 +137,16 @@ end = struct
     with_parent_dir t path @@ fun dirfd path ->
     Err.run (Low_level.unlink ?dirfd ~dir:true) path
 
+  let stat t ~follow path =
+    let buf = Low_level.create_stat () in
+    if follow then (
+      Err.run (Low_level.fstatat ~buf ~follow:true) (resolve t path);
+    ) else (
+      with_parent_dir t path @@ fun dirfd path ->
+      Err.run (Low_level.fstatat ~buf ?dirfd ~follow:false) path;
+    );
+    Flow.eio_of_stat buf
+
   let read_dir t path =
     (* todo: need fdopendir here to avoid races *)
     let path = resolve t path in


### PR DESCRIPTION
This is a simplified version of #599, rebased on `main` and using the existing `File.Stat.t` record type.

As discussed in the call today, we might switch to a GADT version later, if that can be shown to be faster (so far it seems to be at best the same speed, and slower with multiple fields).