### PR TITLE
Add Eio.Pool.use ~never_block

### DIFF
--- a/lib_eio/pool.mli
+++ b/lib_eio/pool.mli
@@ -35,6 +35,12 @@ val create :
                    If it raises, the exception is passed on to the user,
                    but resource is still considered to have been disposed. *)
 
-val use : 'a t -> ('a -> 'b) -> 'b
+val use : 'a t -> ?never_block:bool -> ('a -> 'b) -> 'b
 (** [use t fn] waits for some resource [x] to be available and then runs [f x].
-    Afterwards (on success or error), [x] is returned to the pool. *)
+    Afterwards (on success or error), [x] is returned to the pool.
+
+    @param never_block If [true] and the pool has reached maximum capacity,
+                       then a fresh resource is created to ensure that this [use]
+                       call does not wait for a resource to become available.
+                       This resource is immediately disposed after [f x] returns.
+    *)


### PR DESCRIPTION
This PR adds the optional parameter `?never_block:bool` to `Eio.Pool.use`. The default is `false`.

Quoting `pool.mli`:
> If `true` and the pool has reached maximum capacity, then a fresh resource is created to ensure that this `use` call does not wait for a resource to become available. This resource is immediately disposed after [f x] returns.

In my opinion, this feature makes `Eio.Pool` a valid choice for a wider range of use cases.
| Method | Availability | Overhead |
|-----|-----|-----|
| Creating a resource every time | ✅ Never blocks | 🔴 No reuse |
| Eio.Pool.use | 🔴 Can block | ✅ Maximal reuse |
| Eio.Pool.use ~never_block:true | ✅ Never blocks | 🟡 Some reuse |