### PR TITLE
Update minimum OCaml version to 5.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         os:
           - macos-latest
         ocaml-compiler:
-          - 5.0.x
+          - 5.1.x
         local-packages:
           - eio eio_posix eio_main
 
@@ -44,7 +44,7 @@ jobs:
         with:
           opam-pin: false
           opam-depext: false
-          ocaml-compiler: ocaml.5.0.0,ocaml-option-mingw
+          ocaml-compiler: ocaml.5.1.0,ocaml-option-mingw
           opam-repositories: |
             dra27: https://github.com/dra27/opam-repository.git#windows-5.0
             normal: https://github.com/ocaml/opam-repository.git

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -3,14 +3,12 @@ FROM ocaml/opam:debian-11-ocaml-5.1
 RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 # Ensure opam-repository is up-to-date:
 RUN cd opam-repository && git pull -q origin 0ac3fc79fd11ee365dd46119d43e9763cf57da52 && opam update
-# Install utop for interactive use:
-RUN opam install utop fmt
 # Install Eio's dependencies (adding just the opam files first to help with caching):
 RUN mkdir eio
 WORKDIR eio
 COPY *.opam ./
 RUN opam pin --with-version=dev . -yn
-RUN opam install --deps-only eio_main eio_linux eio
-# Build Eio:
+RUN opam install eio_main yojson
+# Build the benchmarks:
 COPY . ./
-RUN opam install eio_main
+RUN opam exec -- dune build ./bench

--- a/dune-project
+++ b/dune-project
@@ -11,13 +11,9 @@
  (name eio)
  (synopsis "Effect-based direct-style IO API for OCaml")
  (description "An effect-based IO API for multicore OCaml with fibers.")
- (conflicts
-  (ocaml-base-compiler (< 5.0.0~beta1))
-  (ocaml-variants (< 5.0.0~beta1))
-  (ocaml-system (< 5.0.0~beta1))
-  (seq (< 0.3)))
+ (conflicts (seq (< 0.3)))
  (depends
-  (ocaml (>= 5.0.0))
+  (ocaml (>= 5.1.0))
   (bigstringaf (>= 0.9.0))
   (cstruct (>= 6.0.1))
   lwt-dllist

--- a/eio.opam
+++ b/eio.opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
-  "ocaml" {>= "5.0.0"}
+  "ocaml" {>= "5.1.0"}
   "bigstringaf" {>= "0.9.0"}
   "cstruct" {>= "6.0.1"}
   "lwt-dllist"
@@ -26,9 +26,6 @@ depends: [
   "odoc" {with-doc}
 ]
 conflicts: [
-  "ocaml-base-compiler" {< "5.0.0~beta1"}
-  "ocaml-variants" {< "5.0.0~beta1"}
-  "ocaml-system" {< "5.0.0~beta1"}
   "seq" {< "0.3"}
 ]
 build: [


### PR DESCRIPTION
This is to allow using the new events system in future.