### PR TITLE
Fix quoting of quotes in process error messages

### DIFF
--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -97,7 +97,7 @@ let bad_char = function
     c <= 32 || c >= 127
 
 let pp_arg f x =
-  if x = "" || String.exists bad_char x then Fmt.(quote string) f x
+  if x = "" || String.exists bad_char x then Fmt.pf f "%S" x
   else Fmt.string f x
 
 let pp_args = Fmt.hbox (Fmt.list ~sep:Fmt.sp pp_arg)

--- a/tests/process.md
+++ b/tests/process.md
@@ -145,10 +145,10 @@ If a command fails, we get shown the arguments (quoted if necessary):
 
 ```ocaml
 # run @@ fun mgr env ->
-  Process.run mgr ["bash"; "-c"; "exit 3"; ""; "foo"];;
+  Process.run mgr ["bash"; "-c"; "exit 3"; ""; "foo"; "\"bar\""];;
 Exception:
 Eio.Io Process Child_error Exited (code 3),
-  running command: bash -c "exit 3" "" foo
+  running command: bash -c "exit 3" "" foo "\"bar\""
 ```
 
 Exit code success can be determined by is_success (Process.run):


### PR DESCRIPTION
When displaying an argument with quotes, they should be escaped to avoid ambiguity (`Fmt.quote` doesn't do this; it just puts quotes around the outside of the string).