### PR TITLE
Remove default backtrace from Switch.fail

### DIFF
--- a/lib_eio/core/switch.ml
+++ b/lib_eio/core/switch.ml
@@ -47,7 +47,7 @@ let combine_exn ex = function
   | Some ex1 -> Exn.combine ex1 ex
 
 (* Note: raises if [t] is finished or called from wrong domain. *)
-let fail ?(bt=Printexc.get_raw_backtrace ()) t ex =
+let fail ?(bt=Printexc.get_callstack 0) t ex =
   check_our_domain t;
   if t.exs = None then
     Trace.error t.cancel.id ex;


### PR DESCRIPTION
If you didn't pass a backtrace then it would attach a bogus one, which was confusing.