### PR TITLE
Allow trailing whitespace in CHANGES.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # To work around MDX issues
 README.md text eol=lf
+CHANGES.md whitespace=-blank-at-eol


### PR DESCRIPTION
This isn't an error; markdown uses it for a line-break.