### PR TITLE
eio_linux: mark as only available on Linux

### DIFF
--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -34,3 +34,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os = "linux"]

--- a/eio_linux.opam.template
+++ b/eio_linux.opam.template
@@ -1,0 +1,1 @@
+available: [os = "linux"]


### PR DESCRIPTION
This avoids the CI trying to test it on e.g. FreeBSD.