### PR TITLE
Remove Cancel_hook_failed

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -76,10 +76,10 @@ They are run against whichever backend `Eio_main.run` selects, and therefore mus
 
 `lib_eio/tests` tests some internal data structures, such as the lock-free cells abstraction.
 The `.md` files in that directory provide a simple walk-through to demonstrate the basic operation,
-while `lib_eio/tests/dscheck` uses [dscheck][] to perform exhaustive testing of all atomic interleavings
+while `lib_eio/tests/dscheck` uses [dscheck][] to perform exhaustive testing of all atomic interleavings.
 
 At the time of writing, dscheck has some performance problems that make it unusable by default, so
-you must use the version in https://github.com/ocaml-multicore/dscheck/pull/3 instead.
+you must use the version in https://github.com/ocaml-multicore/dscheck/pull/22 instead.
 
 ### Benchmarks
 

--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -526,9 +526,6 @@ module Cancel : sig
 
       The nested exception is only intended for debug-level logging and should generally be ignored. *)
 
-  exception Cancel_hook_failed of exn list
-  (** Raised by {!cancel} if any of the cancellation hooks themselves fail. *)
-
   val sub : (t -> 'a) -> 'a
   (** [sub fn] installs a new cancellation context [t], runs [fn t] inside it, and then restores the old context.
 
@@ -561,9 +558,7 @@ module Cancel : sig
       If [t] is already cancelled then this does nothing.
 
       Note that the caller of this function is still responsible for handling the error somehow
-      (e.g. reporting it to the user); it does not become the responsibility of the cancelled thread(s).
-
-      @raise Cancel_hook_failed if one or more hooks fail. *)
+      (e.g. reporting it to the user); it does not become the responsibility of the cancelled thread(s). *)
 
   val dump : t Fmt.t
   (** Show the cancellation sub-tree rooted at [t], for debugging. *)

--- a/lib_eio/core/exn.ml
+++ b/lib_eio/core/exn.ml
@@ -16,8 +16,6 @@ type err += Multiple_io of (err * context * Printexc.raw_backtrace) list
 
 exception Cancelled of exn
 
-exception Cancel_hook_failed of exn list
-
 let create err = Io (err, { steps = [] })
 
 let add_context ex fmt =
@@ -90,7 +88,6 @@ let () =
   Printexc.register_printer @@ function
   | Io _ as ex -> Some (Fmt.str "@[<v>%a@]" pp ex)
   | Multiple exns -> Some (Fmt.str "%a" pp_multiple exns)
-  | Cancel_hook_failed exns -> Some ("During cancellation:\n" ^ String.concat "\nand\n" (List.map Printexc.to_string exns))
   | Cancelled ex -> Some ("Cancelled: " ^ Printexc.to_string ex)
   | _ -> None
 

--- a/lib_eio/core/switch.ml
+++ b/lib_eio/core/switch.ml
@@ -55,7 +55,7 @@ let fail ?(bt=Printexc.get_raw_backtrace ()) t ex =
   t.exs <- Some (combine_exn (ex, bt) t.exs);
   try
     Cancel.cancel t.cancel ex
-  with Exn.Cancel_hook_failed _ as ex ->
+  with ex ->
     let bt = Printexc.get_raw_backtrace () in
     t.exs <- Some (combine_exn (ex, bt) t.exs)
 


### PR DESCRIPTION
It's not used for anything and it breaks recent versions of dscheck.