### PR TITLE
Improve tracing

### DIFF
--- a/lib_eio/buf_write.ml
+++ b/lib_eio/buf_write.ml
@@ -456,7 +456,7 @@ let rec await_batch t =
   | Closed, false -> raise End_of_file
   | (Active | Closed), true -> Buffers.to_list t.scheduled
   | Paused, _ | Active, false ->
-    Suspend.enter (fun ctx enqueue ->
+    Suspend.enter "Buf_write.await_batch" (fun ctx enqueue ->
         Fiber_context.set_cancel_fn ctx (fun ex ->
             t.wake_writer <- ignore;
             enqueue (Error ex)

--- a/lib_eio/condition.ml
+++ b/lib_eio/condition.ml
@@ -12,7 +12,7 @@ let lock_protected m =
 
 let await_generic ?mutex t =
   match
-    Suspend.enter_unchecked (fun ctx enqueue ->
+    Suspend.enter_unchecked "Condition.await" (fun ctx enqueue ->
         match Fiber_context.get_error ctx with
         | Some ex ->
           Option.iter Eio_mutex.unlock mutex;
@@ -90,7 +90,7 @@ let rec loop_no_mutex t fn =
     ensure_cancelled request;
     x
   | None ->
-    Suspend.enter_unchecked (fun ctx enqueue ->
+    Suspend.enter_unchecked "Condition.loop_no_mutex" (fun ctx enqueue ->
         match Fiber_context.get_error ctx with
         | Some ex ->
           ensure_cancelled request;

--- a/lib_eio/core/dla.ml
+++ b/lib_eio/core/dla.ml
@@ -7,7 +7,7 @@ let prepare_for_await () =
       | _ -> ()
   and await () =
     if Atomic.get state != `Released then
-      Suspend.enter @@ fun ctx enqueue ->
+      Suspend.enter "domain-local-await" @@ fun ctx enqueue ->
       let awaiting = `Awaiting enqueue in
       if Atomic.compare_and_set state `Init awaiting then (
         Cancel.Fiber_context.set_cancel_fn ctx (fun ex ->

--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -698,15 +698,18 @@ module Private : sig
 
   (** Suspend a fiber and enter the scheduler. *)
   module Suspend : sig
-    val enter : (Fiber_context.t -> 'a Effects.enqueue -> unit) -> 'a
-    (** [enter fn] suspends the calling fiber and calls [fn ctx enqueue] in the scheduler's context.
+    val enter : string -> (Fiber_context.t -> 'a Effects.enqueue -> unit) -> 'a
+    (** [enter op fn] suspends the calling fiber and calls [fn ctx enqueue] in the scheduler's context.
+
         This should arrange for [enqueue] to be called when the fiber should be resumed.
         [enqueue] is thread-safe and so can be called from another domain or systhread.
 
         [ctx] should be used to set a cancellation function. Otherwise, the operation is non-interruptable.
-        If the caller's cancellation context is already cancelled, [enter] immediately aborts. *)
+        If the caller's cancellation context is already cancelled, [enter] immediately aborts.
 
-    val enter_unchecked : (Fiber_context.t -> 'a Effects.enqueue -> unit) -> 'a
+        [op] is used when tracing to label the operation. *)
+
+    val enter_unchecked : string -> (Fiber_context.t -> 'a Effects.enqueue -> unit) -> 'a
     (** [enter_unchecked] is like [enter] except that it does not perform the initial check
         that the fiber isn't cancelled (this is useful if you want to do the check yourself, e.g.
         because you need to unlock a mutex if cancelled). *)

--- a/lib_eio/core/single_waiter.ml
+++ b/lib_eio/core/single_waiter.ml
@@ -10,9 +10,9 @@ let create () = { wake = ignore }
 
 let wake t v = t.wake v
 
-let await t id =
+let await t op id =
   let x =
-    Suspend.enter @@ fun ctx enqueue ->
+    Suspend.enter op @@ fun ctx enqueue ->
     Cancel.Fiber_context.set_cancel_fn ctx (fun ex ->
         t.wake <- ignore;
         enqueue (Error ex)
@@ -23,5 +23,5 @@ let await t id =
         enqueue x
       )
   in
-  Trace.read id;
+  Trace.get id;
   x

--- a/lib_eio/core/suspend.ml
+++ b/lib_eio/core/suspend.ml
@@ -1,10 +1,12 @@
 type 'a enqueue = ('a, exn) result -> unit
 type _ Effect.t += Suspend : (Cancel.fiber_context -> 'a enqueue -> unit) -> 'a Effect.t
 
-let enter_unchecked fn = Effect.perform (Suspend fn)
+let enter_unchecked op fn =
+  Trace.suspend_fiber op;
+  Effect.perform (Suspend fn)
 
-let enter fn =
-  enter_unchecked @@ fun fiber enqueue ->
+let enter op fn =
+  enter_unchecked op @@ fun fiber enqueue ->
   match Cancel.Fiber_context.get_error fiber with
   | None -> fn fiber enqueue
   | Some ex -> enqueue (Error ex)

--- a/lib_eio/core/trace.mli
+++ b/lib_eio/core/trace.mli
@@ -12,29 +12,44 @@ val mint_id : unit -> id
 val log : string -> unit
 (** [log msg] attaches text [msg] to the current fiber. *)
 
+val with_span : string -> (unit -> 'a) -> 'a
+(** [with_span op fn] runs [fn ()], labelling the timespan during which it runs with [op]. *)
+
+val suspend_fiber : string -> unit
+(** [suspend_fiber op] records that the current fiber is now suspended waiting for [op]. *)
+
 (** {2 Recording system events}
     These are normally only called by the scheduler. *)
 
-val create : ?label:string -> id -> Eio_runtime_events.ty -> unit
-(** [create id ty] records the creation of [id]. *)
+val create_fiber : cc:id -> id -> unit
+(** [create_fiber ~cc id] records the creation of fiber [id] in context [cc]. *)
 
-val read : id -> unit
-(** [read src] records that promise [src]'s value was read. *)
+val create_cc : id -> Eio_runtime_events.cc_ty -> unit
+(** [create_cc id ty] records the creation of cancellation context [id]. *)
 
-val try_read : id -> unit
-(** [try_read src] records that the current fiber wants to read from [src] (which is not currently ready). *)
+val create_obj : ?label:string -> id -> Eio_runtime_events.obj_ty -> unit
+(** [create_obj id ty] records the creation of [id]. *)
+
+val get : id -> unit
+(** [get src] records reading a promise, taking from a stream, taking a lock, etc. *)
+
+val try_get : id -> unit
+(** [try_get src] records that the current fiber wants to get from [src] (which is not currently ready). *)
+
+val put : id -> unit
+(** [put dst] records resolving a promise, adding to a stream, releasing a lock, etc. *)
 
 val fiber : id -> unit
 (** [fiber id] records that [id] is now the current fiber for this domain. *)
 
-val suspend : Runtime_events.Type.span -> unit
-(** [suspend] records when the event loop is stopped waiting for events from the OS. *)
+val suspend_domain : Runtime_events.Type.span -> unit
+(** [suspend_domain] records when the event loop is stopped waiting for events from the OS. *)
 
-val resolve : id -> unit
-(** [resolve id] records that [id] is now resolved. *)
+val exit_cc : unit -> unit
+(** [exit_cc ()] records that the current CC has finished. *)
 
-val resolve_error : id -> exn -> unit
-(** [resolve_error id exn] records that [id] is now failed. *)
+val exit_fiber : id -> unit
+(** [exit_fiber id] records that fiber [id] has finished. *)
 
-val signal : id -> unit
-(** [signal x] records that [x] was signalled. *)
+val error : id -> exn -> unit
+(** [error id exn] records that [id] received an error. *)

--- a/lib_eio/pool.ml
+++ b/lib_eio/pool.ml
@@ -135,7 +135,7 @@ let use t f =
       maybe_add_slot t;
       (* No item is available right now. Start waiting *)
       let slot =
-        Suspend.enter_unchecked (fun ctx enqueue ->
+        Suspend.enter_unchecked "Pool.acquire" (fun ctx enqueue ->
             let r x = enqueue (Ok x) in
             if Atomic.compare_and_set cell In_transition (Request r) then (
               match Fiber_context.get_error ctx with

--- a/lib_eio/runtime_events/eio_runtime_events.mli
+++ b/lib_eio/runtime_events/eio_runtime_events.mli
@@ -2,45 +2,73 @@
 
 type id = int
 
-type ty =
-  | Fiber
+type obj_ty =
   | Promise
   | Semaphore
-  | Switch
   | Stream
   | Mutex
 (** Types of recorded objects. *)
 
-val ty_to_string : ty -> string
+val obj_ty_to_string : obj_ty -> string
+
+type cc_ty =
+  | Switch
+  | Protect
+  | Sub
+  | Root
+  | Any
+(** Types of cancellation contexts. *)
+
+val cc_ty_to_string : cc_ty -> string
 
 (** {2 Writing events} *)
 
-val create : (id * ty) Runtime_events.User.t
+val create_fiber : (id * id) Runtime_events.User.t
+val create_cc : (id * cc_ty) Runtime_events.User.t
+val create_obj : (id * obj_ty) Runtime_events.User.t
 val log : string Runtime_events.User.t
+val enter_span : string Runtime_events.User.t
+val exit_span : unit Runtime_events.User.t
 val name : (id * string) Runtime_events.User.t
-val resolve : id Runtime_events.User.t
-val resolve_error : (id * exn) Runtime_events.User.t
+val suspend_fiber : string Runtime_events.User.t
+val exit_cc : unit Runtime_events.User.t
+val exit_fiber : id Runtime_events.User.t
+val error : (id * exn) Runtime_events.User.t
 val fiber : id Runtime_events.User.t
-val read : id Runtime_events.User.t
-val try_read : id Runtime_events.User.t
-val signal : id Runtime_events.User.t
-val suspend : Runtime_events.Type.span Runtime_events.User.t
+val get : id Runtime_events.User.t
+val try_get : id Runtime_events.User.t
+val put : id Runtime_events.User.t
+val suspend_domain : Runtime_events.Type.span Runtime_events.User.t
 
 (** {2 Consuming events} *)
+    
+type event = [
+  | `Create of id * [
+      | `Fiber_in of id         (** A new fiber is created in the given CC. *)
+      | `Cc of cc_ty            (** The running fiber creates a new CC. *)
+      | `Obj of obj_ty          (** The running fiber creates a new object. *)
+    ]
+  | `Fiber of id                (** The given fiber is now running. *)
+  | `Name of id * string        (** Names a promise, stream, etc. *)
+  | `Log of string              (** The running fiber logs a message. *)
+  | `Enter_span of string       (** The running fiber enters a traced section. *)
+  | `Exit_span                  (** The running fiber leaves the current traced section. *)
+  | `Get of id                  (** The running fiber gets a value from a promise, stream, acquires a lock, etc. *)
+  | `Try_get of id              (** The running fiber wants to get, but must wait. *)
+  | `Put of id                  (** The running fiber resolves a promise, adds to a stream, releases a lock etc. *)
+  | `Error of (id * string)     (** A CC fails with the given error. *)
+  | `Exit_cc                    (** The current CC ends. *)
+  | `Exit_fiber of id           (** The running fiber ends. *)
+  | `Suspend_domain of Runtime_events.Type.span  (** The domain asks the OS to wait for events. *)
+  | `Suspend_fiber of string    (** The running fiber is suspended (until resumed by [`Fiber]). *)
+]
 
-type 'a handler = int -> Runtime_events.Timestamp.t -> 'a -> unit
-(** A ['a handler] is a function for handling events of type ['a].
-    It is called as [handler ring_id ts value]. *)
+val pp_event : Format.formatter -> event -> unit
+(** [pp_event] formats an event as a human-readable string *)
 
 val add_callbacks:
-  ?create:(id * ty) handler ->
-  ?read:id handler ->
-  ?try_read:id handler ->
-  ?resolve:id handler ->
-  ?resolve_error:(id * string) handler ->
-  ?name:(id * string) handler ->
-  ?log:string handler ->
-  ?fiber:id handler ->
-  ?signal:id handler ->
-  ?suspend:Runtime_events.Type.span handler ->
+  (int -> Runtime_events.Timestamp.t -> event -> unit) ->
   Runtime_events.Callbacks.t -> Runtime_events.Callbacks.t
+(** [add_callbacks fn x] adds event handler [fn] to [x].
+
+    When an Eio event is processed, it calls [fn ring_id ts event]. *)

--- a/lib_eio/semaphore.ml
+++ b/lib_eio/semaphore.ml
@@ -5,14 +5,14 @@ type t = {
 
 let make n =
   let id = Trace.mint_id () in
-  Trace.create id Semaphore;
+  Trace.create_obj id Semaphore;
   {
     id;
     state = Sem_state.create n;
   }
 
 let release t =
-  Trace.signal t.id;
+  Trace.put t.id;
   Sem_state.release t.state
 
 let acquire t =
@@ -20,11 +20,11 @@ let acquire t =
     (* No free resources.
        We must wait until one of the existing users increments the counter and resumes us.
        It's OK if they resume before we suspend; we'll just pick up the token they left. *)
-    Suspend.enter_unchecked (fun ctx enqueue ->
+    Suspend.enter_unchecked "Semaphore.acquire" (fun ctx enqueue ->
         match Sem_state.suspend t.state (fun () -> enqueue (Ok ())) with
         | None -> ()   (* Already resumed *)
         | Some request ->
-          Trace.try_read t.id;
+          Trace.try_get t.id;
           match Fiber_context.get_error ctx with
           | Some ex ->
             if Sem_state.cancel request then enqueue (Error ex);
@@ -36,7 +36,7 @@ let acquire t =
               )
       )
   );
-  Trace.read t.id
+  Trace.get t.id
 
 let get_value t =
   max 0 (Atomic.get t.state.state)

--- a/lib_eio/sync.ml
+++ b/lib_eio/sync.ml
@@ -408,7 +408,7 @@ let put_already_suspended t request =
    Note that we may be suspending the fiber even when using the "resume" queue,
    if the consumer is still in the process of writing its slot. *)
 let put_suspend t v loc =
-  Suspend.enter_unchecked @@ fun ctx enqueue ->
+  Suspend.enter_unchecked "Sync.put" @@ fun ctx enqueue ->
   let cancel =
     match loc with
     | Short _ -> `Resuming      (* Can't cancel this *)
@@ -454,7 +454,7 @@ let rec consumer_resume_cell t ~success ~in_transition cell =
     else consumer_resume_cell t ~success ~in_transition cell
 
 let take_suspend t loc =
-  Suspend.enter_unchecked @@ fun ctx enqueue ->
+  Suspend.enter_unchecked "Sync.take" @@ fun ctx enqueue ->
   let Short cell | Long (_, cell) = loc in
   let kc v = enqueue (Ok v); true in
   add_to_cell t.producers (Slot kc) cell;

--- a/lib_eio/unix/rcfd.ml
+++ b/lib_eio/unix/rcfd.ml
@@ -132,7 +132,7 @@ let remove t =
     put t;
     None
   | Open fd as prev ->
-    Eio.Private.Suspend.enter_unchecked (fun _ctx enqueue ->
+    Eio.Private.Suspend.enter_unchecked "Rcfd.remove" (fun _ctx enqueue ->
         if Atomic.compare_and_set t.fd prev (Closing (fun () -> enqueue (Ok (Some fd)))) then (
           (* We transitioned from [open] to [closing/users]. We are the closer. *)
           put t

--- a/lib_eio/waiters.ml
+++ b/lib_eio/waiters.ml
@@ -62,5 +62,5 @@ let await_internal ~mutex (t:'a t) ctx enqueue =
       Mutex.unlock mutex
 
 (* Returns a result if the wait succeeds, or raises if cancelled. *)
-let await ~mutex waiters =
-  Suspend.enter_unchecked (await_internal ~mutex waiters)
+let await ~mutex op waiters =
+  Suspend.enter_unchecked op (await_internal ~mutex waiters)

--- a/lib_eio/waiters.mli
+++ b/lib_eio/waiters.mli
@@ -21,8 +21,9 @@ val is_empty : 'a t -> bool
 
 val await :
   mutex:Mutex.t option ->
+  string ->
   'a t -> 'a
-(** [await ~mutex t] suspends the current fiber and adds its continuation to [t].
+(** [await ~mutex op t] suspends the current fiber and adds its continuation to [t].
     When the waiter is woken, the fiber is resumed and returns the result.
     If [t] can be used from multiple domains:
     - [mutex] must be set to the mutex to use to unlock it.

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -408,14 +408,14 @@ module Domain_mgr = struct
 
   let run_raw _t fn =
     let domain = ref None in
-    Sched.enter (fun t k ->
+    Sched.enter "run-domain" (fun t k ->
         domain := Some (Domain.spawn (fun () -> Fun.protect (wrap_backtrace fn) ~finally:(fun () -> Sched.enqueue_thread t k ())))
       );
     unwrap_backtrace (Domain.join (Option.get !domain))
 
   let run t fn =
     let domain = ref None in
-    Sched.enter (fun sched k ->
+    Sched.enter "run-domain" (fun sched k ->
         let cancelled, set_cancelled = Promise.create () in
         Fiber_context.set_cancel_fn k.fiber (Promise.resolve set_cancelled);
         domain := Some (Domain.spawn (fun () ->

--- a/lib_eio_posix/domain_mgr.ml
+++ b/lib_eio_posix/domain_mgr.ml
@@ -92,14 +92,14 @@ module Impl = struct
 
   let run_raw () fn =
     let domain = ref None in
-    Eio.Private.Suspend.enter (fun _ctx enqueue ->
+    Eio.Private.Suspend.enter "run-domain" (fun _ctx enqueue ->
         domain := Some (Domain.spawn (fun () -> Fun.protect (wrap_backtrace fn) ~finally:(fun () -> enqueue (Ok ()))))
       );
     unwrap_backtrace (Domain.join (Option.get !domain))
 
   let run () fn =
     let domain = ref None in
-    Eio.Private.Suspend.enter (fun ctx enqueue ->
+    Eio.Private.Suspend.enter "run-domain" (fun ctx enqueue ->
         let cancelled, set_cancelled = Promise.create () in
         Eio.Private.Fiber_context.set_cancel_fn ctx (Promise.resolve set_cancelled);
         domain := Some (Domain.spawn (fun () ->

--- a/lib_eio_posix/low_level.mli
+++ b/lib_eio_posix/low_level.mli
@@ -14,8 +14,8 @@ open Eio.Std
 
 type fd := Eio_unix.Fd.t
 
-val await_readable : fd -> unit
-val await_writable : fd -> unit
+val await_readable : string -> fd -> unit
+val await_writable : string -> fd -> unit
 
 val sleep_until : Mtime.t -> unit
 

--- a/lib_eio_posix/sched.mli
+++ b/lib_eio_posix/sched.mli
@@ -38,7 +38,9 @@ val await_timeout : t -> unit Eio_utils.Suspended.t -> Mtime.t -> exit
 
     When [time] is reached, [k] is resumed. Cancelling [k] removes the entry from the timer. *)
 
-val enter : (t -> 'a Eio_utils.Suspended.t -> exit) -> 'a
-(** [enter fn] suspends the current fiber and runs [fn t k] in the scheduler's context.
+val enter : string -> (t -> 'a Eio_utils.Suspended.t -> exit) -> 'a
+(** [enter op fn] suspends the current fiber and runs [fn t k] in the scheduler's context.
 
-    [fn] should either resume [k] immediately itself, or call one of the [await_*] functions above. *)
+    [fn] should either resume [k] immediately itself, or call one of the [await_*] functions above.
+
+    [op] is used when tracing. *)

--- a/lib_eio_windows/domain_mgr.ml
+++ b/lib_eio_windows/domain_mgr.ml
@@ -93,14 +93,14 @@ module Impl = struct
 
   let run_raw () fn =
     let domain = ref None in
-    Eio.Private.Suspend.enter (fun _ctx enqueue ->
+    Eio.Private.Suspend.enter "run-domain" (fun _ctx enqueue ->
         domain := Some (Domain.spawn (fun () -> Fun.protect (wrap_backtrace fn) ~finally:(fun () -> enqueue (Ok ()))))
       );
     unwrap_backtrace (Domain.join (Option.get !domain))
 
   let run () fn =
     let domain = ref None in
-    Eio.Private.Suspend.enter (fun ctx enqueue ->
+    Eio.Private.Suspend.enter "run-domain" (fun ctx enqueue ->
         let cancelled, set_cancelled = Promise.create () in
         Eio.Private.Fiber_context.set_cancel_fn ctx (Promise.resolve set_cancelled);
         domain := Some (Domain.spawn (fun () ->

--- a/lib_eio_windows/sched.ml
+++ b/lib_eio_windows/sched.ml
@@ -202,16 +202,16 @@ let rec next t : [`Exit_scheduler] =
           (* At this point we're not going to check [run_q] again before sleeping.
              If [need_wakeup] is still [true], this is fine because we don't promise to do that.
              If [need_wakeup = false], a wake-up event will arrive and wake us up soon. *)
-          Trace.suspend Begin;
+          Trace.suspend_domain Begin;
           let cons fd acc = fd :: acc in
           let read = FdSet.fold cons t.poll.to_read [] in
           let write = FdSet.fold cons t.poll.to_write [] in
           match Unix.select read write [] timeout with 
           | exception Unix.(Unix_error (EINTR, _, _)) ->
-            Trace.suspend End;
+            Trace.suspend_domain End;
             next t
           | readable, writeable, _ ->
-            Trace.suspend End;
+            Trace.suspend_domain End;
             Atomic.set t.need_wakeup false;
             Lf_queue.push t.run_q IO;                   (* Re-inject IO job in the run queue *)
             List.iter (ready t [ `W ]) writeable; 


### PR DESCRIPTION
This adds tracing of cancellation contexts and OS operations, and
documents and cleans up the API a bit.

When reading events, instead of the consumer providing one function per
event, we now use a single function taking a variant. This makes the API
easier to use and lets the caller decide whether they want to handle all
events (checked by the compiler) or just some of them.

Note: eio_posix yields before each operation to avoid starvation.
However, if it needed to block then it did another yield afterwards when
retrying, which isn't necessary and clutters up the traces. This commit
also removes that.