### PR TITLE
Stat benchmark: report cleanup time and optimise

### DIFF
--- a/bench/main.ml
+++ b/bench/main.ml
@@ -1,3 +1,5 @@
+open Eio.Std
+
 let benchmarks = [
   "Promise", Bench_promise.run;
   "Cancel", Bench_cancel.run;
@@ -22,6 +24,7 @@ let usage_error () =
 
 let () =
   Eio_main.run @@ fun env ->
+  traceln "Using %s backend" env#backend_id;
   let benchmarks =
     match Array.to_list Sys.argv with
     | [_] -> benchmarks
@@ -35,7 +38,7 @@ let () =
     | _ -> usage_error ()
   in
   let run (name, fn) =
-    Eio.traceln "Running %s..." name;
+    traceln "Running %s..." name;
     let metrics = fn env in
     `Assoc [
       "name", `String name;


### PR DESCRIPTION
I want to make some improvements here. But let's start by benchmarking the current state of things.

Initially, I get:
```
+Using linux backend
+Running Path.stat...
+Going to create 168420 files and directories
+Created in 2.37 s
+Statted in 1.32 s
+Removed in 5.55 s

+Using posix backend
+Running Path.stat...
+Going to create 168420 files and directories
+Created in 8.61 s
+Statted in 4.10 s
+Removed in 20.41 s
```

Now, instead of creating thousands of fibers and having them fight over a semaphore, limit the number of fibers created (this also makes the traces easier to view). Also, fill the files with zero bytes instead of asking the OS for secure random data, since that's slow and isn't useful for the test.

On my machine:
```
+Using linux backend                   
+Running Path.stat...
+Going to create 168420 files and directories
+Created in 1.62 s
+Statted in 1.04 s
+Removed in 8.00 s

+Using posix backend                   
+Running Path.stat...
+Going to create 168420 files and directories
+Created in 2.92 s
+Statted in 3.82 s
+Removed in 22.27 s
```
On CI:

![Screenshot 2024-02-14 at 11-53-31 OCaml Benchmarks](https://github.com/ocaml-multicore/eio/assets/554131/3926600a-9e9f-4daf-910a-4a00622900f0)

Interestingly, removal was a bit slower in all three cases, even though that bit wasn't changed!