### PR TITLE
Add Path.{basename,dirname}

### DIFF
--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -53,6 +53,10 @@ let split (dir, p) =
       in
       Some ((dir, dirname), basename)
 
+let basename t = Option.map snd (split t)
+
+let dirname t = Option.map (fun ((_, dir), _) -> dir) (split t)
+
 let open_in ~sw t =
   let (Resource.T (dir, ops), path) = t in
   let module X = (val (Resource.get ops Fs.Pi.Dir)) in

--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -55,7 +55,7 @@ let split (dir, p) =
 
 let basename t = Option.map snd (split t)
 
-let dirname t = Option.map (fun ((_, dir), _) -> dir) (split t)
+let dirname t = Option.map fst (split t)
 
 let open_in ~sw t =
   let (Resource.T (dir, ops), path) = t in

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -81,6 +81,42 @@ val split : 'a t -> ('a t * string) option
     - [split (root, "/") = None]
 *)
 
+val basename : _ t -> string option
+(** [basename t] returns the last path component in [t].
+
+    This is a convenience wrapper around {!split}. [basename t = None] if there
+    is nothing to split.
+
+   For example:
+
+    - [basename (root, "foo/bar") = Some "bar"]
+    - [basename (root, "/foo/bar") = Some "bar"]
+    - [basename (root, "/foo/bar/baz") = Some "baz"]
+    - [basename (root, "/foo/bar//baz/") = Some "baz"]
+    - [basename (root, "bar") = Some "bar"]
+    - [basename (root, ".") = Some "."]
+    - [basename (root, "") = None]
+    - [basename (root, "/") = None]
+*)
+
+val dirname : _ t -> string option
+(** [dirname t] returns [Some dir], where [dir] is [t] without its last path component.
+
+    This is a convenience wrapper around {!split}. [dirname t = None] if there
+    is nothing to split.
+
+    For example:
+
+    - [dirname (root, "foo/bar") = Some "foo"]
+    - [dirname (root, "/foo/bar") = Some "/foo"]
+    - [dirname (root, "/foo/bar/baz") = Some "/foo/bar"]
+    - [dirname (root, "/foo/bar//baz/") = Some "/foo/bar"]
+    - [dirname (root, "bar") = Some ""]
+    - [dirname (root, ".") = Some ""]
+    - [dirname (root, "") = None]
+    - [dirname (root, "/") = None]
+*)
+
 (** {1 Reading files} *)
 
 val load : _ t -> string

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -99,7 +99,7 @@ val basename : _ t -> string option
     - [basename (root, "/") = None]
 *)
 
-val dirname : _ t -> string option
+val dirname : 'a t -> 'a t option
 (** [dirname t] returns [Some dir], where [dir] is [t] without its last path component.
 
     This is a convenience wrapper around {!split}. [dirname t = None] if there
@@ -107,12 +107,12 @@ val dirname : _ t -> string option
 
     For example:
 
-    - [dirname (root, "foo/bar") = Some "foo"]
-    - [dirname (root, "/foo/bar") = Some "/foo"]
-    - [dirname (root, "/foo/bar/baz") = Some "/foo/bar"]
-    - [dirname (root, "/foo/bar//baz/") = Some "/foo/bar"]
-    - [dirname (root, "bar") = Some ""]
-    - [dirname (root, ".") = Some ""]
+    - [dirname (root, "foo/bar") = Some (root, "foo")]
+    - [dirname (root, "/foo/bar") = Some (root, "/foo")]
+    - [dirname (root, "/foo/bar/baz") = Some (root, "/foo/bar")]
+    - [dirname (root, "/foo/bar//baz/") = Some (root, "/foo/bar")]
+    - [dirname (root, "bar") = Some (root, "")]
+    - [dirname (root, ".") = Some (root, "")]
     - [dirname (root, "") = None]
     - [dirname (root, "/") = None]
 *)

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -318,7 +318,7 @@ let basename path = Eio.Path.basename (fake_dir, path)
 # Dirname
 
 ```ocaml
-let dirname path = Eio.Path.dirname (fake_dir, path)
+let dirname path = Eio.Path.dirname (fake_dir, path) |> Option.map (fun (_, dirname) -> dirname)
 ```
 
 ```ocaml

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -274,6 +274,88 @@ let split path = Eio.Path.split (fake_dir, path) |> Option.map (fun ((_, dirname
 - : (string * string) option = None
 ```
 
+# Basename
+
+```ocaml
+let basename path = Eio.Path.basename (fake_dir, path)
+```
+
+```ocaml
+# basename "foo/bar";
+- : string option = Some "bar"
+
+# basename "/foo/bar";
+- : string option = Some "bar"
+
+# basename "/foo/bar/baz";
+- : string option = Some "baz"
+
+# basename "/foo/bar//baz/";
+- : string option = Some "baz"
+
+# basename "bar";
+- : string option = Some "bar"
+
+# basename "/bar";
+- : string option = Some "bar"
+
+# basename ".";
+- : string option = Some "."
+
+# basename "./";
+- : string option = Some "."
+
+# basename "";
+- : string option = None
+
+# basename "/";
+- : string option = None
+
+# basename "///";
+- : string option = None
+```
+
+# Dirname
+
+```ocaml
+let dirname path = Eio.Path.dirname (fake_dir, path)
+```
+
+```ocaml
+# dirname "foo/bar";
+- : string option = Some "foo"
+
+# dirname "/foo/bar";
+- : string option = Some "/foo"
+
+# dirname "/foo/bar/baz";
+- : string option = Some "/foo/bar"
+
+# dirname "/foo/bar//baz/";
+- : string option = Some "/foo/bar"
+
+# dirname "bar";
+- : string option = Some ""
+
+# dirname "/bar";
+- : string option = Some "/"
+
+# dirname ".";
+- : string option = Some ""
+
+# dirname "./";
+- : string option = Some ""
+
+# dirname "";
+- : string option = None
+
+# dirname "/";
+- : string option = None
+
+# dirname "///";
+- : string option = None
+```
+
 # Mkdirs
 
 Recursively creating directories with `mkdirs`.


### PR DESCRIPTION
Add `Path.basename` and `Path.dirname` as convenience wrappers around `Path.split`.

I had originally thought it would be useful for these functions not to return an option, but later changed my mind. I updated the PR to match @talex5's recommendation in #642:

> I think basename etc should just be e.g. snd (split t).

As it turns out, I now only uses `split` in the piece of code that I was migrating to eio that prompted my original feedback, thus I am not confident whether these wrappers are useful. Please feel free to close the PR. Thank you!
