### PR TITLE
Minor file-descriptor improvements

### DIFF
--- a/lib_eio/unix/fd.ml
+++ b/lib_eio/unix/fd.ml
@@ -77,6 +77,8 @@ let is_seekable t =
     t.seekable <- if seekable then Yes else No;
     seekable
 
+let is_open t = Rcfd.is_open t.fd
+
 let rec use_exn_list op xs k =
   match xs with
   | [] -> k []

--- a/lib_eio/unix/fd.mli
+++ b/lib_eio/unix/fd.mli
@@ -55,6 +55,12 @@ val remove : t -> Unix.file_descr option
 
     Returns [None] if [t] is closed by another fiber first. *)
 
+val is_open : t -> bool
+(** [is_open t] returns [true] until [t] has been marked as closing, after which it returns [false].
+
+    This is mostly useful inside the callback of {!use}, to test whether
+    another fiber has started closing [t] (in which case you may decide to stop early). *)
+
 (** {2 Flags} *)
 
 val is_blocking : t -> bool

--- a/lib_eio_posix/include/discover.ml
+++ b/lib_eio_posix/include/discover.ml
@@ -8,7 +8,7 @@ let optional_flags = [
 
 let () =
   C.main ~name:"discover" (fun c ->
-      let c_flags = ["-D_LARGEFILE64_SOURCE"; "-D_XOPEN_SOURCE=700"; "-D_DARWIN_C_SOURCE"] in
+      let c_flags = ["-D_LARGEFILE64_SOURCE"; "-D_XOPEN_SOURCE=700"; "-D_DARWIN_C_SOURCE"; "-D_GNU_SOURCE"] in
       let includes = ["sys/types.h"; "sys/stat.h"; "fcntl.h"] in
       let extra_flags, missing_defs =
         C.C_define.import c ~c_flags ~includes


### PR DESCRIPTION
This adds `Eio_unix.Fd.is_open`, which just makes the internal `is_open` feature public, adds a missing header that prevented `O_PATH` from being found on Linux, and adds some tests for `Path.open_dir`.