### PR TITLE
Add Buf_write.printf (symbolic formatter)

### DIFF
--- a/lib_eio/buf_write.mli
+++ b/lib_eio/buf_write.mli
@@ -46,7 +46,7 @@
     or application-specific output APIs.
 
     A Buf_write serializer manages an internal buffer and a queue of output
-    buffers. The output bufferes may be a sub range of the serializer's
+    buffers. The output buffers may be a sub range of the serializer's
     internal buffer or one that is user-provided. Buffered writes such as
     {!string}, {!char}, {!cstruct}, etc., copy the source bytes into the
     serializer's internal buffer. Unbuffered writes are done with
@@ -122,6 +122,18 @@ val cstruct : t -> Cstruct.t -> unit
 (** [cstruct t cs] copies [cs] into the serializer's internal buffer.
     It is safe to modify [cs] after this call returns.
     For large cstructs, it may be more efficient to use {!schedule_cstruct}. *)
+
+val printf : t -> ('a, Format.formatter, unit) format -> 'a
+(** [printf t fmt x y z] formats the arguments according to the format string [fmt].
+    It supports all formatting and pretty-printing features of the Format module.
+    Accordingly, explicit flushes using [@.] or [%!] must perform a full (blocking) flush
+    so consider using [Fiber.fork] in such cases. *)
+
+val get_formatter : t -> Format.formatter
+(** [get_formatter t] returns the underlying formatter used by calls to [printf].
+    This function is useful to mutate formatter settings by calling, for example,
+    [Format.pp_set_margin] or [Format.pp_set_geometry].
+    Note that these formatter settings only affect calls to [printf]. *)
 
 val write_gen
   :  t

--- a/tests/buf_write.md
+++ b/tests/buf_write.md
@@ -146,6 +146,44 @@ With pausing
 - : unit = ()
 ```
 
+## Formatting
+
+```ocaml
+# Eio_mock.Backend.run @@ fun () ->
+  let f t =
+    let formatter = Write.get_formatter t in
+    Write.string t "Hello";
+    Format.pp_set_geometry formatter ~max_indent:4 ~margin:10;
+    (*
+      "@ "      breakable space
+      "@[<v 6>" open vertical box, indentation: 6 (overriden by our geometry settings)
+      "%s"      print string
+      "@ "      breakable space
+      "%i"      print int
+      "@."      print newline + explicit flush
+      "%a"      print arbitrary type
+      "@]"      close box
+      "@ "      breakable space
+    *)
+    Write.printf t "@ @[<v 6>%s@ %i@.%a@]@ "
+      "This is a test" 123
+      Eio.Net.Sockaddr.pp (`Tcp (Eio.Net.Ipaddr.V6.loopback, 8080));
+
+    Write.string t "-> Not from printf <-";
+    Write.printf t "@.Ok back to %s@." "printf";
+    Write.string t "Goodbye"
+  in
+  Write.with_flow flow f;;
++flow: wrote "Hello\n"
++            "This is a test\n"
++            "    123\n"
++flow: wrote "tcp:[::1]:8080\n"
++            "-> Not from printf <-\n"
++flow: wrote "Ok back to printf\n"
++flow: wrote "Goodbye"
+- : unit = ()
+```
+
 ## Flushing
 
 ```ocaml


### PR DESCRIPTION
This PR adds `Eio.Buf_write.printf` and `Eio.Buf_write.get_formatter`.

I decided to work on this when I saw this exchange:

@mbarbin in #642 
> I felt like missing a function to refactor code that would make use of format string, such as `Printf.printf` or `Format.printf` equivalent. So far this looks like `Eio.Flow.copy_string (Printf.sprintf "..." ...) sink`. It would be great to have a more direct alternate, that probably would take the sink as first argument and format second.

@talex5 
> I think `Buf_write.printf` would be a great addition (PRs welcome).

The `Format` module is surprisingly powerful and I wanted to support its full breadth of features. This is not possible by dropping down to a string with `Format.sprintf`.

There are 2 ways to do this:
- Custom formatter: `Format.make_formatter do_write do_flush`
  - `do_write` is `(string -> int -> int -> unit)`
  - `do_flush` is `(unit -> unit)`
- Symbolic formatter: `Format.make_symbolic_output_buffer`, `Format.formatter_of_symbolic_output_buffer` and `Format.flush_symbolic_output_buffer`

On the surface, using a Custom Formatter appears to be the way to go. It exposes the formatter's internal buffer (along with `pos` and `len`) in the `do_write` callback, letting us copy it into the `Buf_write` buffer. The problem is that the formatter has its own buffering and we're forced to track whether `printf` has been called in order to issue manual flushes of the formatter every time the user calls another writing function (like `Buf_write.string`, `Buf_write.cstruct`, etc). It adds a lot of messy state to `Buf_write.t`.

With a symbolic formatter, the lifecycle of a call to `Buf_write.printf` does not leak into a dozen of other functions and it doesn't add mutable state to `Buf_write.t`. I'm also able to "look ahead" in the pattern and issue exactly one call to `ensure_space`, one call to `writable_exn`, and the minimal number of calls to `wake_writer`. The full range of `Format` features is supported, including `%a` and explicit flushes (`%!`, `@.`). The downside of the symbolic formatter is the increased allocations: it's a list of variants with nice sliced strings, not just offsets in a buffer. Overall I believe this is acceptable because of the other optimizations it enables.