### PR TITLE
Allow closing synchronous streams

### DIFF
--- a/lib_eio/stream.ml
+++ b/lib_eio/stream.ml
@@ -120,12 +120,15 @@ let add t v =
   | Locking x -> Locking.add x v
 
 let take = function
-  | Sync x -> Sync.take x
+  | Sync x -> Sync.take x |> Result.get_ok     (* todo: allow closing streams *)
   | Locking x -> Locking.take x
 
 let take_nonblocking = function
-  | Sync x -> Sync.take_nonblocking x
   | Locking x -> Locking.take_nonblocking x
+  | Sync x ->
+    match Sync.take_nonblocking x with
+    | Ok x -> Some x
+    | Error `Closed | Error `Would_block -> None
 
 let length = function
   | Sync _ -> 0

--- a/lib_eio/sync.mli
+++ b/lib_eio/sync.mli
@@ -18,26 +18,35 @@ val put : 'a t -> 'a -> unit
     If no consumer is available, it waits until one comes along and accepts [x].
 
     Note: Producers are mostly handled fairly, in the order in which they arrive,
-    but consumers can cancel or reject values so this isn't guaranteed. *)
+    but consumers can cancel or reject values so this isn't guaranteed.
 
-val take : 'a t -> 'a
+    @raise Invalid_argument if [t] was closed before [x] was added. *)
+
+val take : 'a t -> ('a, [> `Closed]) result
 (** [take t] waits until a producer is available with an item and then returns it.
 
     Note: Consumers are mostly handled fairly, in the order in which they arrive,
     but producers can cancel so this isn't guaranteed if [t] is shared between
-    domains. *)
+    domains.
 
-val take_nonblocking : 'a t -> 'a option
-(** [take_nonblocking t] is like {!take}, but returns [None] if no producer is immediately available.
+    Returns [Error `Closed] if [t] was closed before an item was taken. *)
+
+val take_nonblocking : 'a t -> ('a, [> `Would_block | `Closed]) result
+(** [take_nonblocking t] is like {!take}, but returns [Error `Would_block] if no producer is immediately available.
 
     Note: When [t] is shared between domains, it is possible that a producer may be assigned but still be
-    in the process of writing its value to [t].
-    In this case, [take_nonblocking] will cancel and retry with a new producer,
+    in the process of writing its value to [t]. In this case, [take_nonblocking] will cancel it,
     causing the old producer to lose its place in the queue and have to rejoin at the end.
     Since the producer reached the head of the queue while it was still joining,
     the queue is presumably very short in this case anyway. *)
 
-val balance : 'a t -> int
+val close : 'a t -> unit
+(** [close t] prevents any further items from being added to [t].
+
+    Any consumers or producers that were waiting will receive an exception.
+    If [t] is already closed then this does nothing. *)
+
+val balance : 'a t -> (int, [> `Closed]) result
 (** [balance t] is the number of waiting producers minus the number of waiting consumers.
 
     If the balance is non-negative then it is the number of waiting producers.

--- a/lib_eio/tests/dscheck/test_sync.ml
+++ b/lib_eio/tests/dscheck/test_sync.ml
@@ -23,7 +23,8 @@ let test ~prod ~cons ~take_nonblocking () =
     Fake_sched.run
       (fun () ->
          match T.take t with
-         | v ->
+         | Error `Closed -> assert false
+         | Ok v ->
            if debug then log "c%d: Recv %d" l v;
            received := !received + v
          | exception Eio__core.Cancel.Cancelled _ ->
@@ -62,10 +63,11 @@ let test ~prod ~cons ~take_nonblocking () =
   for i = 1 to take_nonblocking do
     Atomic.spawn (fun () ->
         match T.take_nonblocking t with
-        | None ->
+        | Error `Closed -> assert false
+        | Error `Would_block ->
           if debug then log "nb%d: found nothing" i;
           incr cancelled_consumers;
-        | Some v ->
+        | Ok v ->
           if debug then log "nb%d: took %d" i v;
           received := !received + v
       )
@@ -84,11 +86,69 @@ let test ~prod ~cons ~take_nonblocking () =
       assert (!finished_producers = prod);
       (* Everyone finishes by trying to cancel (if they didn't succeed immediately),
          so there shouldn't be any balance at the end. *)
-      assert (T.balance t = 0);
+      assert (T.balance t = Ok 0);
       assert (!received = !expected_total);
+    )
+
+(* A producer puts "A" and then closes the stream.
+   Two consumers try to read. One gets the "A", the other gets end-of-stream. *)
+let test_close () =
+  let t = T.create () in
+  let got = ref [] in
+  Atomic.spawn
+    (fun () ->
+       let _ : Sync.Cancel.t option = Fake_sched.run (fun () -> T.put t "A"; T.close t) in
+       ()
+    );
+  for _ = 1 to 2 do
+    Atomic.spawn
+      (fun () ->
+         let _ : Sync.Cancel.t option = Fake_sched.run (fun () ->
+             let msg = T.take t |> Result.value ~default:"end-of-stream" in
+             got := msg :: !got
+           )
+         in
+         ()
+      );
+  done;
+  Atomic.final (fun () ->
+      let results = List.sort String.compare !got in
+      if debug then (
+        Fmt.pr "%a@." T.dump t;
+        Fmt.pr "%a@." Fmt.(Dump.list string) results;
+      );
+      assert (results = ["A"; "end-of-stream"]);
+      assert (T.balance t = Error `Closed);
+    )
+
+(* A producer tries to add an item (but never succeeds, as there are no consumers).
+   At some point, the stream is closed and the operation aborts. *)
+let test_close2 () =
+  let t = T.create () in
+  let result = ref "Waiting" in
+  Atomic.spawn
+    (fun () ->
+       let _ : Sync.Cancel.t option = Fake_sched.run (fun () ->
+           match T.put t "A" with
+           | () -> failwith "Shouldn't succeed with no consumer!"
+           | exception (Invalid_argument msg) -> result := msg
+         ) in
+       ()
+    );
+  Atomic.spawn (fun () -> T.close t);
+  Atomic.final (fun () ->
+      if debug then (
+        Fmt.pr "%a@." T.dump t;
+        Fmt.pr "%s@." !result;
+      );
+      match !result with
+      | "Stream closed" -> ()
+      | x -> failwith x
     )
 
 let () =
   Atomic.trace (test ~prod:1 ~cons:1 ~take_nonblocking:1);
   Atomic.trace (test ~prod:2 ~cons:1 ~take_nonblocking:0);
   Atomic.trace (test ~prod:1 ~cons:2 ~take_nonblocking:0);
+  Atomic.trace test_close;
+  Atomic.trace test_close2;


### PR DESCRIPTION
This isn't currently exposed in the public interface, but that could be done easily enough.

Need to decide how to indicate end-of-stream. This version has `take` return `None`, but that also means that `take_nonblocking` returns `None` for both no-item and closed-stream.

/cc @SGrondin This might be useful for #639.