### PR TITLE
Add Path.rmtree

### DIFF
--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -139,12 +139,12 @@ val mkdirs : ?exists_ok:bool -> perm:File.Unix_perm.t -> _ t -> unit
 
     @param exist_ok If [false] (the default) then we raise {! Fs.Already_exists} if [t] is already a directory. *)
 
-val open_dir : sw:Switch.t -> _ t -> [`Close | dir_ty] t
+val open_dir : sw:Switch.t -> _ t -> [< `Close | dir_ty] t
 (** [open_dir ~sw t] opens [t].
 
     This can be passed to functions to grant access only to the subtree [t]. *)
 
-val with_open_dir : _ t -> ([`Close | dir_ty] t -> 'a) -> 'a
+val with_open_dir : _ t -> ([< `Close | dir_ty] t -> 'a) -> 'a
 (** [with_open_dir] is like [open_dir], but calls [fn dir] with the new directory and closes
     it automatically when [fn] returns (if it hasn't already been closed by then). *)
 
@@ -191,6 +191,9 @@ val rmdir : _ t -> unit
     This only works when the entry is itself a directory.
 
     Note: this usually requires the directory to be empty. *)
+
+val rmtree : _ t -> unit
+(** [rmtree t] removes directory [t] and its contents, recursively. *)
 
 val rename : _ t -> _ t -> unit
 (** [rename old_t new_t] atomically unlinks [old_t] and links it as [new_t].

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -61,6 +61,11 @@ let try_rmdir path =
   | () -> traceln "rmdir %a -> ok" Path.pp path
   | exception ex -> traceln "@[<h>%a@]" Eio.Exn.pp ex
 
+let try_rmtree path =
+  match Path.rmtree path with
+  | () -> traceln "rmtree %a -> ok" Path.pp path
+  | exception ex -> traceln "@[<h>%a@]" Eio.Exn.pp ex
+
 let chdir path =
   traceln "chdir %S" path;
   Unix.chdir path
@@ -394,6 +399,23 @@ Removing something that doesn't exist or is out of scope:
 +Eio.Io Fs Permission_denied _, removing directory <cwd:../foo>
 +Eio.Io Fs Not_found _, removing directory <cwd:to-subdir/foo>
 +Eio.Io Fs Permission_denied _, removing directory <cwd:to-root/foo>
+- : unit = ()
+```
+
+# Recursive removal
+
+```ocaml
+# run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let cwd = Eio.Stdenv.cwd env in
+  let foo = cwd / "foo" in
+  try_mkdirs (foo / "bar"/ "baz");
+  try_write_file ~create:(`Exclusive 0o600) (foo / "bar/file1") "data";
+  try_rmtree foo;
+  assert (Path.kind ~follow:false foo = `Not_found);
++mkdirs <cwd:foo/bar/baz> -> ok
++write <cwd:foo/bar/file1> -> ok
++rmtree <cwd:foo> -> ok
 - : unit = ()
 ```
 


### PR DESCRIPTION
We might want to add a `~force:true` argument at some point, but this will do to start with.

Needed for #601 and helpful for creating temporary directories (#510).

/cc @SGrondin