### PR TITLE
Eio_mock.Backend.yield_until_stable

### DIFF
--- a/lib_eio/mock/backend.mli
+++ b/lib_eio/mock/backend.mli
@@ -10,3 +10,5 @@ exception Deadlock_detected
 val run : (unit -> 'a) -> 'a
 (** [run fn] runs an event loop and then calls [fn env] within it.
     @raise Deadlock_detected if the run queue becomes empty but [fn] hasn't returned. *)
+
+val yield_until_stable : unit -> unit

--- a/tests/fiber.md
+++ b/tests/fiber.md
@@ -416,9 +416,9 @@ The number of concurrent fibers can be limited:
        finish 1 "one";
        Fiber.yield ();
        finish 2 "two";
-       Fiber.yield (); Fiber.yield ();
+       Eio_mock.Backend.yield_until_stable ();
        finish 0 "zero";
-       Fiber.yield (); Fiber.yield ();
+       Eio_mock.Backend.yield_until_stable ();
        finish 3 "three";
     );;
 +Start 0
@@ -468,9 +468,9 @@ Simple iteration:
        finish 1;
        Fiber.yield ();
        finish 2;
-       Fiber.yield (); Fiber.yield ();
+       Eio_mock.Backend.yield_until_stable ();
        finish 0;
-       Fiber.yield (); Fiber.yield ();
+       Eio_mock.Backend.yield_until_stable ();
        finish 3;
     );;
 +Start 0


### PR DESCRIPTION
This is a complement to the new auto-advancing mock clocks of #644 

I didn't replace the double-yield in `network.md` because #644 takes care of it.

This PR is intended to eliminate the need to manually yield more than once in tests, in the absence of clocks.