### PR TITLE
Make Switch.on_release thread safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ dscheck:
 stress:
 	dune exec -- ./stress/stress_proc.exe
 	dune exec -- ./stress/stress_semaphore.exe
+	dune exec -- ./stress/stress_release.exe
 
 docker:
 	docker build -t eio .

--- a/lib_eio/pool.mli
+++ b/lib_eio/pool.mli
@@ -24,11 +24,8 @@ val create :
     If [alloc] raises an exception then that use fails, but future calls to {!use} will retry.
 
     The [alloc] function is called in the context of the fiber trying to use the pool.
-    If the pool is shared between domains and the resources are attached to a switch, this
-    might cause trouble (since switches can't be shared between domains).
-    You might therefore want to make [alloc] request a resource from the main domain rather than creating one itself.
 
-    You should also take care about handling cancellation in [alloc], since resources are typically
+    You should take care about handling cancellation in [alloc], since resources are typically
     attached to a switch with the lifetime of the pool, meaning that if [alloc] fails then they won't
     be freed automatically until the pool itself is finished.
 

--- a/stress/dune
+++ b/stress/dune
@@ -1,3 +1,3 @@
 (executables
-  (names stress_semaphore stress_proc)
+  (names stress_semaphore stress_proc stress_release)
   (libraries eio_main))

--- a/stress/stress_release.ml
+++ b/stress/stress_release.ml
@@ -1,0 +1,62 @@
+open Eio.Std
+
+let n_domains = 3
+let n_rounds = 1000
+
+(* Each worker domain loops, creating resources and attaching them to the
+   shared switch [sw]. It also randomly close resources, cancelling the hook.
+   The main domain finishes the switch while this is happening, freeing all
+   registered resources. At the end, we check that the number of resources
+   allocated matches the number freed. *)
+let[@warning "-52"] run_domain ~sw ~hooks resources =
+  try
+    while true do
+      Atomic.incr resources;
+      let hook = Switch.on_release_cancellable sw (fun () -> Atomic.decr resources) in
+      if Random.bool () then (
+        (* Manually close an existing resource. *)
+        let i = Random.int (Array.length hooks) in
+        if Switch.try_remove_hook hooks.(i) then
+          Atomic.decr resources
+      );
+      if Random.bool () then (
+        let i = Random.int (Array.length hooks) in
+        hooks.(i) <- hook;
+      )
+    done
+  with Invalid_argument "Switch finished!" ->
+    ()
+
+let main ~pool =
+  let resources = Array.init n_domains (fun _ -> Atomic.make 0) in
+  (* Keep up to 10 hooks so we can cancel them randomly too. *)
+  let hooks = Array.make 10 Switch.null_hook in
+  for _ = 1 to n_rounds do
+    (* if i mod 1000 = 0 then traceln "Round %d" i; *)
+    Switch.run (fun domains_sw ->
+        Switch.run (fun sw ->
+            resources |> Array.iter (fun resources ->
+                Fiber.fork ~sw:domains_sw (fun () ->
+                    Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () -> run_domain ~sw ~hooks resources)
+                  )
+              );
+            (* traceln "Wait for domains to start"; *)
+            while Atomic.get (resources.(n_domains - 1)) < 20 do
+              Domain.cpu_relax ()
+            done;
+          );
+        (* The child domains will start to finish as they find that
+           [sw] is not accepting new resources. They may each still
+           create one last resource. *)
+      );
+   (* All child domains are now finished. *)
+    let x = Array.fold_left (fun acc resources -> acc + Atomic.get resources) 0 resources in
+    if x <> 0 then Fmt.failwith "%d resources still open at end!" x
+  done
+
+let () =
+  Eio_main.run @@ fun env ->
+  let domain_mgr = Eio.Stdenv.domain_mgr env in
+  Switch.run @@ fun sw ->
+  let pool = Eio.Executor_pool.create ~sw ~domain_count:n_domains domain_mgr in
+  main ~pool


### PR DESCRIPTION
This is needed to allow resource pools to be shared between domains. Fixes #669.

It works by putting a mutex around the `on_release` list. I tried a lock-free version too, but it was quite messy.

There is one change to the existing behaviour: it used to be possible to attach new resources to a switch in a release handler, but now that is rejected. I don't think the old behaviour was useful, but it could be brought back if needed (we'd just need to take the mutex again at the end).

I was thinking of deprecating `remove_hook` in favour of `try_remove_hook`, but all existing uses were safe so I decided not to do that for now.

Note: There are some places where we do `Switch.check` before creating a resource. This isn't thread-safe, and might pass even after the switch has ended if called from a different domain. That shouldn't be a problem (the switch could always have ended after the check anyway), but might annoy TSan.