### PR TITLE
Optimise Flow.copy with Buf_read.as_flow

### DIFF
--- a/bench/bench_copy.ml
+++ b/bench/bench_copy.ml
@@ -1,3 +1,5 @@
+(* A client opens a connection to an echo service and sends a load of data via it. *)
+
 open Eio.Std
 
 let chunk_size = 1 lsl 16
@@ -31,7 +33,7 @@ let time name service =
   let time = t1 -. t0 in
   let bytes_per_second = float n_bytes /. time in
   traceln "%s: %.2f MB/s" name (bytes_per_second /. 1024. /. 1024.);
-  (Metric.create name (`Float bytes_per_second) "bytes/s" (name ^ " Flow.copy"))
+  Metric.create name (`Float bytes_per_second) "bytes/s" (name ^ " Flow.copy")
 
 let run _env =
   [

--- a/bench/bench_copy.ml
+++ b/bench/bench_copy.ml
@@ -1,0 +1,42 @@
+open Eio.Std
+
+let chunk_size = 1 lsl 16
+let n_chunks = 10000
+let n_bytes = n_chunks * chunk_size
+
+let run_client sock =
+  Fiber.both
+    (fun () ->
+       let chunk = Cstruct.create chunk_size in
+       for _ = 1 to n_chunks do
+         Eio.Flow.write sock [chunk]
+       done;
+       Eio.Flow.shutdown sock `Send
+    )
+    (fun () ->
+       let chunk = Cstruct.create chunk_size in
+       for _ = 1 to n_chunks do
+         Eio.Flow.read_exact sock chunk
+       done
+    )
+
+let time name service =
+  Switch.run @@ fun sw ->
+  let client_sock, server_sock = Eio_unix.Net.socketpair_stream ~sw () in
+  let t0 = Unix.gettimeofday () in
+  Fiber.both
+    (fun () -> service server_sock)
+    (fun () -> run_client client_sock);
+  let t1 = Unix.gettimeofday () in
+  let time = t1 -. t0 in
+  let bytes_per_second = float n_bytes /. time in
+  traceln "%s: %.2f MB/s" name (bytes_per_second /. 1024. /. 1024.);
+  (Metric.create name (`Float bytes_per_second) "bytes/s" (name ^ " Flow.copy"))
+
+let run _env =
+  [
+    time "default" (fun sock -> Eio.Flow.copy sock sock);
+    time "buf_read" (fun sock ->
+        let r = Eio.Buf_read.of_flow sock ~initial_size:(64 * 1024) ~max_size:(64 * 1024) |> Eio.Buf_read.as_flow in
+        Eio.Flow.copy r sock);
+  ]

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -11,6 +11,7 @@ let benchmarks = [
   "Eio_unix.Fd", Bench_fd.run;
   "File.stat", Bench_fstat.run;
   "Path.stat", Bench_stat.run;
+  "Flow.copy", Bench_copy.run;
 ]
 
 let usage_error () =

--- a/lib_eio/buf_read.ml
+++ b/lib_eio/buf_read.ml
@@ -140,7 +140,13 @@ module F = struct
     consume t len;
     len
 
-  let read_methods = []
+  let rsb t fn =
+    ensure t 1;
+    let data = peek t in
+    let sent = fn [data] in
+    consume t sent
+
+  let read_methods = [Flow.Read_source_buffer rsb]
 end
 
 let as_flow =


### PR DESCRIPTION
By default, `Flow.copy` creates a 4KB buffer and copies the data through that. However, if the source of the copy is a buffered reader then it is much more efficient to use its buffer directly.

This updates the flow you get from `Buf_read.as_flow` to offer this optimisation, and also updates the eio_posix backend's flow to use this optimisation when available (eio_linux already supported this).

Detected in a benchmark by @leostera.

Possibly we should increase the default buffer size too.

This PR is made of two commits. The first just adds a benchmark to show the effect of the change. On my Linux machine, I get:

```
buf_read: 1091.79 MB/s   # Before
buf_read: 3306.98 MB/s   # After
```