### PR TITLE
eio.mock: auto-advancing mock clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,16 +982,24 @@ The standard environment provides a [clock][Eio.Time] with the usual POSIX time:
 ```ocaml
 # Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
-  traceln "The time is now %f" (Eio.Time.now clock);
-  Eio.Time.sleep clock 1.0;
   traceln "The time is now %f" (Eio.Time.now clock);;
 +The time is now 1623940778.270336
-+The time is now 1623940779.270336
 - : unit = ()
 ```
 
-You might like to replace this clock with a mock for tests.
-In fact, this README does just that! See [doc/prelude.ml](doc/prelude.ml) for the fake clock used in the example above.
+The mock backend provides a mock clock that advances automatically where there is nothing left to do:
+
+```ocaml
+# Eio_mock.Backend.run_full @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  traceln "Sleeping for five seconds...";
+  Eio.Time.sleep clock 5.0;
+  traceln "Resumed";;
++Sleeping for five seconds...
++mock time is now 5
++Resumed
+- : unit = ()
+```
 
 ## Multicore Support
 

--- a/doc/prelude.ml
+++ b/doc/prelude.ml
@@ -4,30 +4,16 @@
 module Eio_main = struct
   open Eio.Std
 
-  let now = ref 1623940778.27033591
-
   module Fake_clock = struct
     type time = float
-    type t = time Eio.Time.clock_ty r  (* The real clock *)
-
-    let make real_clock = (real_clock :> t)
-
-    let sleep_until real_clock time =
-      (* The fake times are all in the past, so we just ask to wait until the
-         fake time is due and it will happen immediately. If we wait for
-         multiple times, they'll get woken in the right order. At the moment,
-         the scheduler only checks for expired timers when the run-queue is
-         empty, so this is a convenient way to wait for the system to be idle.
-         TODO: This is no longer true (since #213). *)
-      Eio.Time.sleep_until real_clock time;
-      now := max !now time
-
-    let now _ = !now
+    type t = unit
+    let sleep_until () _time = failwith "No sleeping in tests!"
+    let now _ = 1623940778.27033591
   end
 
   let fake_clock =
     let handler = Eio.Time.Pi.clock (module Fake_clock) in
-    fun real_clock -> Eio.Resource.T (Fake_clock.make real_clock, handler)
+    Eio.Resource.T ((), handler)
 
   let run fn =
     (* To avoid non-deterministic output, we run the examples a single domain. *)
@@ -41,7 +27,7 @@ module Eio_main = struct
       method cwd         = env#cwd
       method process_mgr = env#process_mgr
       method domain_mgr  = fake_domain_mgr
-      method clock       = fake_clock env#clock
+      method clock       = fake_clock
     end
 end
 

--- a/lib_eio/mock/backend.mli
+++ b/lib_eio/mock/backend.mli
@@ -10,3 +10,11 @@ exception Deadlock_detected
 val run : (unit -> 'a) -> 'a
 (** [run fn] runs an event loop and then calls [fn env] within it.
     @raise Deadlock_detected if the run queue becomes empty but [fn] hasn't returned. *)
+
+type stdenv = <
+  debug : Eio.Debug.t;
+  backend_id: string;
+>
+
+val run_full : (stdenv -> 'a) -> 'a
+(* [run_full] is like {!run} but also provides a mock environment. *)

--- a/lib_eio/mock/backend.mli
+++ b/lib_eio/mock/backend.mli
@@ -12,9 +12,14 @@ val run : (unit -> 'a) -> 'a
     @raise Deadlock_detected if the run queue becomes empty but [fn] hasn't returned. *)
 
 type stdenv = <
+  clock : Clock.t;
+  mono_clock : Clock.Mono.t;
   debug : Eio.Debug.t;
   backend_id: string;
 >
 
 val run_full : (stdenv -> 'a) -> 'a
-(* [run_full] is like {!run} but also provides a mock environment. *)
+(** [run_full] is like {!run} but also provides a mock environment.
+
+    The mock monotonic clock it provides advances automatically when there is nothing left to do.
+    The mock wall clock is linked directly to the monotonic time. *)

--- a/lib_eio/mock/clock.mli
+++ b/lib_eio/mock/clock.mli
@@ -1,3 +1,6 @@
+(** Note that {!Backend.run_full} provides mock clocks
+    that advance automatically when there is nothing left to do. *)
+
 open Eio.Std
 
 type 'time ty = [`Mock | 'time Eio.Time.clock_ty]
@@ -15,6 +18,9 @@ module type S = sig
   val advance : t -> unit
   (** [advance t] sets the time to the next scheduled event (adding any due fibers to the run queue).
       @raise Invalid_argument if nothing is scheduled. *)
+
+  val try_advance : t -> bool
+  (** Like {!advance}, but returns [false] instead of raising an exception. *)
 
   val set_time : t -> time -> unit
   (** [set_time t time] sets the time to [time] (adding any due fibers to the run queue). *)


### PR DESCRIPTION
The clock advances automatically when the run queue is empty, as discussed in https://github.com/ocaml-multicore/eio/pull/584#discussion_r1313985513.

Requested by @SGrondin.