### PR TITLE
Mention Path module in File and Fs documentation

### DIFF
--- a/lib_eio/file.mli
+++ b/lib_eio/file.mli
@@ -1,3 +1,8 @@
+(** Files implement the {!Flow} APIs, which can be used for reading and writing data.
+    This module provides additonal file-specific operations, such as seeking within a file.
+
+    To get an open file, use the functions in the {!Path} module. *)
+
 open Std
 
 (** {2 Types} *)

--- a/lib_eio/fs.ml
+++ b/lib_eio/fs.ml
@@ -1,6 +1,9 @@
-(** Defines types used by file-systems. *)
+(** Note: file-system operations, such as opening or deleting files,
+    can be found in the {!Path} module. *)
 
 open Std
+
+(** {2 Types} *)
 
 type path = string
 
@@ -43,6 +46,8 @@ type create = [
 type dir_ty = [`Dir]
 type 'a dir = ([> dir_ty] as 'a) r
 (** Note: use the functions in {!Path} to access directories. *)
+
+(** {2 Provider Interface} *)
 
 module Pi = struct
   module type DIR = sig


### PR DESCRIPTION
Someone trying to open a file may start looking in these modules. Explain what each module is for and point people at the Path module.

Based on feedback from @clecat.