### PR TITLE
eio_windows: add explicit fmt dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -56,6 +56,7 @@
  (allow_empty)  ; Work-around for dune bug #6938
  (depends
   (eio (= :version))
+  (fmt (>= 0.8.9))
   (kcas (and (>= 0.3.0) :with-test))
   (alcotest (and (>= 1.7.0) :with-test))))
 (package

--- a/eio_windows.opam
+++ b/eio_windows.opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
   "eio" {= version}
+  "fmt" {>= "0.8.9"}
   "kcas" {>= "0.3.0" & with-test}
   "alcotest" {>= "1.7.0" & with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
Avoids a CI warning.