### PR TITLE
Fiber.all: use the parent fiber

### DIFF
--- a/bench/bench_copy.ml
+++ b/bench/bench_copy.ml
@@ -23,7 +23,7 @@ let run_client sock =
     )
 
 let time name service =
-  Switch.run @@ fun sw ->
+  Switch.run ~name @@ fun sw ->
   let client_sock, server_sock = Eio_unix.Net.socketpair_stream ~sw () in
   let t0 = Unix.gettimeofday () in
   Fiber.both


### PR DESCRIPTION
Previously, it created one fiber for each job and then the parent fiber just waited. It's a little more efficient to have the parent fiber run the last job itself, and also reduces clutter in the traces.

This also affects `Fiber.both`, which uses `all` internally.