### PR TITLE
Add Eio.Path.{kind, is_file, is_directory}

### DIFF
--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -69,6 +69,16 @@ let stat ~follow t =
     let bt = Printexc.get_raw_backtrace () in
     Exn.reraise_with_context ex bt "examining %a" pp t
 
+let kind ~follow t =
+  try ((stat ~follow t).kind :> [File.Stat.kind | `Not_found])
+  with Exn.Io (Fs.E Not_found _, _) -> `Not_found
+
+let is_file t =
+  kind ~follow:true t = `Regular_file
+
+let is_directory t = 
+  kind ~follow:true t = `Directory
+
 let with_open_in path fn =
   Switch.run @@ fun sw -> fn (open_in ~sw path)
 

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -128,13 +128,28 @@ val read_dir : _ t -> string list
 
     Note: The special Unix entries "." and ".." are not included in the results. *)
 
-(** {2 Metadata} *)
+(** {1 Metadata} *)
 
 val stat : follow:bool -> _ t -> File.Stat.t
 (** [stat ~follow t] returns metadata about the file [t].
 
     If [t] is a symlink, the information returned is about the target if [follow = true],
     otherwise it is about the link itself. *)
+
+val kind : follow:bool -> _ t -> [ File.Stat.kind | `Not_found ]
+(** [kind ~follow t] is the type of [t], or [`Not_found] if it doesn't exist.
+
+    @param follow If [true] and [t] is a symlink, return the type of the target rather than [`Symbolic_link]. *)
+
+val is_file : _ t -> bool
+(** [is_file t] is [true] if [t] is a regular file, and [false] if it doesn't exist or has a different type.
+
+    [is_file t] is [kind ~follow:true t = `Regular_file]. *)
+
+val is_directory : _ t -> bool
+(** [is_directory t] is [true] if [t] is a directory, and [false] if it doesn't exist or has a different type.
+
+    [is_directory t] is [kind ~follow:true t = `Directory]. *)
 
 (** {1 Other} *)
 


### PR DESCRIPTION
This is based on #599. I replaced `exists` with `kind` because I always have to look up what it means, and the PR's behaviour of "is a regular file or directory, or symlink to something that is" wasn't obvious to me.