### PR TITLE
eio_linux: require Linux >= 5.18 for reliable statx

### DIFF
--- a/bench/main.ml
+++ b/bench/main.ml
@@ -1,3 +1,5 @@
+open Eio.Std
+
 let benchmarks = [
   "Promise", Bench_promise.run;
   "Cancel", Bench_cancel.run;
@@ -39,6 +41,7 @@ let () =
       "metrics", `List metrics;
     ]
   in
+  traceln "Using backend %S" env#backend_id;
   Fmt.pr "%a@." (Yojson.Safe.pretty_print ~std:true) @@ `Assoc [
     "results", `List (List.map run benchmarks);
   ]

--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -522,9 +522,10 @@ let with_sched ?(fallback=no_fallback) config fn =
   | exception Unix.Unix_error(Unix.ENOSYS, _, _) -> fallback (`Msg "io_uring is not available on this system")
   | uring ->
     let probe = Uring.get_probe uring in
-    if not (Uring.op_supported probe Uring.Op.shutdown) then (
+    if not (Uring.op_supported probe Uring.Op.msg_ring) then (
+      (* statx is unrealiable before 5.18. *)
       Uring.exit uring;
-      fallback (`Msg "Linux >= 5.11 is required for io_uring support")
+      fallback (`Msg "Linux >= 5.18 is required for io_uring support")
     ) else (
       match
         let mem =


### PR DESCRIPTION
See: [io-uring: Make statx API stable](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1b6fe6e0dfecf8c82a64fb87148ad9333fa2f62e).

Also, display backend in use in benchmark output.