### PR TITLE
Add Path.rmtree ?missing_ok and allow non-directories

### DIFF
--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -192,8 +192,13 @@ val rmdir : _ t -> unit
 
     Note: this usually requires the directory to be empty. *)
 
-val rmtree : _ t -> unit
-(** [rmtree t] removes directory [t] and its contents, recursively. *)
+val rmtree : ?missing_ok:bool -> _ t -> unit
+(** [rmtree t] removes [t] (and its contents, recursively, if it's a directory).
+
+    @param missing_ok If [false] (the default), raise an {!Fs.Not_found} IO error if [t] doesn't exist.
+                      If [true], ignore missing items.
+                      This applies recursively, allowing two processes
+                      to attempt to remove a tree at the same time. *)
 
 val rename : _ t -> _ t -> unit
 (** [rename old_t new_t] atomically unlinks [old_t] and links it as [new_t].

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -61,8 +61,8 @@ let try_rmdir path =
   | () -> traceln "rmdir %a -> ok" Path.pp path
   | exception ex -> traceln "@[<h>%a@]" Eio.Exn.pp ex
 
-let try_rmtree path =
-  match Path.rmtree path with
+let try_rmtree ?missing_ok path =
+  match Path.rmtree ?missing_ok path with
   | () -> traceln "rmtree %a -> ok" Path.pp path
   | exception ex -> traceln "@[<h>%a@]" Eio.Exn.pp ex
 
@@ -413,9 +413,17 @@ Removing something that doesn't exist or is out of scope:
   try_write_file ~create:(`Exclusive 0o600) (foo / "bar/file1") "data";
   try_rmtree foo;
   assert (Path.kind ~follow:false foo = `Not_found);
+  traceln "A second rmtree is OK with missing_ok:";
+  try_rmtree ~missing_ok:true foo;
+  traceln "But not without:";
+  try_rmtree ~missing_ok:false foo;
 +mkdirs <cwd:foo/bar/baz> -> ok
 +write <cwd:foo/bar/file1> -> ok
 +rmtree <cwd:foo> -> ok
++A second rmtree is OK with missing_ok:
++rmtree <cwd:foo> -> ok
++But not without:
++Eio.Io Fs Not_found _, removing file <cwd:foo>
 - : unit = ()
 ```
 


### PR DESCRIPTION
- Allow ignoring missing items.
- Allow removing non-directories (suggested by @SGrondin).

These are both useful for tests when trying to ensure that old files have been removed.