### PR TITLE
Executor_pool docs

### DIFF
--- a/doc/domainslib.md
+++ b/doc/domainslib.md
@@ -1,0 +1,32 @@
+You can resolve an Eio promise from non-Eio domains (or systhreads), which provides an easy way to retrieve the result.
+For example:
+
+<!-- $MDX skip -->
+```ocaml
+open Eio.Std
+
+let pool = Domainslib.Task.setup_pool ~num_domains:2 ()
+
+let fib n = ... (* Some Domainslib function *)
+
+let run_in_pool fn x =
+  let result, set_result = Promise.create () in
+  let _ : unit Domainslib.Task.promise = Domainslib.Task.async pool (fun () ->
+      Promise.resolve set_result @@
+      match fn x with
+      | r -> Ok r
+      | exception ex -> Error ex
+    )
+  in
+  Promise.await_exn result
+
+let () =
+  Eio_main.run @@ fun _ ->
+  Fiber.both
+    (fun () -> traceln "fib 30 = %d" (run_in_pool fib 30))
+    (fun () -> traceln "fib 10 = %d" (run_in_pool fib 10))
+```
+Note that most Domainslib functions can only be called from code running in the Domainslib pool,
+while most Eio functions can only be used from Eio domains.
+The bridge function `run_in_pool` makes use of the fact that `Domainslib.Task.async` is able to run from
+an Eio domain, and `Eio.Promise.resolve` is able to run from a Domainslib one.

--- a/doc/kcas.md
+++ b/doc/kcas.md
@@ -1,0 +1,56 @@
+Eio provides the support [kcas][] requires to implement blocking in the
+lock-free software transactional memory (STM) implementation that it provides.
+This means that one can use all the composable lock-free data structures and
+primitives for communication and synchronization implemented using **kcas** to
+communicate and synchronize between Eio fibers, raw domains, and any other
+schedulers that provide the domain local await mechanism.
+
+To demonstrate **kcas**
+
+```ocaml
+# #require "kcas"
+# open Kcas
+```
+
+let's first create a couple of shared memory locations
+
+```ocaml
+# let x = Loc.make 0
+val x : int Loc.t = <abstr>
+# let y = Loc.make 0
+val y : int Loc.t = <abstr>
+```
+
+and spawn a domain
+
+```ocaml
+# let foreign_domain = Domain.spawn @@ fun () ->
+    let x = Loc.get_as (fun x -> Retry.unless (x <> 0); x) x in
+    Loc.set y 22;
+    x
+val foreign_domain : int Domain.t = <abstr>
+```
+
+that first waits for one of the locations to change value and then writes to the
+other location.
+
+Then we run a Eio program
+
+```ocaml
+# let y = Eio_main.run @@ fun _env ->
+    Loc.set x 20;
+    Loc.get_as (fun y -> Retry.unless (y <> 0); y) y
+val y : int = 22
+```
+
+that first writes to the location the other domain is waiting on and then waits
+for the other domain to write to the other location.
+
+Joining with the other domain
+
+```ocaml
+# y + Domain.join foreign_domain
+- : int = 42
+```
+
+we arrive at the answer.

--- a/lib_eio/executor_pool.mli
+++ b/lib_eio/executor_pool.mli
@@ -1,9 +1,9 @@
-(** An executor pool distributes jobs among a pool of domains workers (threads).
+(** An executor pool distributes jobs (functions to execute) among a pool of domain workers (threads).
 
     Domains are reused and can execute multiple jobs concurrently.
     Jobs are queued up if they cannot be started immediately due to all workers being busy.
 
-    [Eio.Executor_pool] is the recommended way of leveraging OCaml's 5 multicore capabilities.
+    [Eio.Executor_pool] is the recommended way of leveraging OCaml 5's multicore capabilities.
     It is built on top of the low level [Eio.Domain_manager].
 
     Usually you will only want one pool for an entire application,
@@ -37,7 +37,7 @@ val create :
     The executor pool will not block switch [sw] from completing;
     when the switch finishes, all domain workers and running jobs are cancelled.
 
-    @param domain_count The number of additional domain workers to create.
+    @param domain_count The number of domain workers to create.
                         The total number of domains should not exceed {!Domain.recommended_domain_count} or the number of cores on your system.
                         Additionally, consider reducing this number by 1 if your original domain will be performing CPU intensive work at the same time as the Executor_pool.
 *)


### PR DESCRIPTION
Changes to the README:
- Replaced a few `"5.0"` with `"5.1"` since Eio now requires OCaml 5.1
- Moved the `Domainslib` and `kcas` sections to their own files in `doc/`
- Rewrote the `Multicore Support` section to include, in order:
  - an overview of the tools available
  - a comparison between `Executor_pool` and `Domain_manager.run`. Assumption: expert users will know when they need to directly create threads, no need to explain the rationale to them.
  - docs and example for `Executor_pool`
  - docs and example for `Domain_manager.run`
  - a basic "Multicore Performance Guide" based on our conversation with @samoht
- ~I've moved the following sections to be after `Synchronization tools`:~
  - ~`Multicore Support` (the user shoul learn about Promise, Mutexes, Streams, etc. first)~
  - ~`Running processes` (same, and I expect this feature to see less frequent use than most modules that were placed ahead of it in the docs)~
  - ~`Tracing` (this is a somewhat advanced feature, mostly geared towards debugging. I find it easier to not constantly mix "features" with "testing+debugging" in the docs)~
  - ~`Testing with Mocks` (same as Tracing)~
- ~Moved the `Mock Clocks` section from `Time` to `Testing with Mocks`~
- Removed the `Worker Pool` example from the `Streams` section
  - I kept as much information as possible. Feel free to re-add anything here.

Please let me know if any of the above causes issues. Feel free to make changes directly on this branch.