### PR TITLE
Make benchmarks start faster

### DIFF
--- a/bench/bench_buf_read.ml
+++ b/bench/bench_buf_read.ml
@@ -1,8 +1,7 @@
 module R = Eio.Buf_read
 
-let test_data = String.init 100_000_000 (fun _ -> 'x')
-
 let run _env =
+  let test_data = String.make 100_000_000 'x' in
   let r = R.of_string test_data in
   let t0 = Unix.gettimeofday () in
   let i = ref 0 in


### PR DESCRIPTION
The Buf_read benchmark created a large string at start-up using `String.init`, which adds about 170ms to the start-up time of all benchmarks. Now, only create the string when running that benchmark, and use the more efficient `String.make`.

Before:
![before](https://github.com/ocaml-multicore/eio/assets/554131/ba540dc7-1193-4301-bdef-6d8cc0e66723)

After:
![after](https://github.com/ocaml-multicore/eio/assets/554131/322213b3-c354-42cc-a1bb-c91e20fad917)
