### PR TITLE
Include backtrace in systhread errors

### DIFF
--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -469,6 +469,9 @@ module Exn : sig
   val pp_err : err Fmt.t
   (** [pp_err] formats an error code. *)
 
+  val empty_backtrace : Printexc.raw_backtrace
+  (** A backtrace with no frames. *)
+
   (** Extensible backend-specific exceptions. *)
   module Backend : sig
     type t = ..

--- a/lib_eio/core/exn.ml
+++ b/lib_eio/core/exn.ml
@@ -18,6 +18,8 @@ exception Cancelled of exn
 
 let create err = Io (err, { steps = [] })
 
+let empty_backtrace = Printexc.get_callstack 0
+
 let add_context ex fmt =
   fmt |> Fmt.kstr @@ fun msg ->
   match ex with
@@ -96,9 +98,9 @@ let combine e1 e2 =
   else match e1, e2 with
     | (Cancelled _, _), e
     | e, (Cancelled _, _) -> e  (* Don't need to report a cancelled exception if we have something better *)
-    | (Io (c1, t1), bt1), (Io (c2, t2), bt2) -> create (Multiple_io [(c1, t1, bt1); (c2, t2, bt2)]), Printexc.get_callstack 0
+    | (Io (c1, t1), bt1), (Io (c2, t2), bt2) -> create (Multiple_io [(c1, t1, bt1); (c2, t2, bt2)]), empty_backtrace
     | (Multiple exs, bt1), e2 -> Multiple (e2 :: exs), bt1
-    | e1, e2 -> Multiple [e2; e1], Printexc.get_callstack 0
+    | e1, e2 -> Multiple [e2; e1], empty_backtrace
 
 module Backend = struct
   type t = ..

--- a/lib_eio/core/switch.ml
+++ b/lib_eio/core/switch.ml
@@ -54,7 +54,7 @@ let combine_exn ex = function
   | Some ex1 -> Exn.combine ex1 ex
 
 (* Note: raises if [t] is finished or called from wrong domain. *)
-let fail ?(bt=Printexc.get_callstack 0) t ex =
+let fail ?(bt=Exn.empty_backtrace) t ex =
   check_our_domain t;
   t.exs <- Some (combine_exn (ex, bt) t.exs);
   try

--- a/lib_eio/unix/thread_pool.mli
+++ b/lib_eio/unix/thread_pool.mli
@@ -13,7 +13,7 @@ val run : t -> (unit -> 'a) -> 'a
 val submit :
   t ->
   ctx:Eio.Private.Fiber_context.t ->
-  enqueue:(('a, exn) result -> unit) ->
+  enqueue:(('a, Eio.Exn.with_bt) result -> unit) ->
   (unit -> 'a) ->
   unit
 (** [submit t ~ctx ~enqueue fn] starts running [fn] in a sys-thread, which uses [enqueue] to return the result.
@@ -21,5 +21,5 @@ val submit :
     If [ctx] is already cancelled then the error is passed to [enqueue] immediately.
     Systhreads do not respond to cancellation once running. *)
 
-type _ Effect.t += Run_in_systhread : (unit -> 'a) -> (('a, exn) result * t) Effect.t
+type _ Effect.t += Run_in_systhread : (unit -> 'a) -> (('a, Eio.Exn.with_bt) result * t) Effect.t
 val run_in_systhread : ?label:string -> (unit -> 'a) -> 'a


### PR DESCRIPTION
Also, add `Exn.empty_backtrace` as a convenience.