### PR TITLE
Don't use uring on centos 7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,8 @@ Build and test changes:
 
 - Generate prototypes for C stubs from ml files (@talex5 #615).
 
+- Don't try to compile uring support on centos 7 (@talex5 #638, reported by @zenfey).
+
 ## v0.12
 
 New features / API changes:

--- a/dune-project
+++ b/dune-project
@@ -66,7 +66,10 @@
   (mdx (and (>= 2.2.0) :with-test))
   (kcas (and (>= 0.3.0) :with-test))
   (yojson (and (>= 2.0.2) :with-test))
-  (eio_linux (and (= :version) (= :os "linux")))
+  (eio_linux (and
+               (= :version)
+               (= :os "linux")
+               (or (<> :os-distribution "centos") (> :os-version 7))))
   (eio_posix (and (= :version) (<> :os "win32")))
   (eio_windows (and (= :version) (= :os "win32")))))
 (using mdx 0.2)

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -13,7 +13,9 @@ depends: [
   "mdx" {>= "2.2.0" & with-test}
   "kcas" {>= "0.3.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
-  "eio_linux" {= version & os = "linux"}
+  "eio_linux"
+    {= version & os = "linux" &
+     (os-distribution != "centos" | os-version > "7")}
   "eio_posix" {= version & os != "win32"}
   "eio_windows" {= version & os = "win32"}
   "odoc" {with-doc}


### PR DESCRIPTION
The C headers there are too old even to compile it.

Reported by @zenfey in https://github.com/ocaml-multicore/ocaml-uring/issues/106.