### PR TITLE
Expect opam-repo-ci tests to fail on macos

### DIFF
--- a/eio_main.opam
+++ b/eio_main.opam
@@ -35,3 +35,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+x-ci-accept-failures: ["macos-homebrew"]

--- a/eio_main.opam.template
+++ b/eio_main.opam.template
@@ -1,0 +1,1 @@
+x-ci-accept-failures: ["macos-homebrew"]


### PR DESCRIPTION
It uses a sandbox that causes the network tests to fail, even though they only use the loopback interface.