### PR TITLE
Trace domain spawning

### DIFF
--- a/lib_eio/core/trace.ml
+++ b/lib_eio/core/trace.ml
@@ -48,6 +48,7 @@ let exit_fiber = add_event RE.exit_fiber
 let exit_cc = add_event RE.exit_cc
 let error id ex = add_event RE.error (id, ex)
 let suspend_fiber op = add_event RE.suspend_fiber op
+let domain_spawn ~parent = add_event RE.domain_spawn parent
 
 let with_span op fn =
   enter_span op;

--- a/lib_eio/core/trace.mli
+++ b/lib_eio/core/trace.mli
@@ -48,6 +48,9 @@ val fiber : id -> unit
 val suspend_domain : Runtime_events.Type.span -> unit
 (** [suspend_domain] records when the event loop is stopped waiting for events from the OS. *)
 
+val domain_spawn : parent:id -> unit
+(** [domain_spawn ~parent] records that the current domain was spawned by fiber [parent]. *)
+
 val exit_cc : unit -> unit
 (** [exit_cc ()] records that the current CC has finished. *)
 

--- a/lib_eio/runtime_events/eio_runtime_events.mli
+++ b/lib_eio/runtime_events/eio_runtime_events.mli
@@ -39,6 +39,7 @@ val get : id Runtime_events.User.t
 val try_get : id Runtime_events.User.t
 val put : id Runtime_events.User.t
 val suspend_domain : Runtime_events.Type.span Runtime_events.User.t
+val domain_spawn : id Runtime_events.User.t
 
 (** {2 Consuming events} *)
     
@@ -61,6 +62,7 @@ type event = [
   | `Exit_fiber of id           (** The running fiber ends. *)
   | `Suspend_domain of Runtime_events.Type.span  (** The domain asks the OS to wait for events. *)
   | `Suspend_fiber of string    (** The running fiber is suspended (until resumed by [`Fiber]). *)
+  | `Domain_spawn of id         (** The current domain was spawned by fiber [id]. *)
 ]
 
 val pp_event : Format.formatter -> event -> unit


### PR DESCRIPTION
This allows e.g. eio-trace to show a link between the spawning fiber and the spawned domain.

It also shows the time spent doing `Domain.join`.