### PR TITLE
eio_posix: use directory FDs instead of realpath

### DIFF
--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -103,6 +103,7 @@ module Private : sig
   module Thread_pool = Thread_pool
 
   val read_link : Fd.t option -> string -> string
+  val read_link_unix : Unix.file_descr option -> string -> string
 end
 
 module Pi = Pi

--- a/lib_eio/unix/fd.ml
+++ b/lib_eio/unix/fd.ml
@@ -87,6 +87,11 @@ let rec use_exn_list op xs k =
     use_exn_list op xs @@ fun xs ->
     k (x :: xs)
 
+let use_exn_opt op x f =
+  match x with
+  | None -> f None
+  | Some x -> use_exn op x (fun x -> f (Some x))
+
 let stdin = of_unix_no_hook Unix.stdin
 let stdout = of_unix_no_hook Unix.stdout
 let stderr= of_unix_no_hook Unix.stderr

--- a/lib_eio/unix/fd.mli
+++ b/lib_eio/unix/fd.mli
@@ -35,6 +35,9 @@ val use_exn : string -> t -> (Unix.file_descr -> 'a) -> 'a
 val use_exn_list : string -> t list -> (Unix.file_descr list -> 'a) -> 'a
 (** [use_exn_list op fds fn] calls {!use_exn} on each FD in [fds], calling [fn wrapped_fds] on the results. *)
 
+val use_exn_opt : string -> t option -> (Unix.file_descr option -> 'a) -> 'a
+(** [use_exn_opt op fd fn] is like {!use_exn}, but if [fd = None] then it just calls [fn None]. *)
+
 (** {2 Closing} *)
 
 val close : t -> unit

--- a/lib_eio/unix/private.ml
+++ b/lib_eio/unix/private.ml
@@ -20,11 +20,10 @@ module Thread_pool = Thread_pool
 
 external eio_readlinkat : Unix.file_descr -> string -> Cstruct.t -> int = "eio_unix_readlinkat"
 
-let read_link fd path =
+let read_link_unix fd path =
   match fd with
   | None -> Unix.readlink path
   | Some fd ->
-    Fd.use_exn "readlink" fd @@ fun fd ->
     let rec aux size =
       let buf = Cstruct.create_unsafe size in
       let len = eio_readlinkat fd path buf in
@@ -32,3 +31,5 @@ let read_link fd path =
       else aux (size * 4)
     in
     aux 1024
+
+let read_link fd path = Fd.use_exn_opt "readlink" fd (fun fd -> read_link_unix fd path)

--- a/lib_eio_posix/eio_posix_stubs.c
+++ b/lib_eio_posix/eio_posix_stubs.c
@@ -17,6 +17,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <stdlib.h>
+#include <dirent.h>
 
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
@@ -526,4 +527,14 @@ CAMLprim value caml_eio_posix_recv_msg(value v_fd, value v_max_fds, value v_bufs
   Store_field(v_result, 2, get_msghdr_fds(&msg));
 
   CAMLreturn(v_result);
+}
+
+CAMLprim value caml_eio_posix_fdopendir(value v_fd) {
+  DIR *d = fdopendir(Int_val(v_fd));
+  if (!d)
+    caml_uerror("fdopendir", Nothing);
+
+  value v_result = caml_alloc_small(1, Abstract_tag);
+  DIR_Val(v_result) = d;
+  return v_result;
 }

--- a/lib_eio_posix/err.ml
+++ b/lib_eio_posix/err.ml
@@ -1,5 +1,5 @@
 type Eio.Exn.Backend.t +=
-  | Outside_sandbox of string * string
+  | Outside_sandbox of string
   | Absolute_path
   | Invalid_leaf of string
 
@@ -7,7 +7,7 @@ let unclassified_error e = Eio.Exn.create (Eio.Exn.X e)
 
 let () =
   Eio.Exn.Backend.register_pp (fun f -> function
-      | Outside_sandbox (path, dir) -> Fmt.pf f "Outside_sandbox (%S, %S)" path dir; true
+      | Outside_sandbox path -> Fmt.pf f "Outside_sandbox (%S)" path; true
       | Absolute_path -> Fmt.pf f "Absolute_path"; true
       | Invalid_leaf x -> Fmt.pf f "Invalid_leaf %S" x; true
       | _ -> false

--- a/lib_eio_posix/net.ml
+++ b/lib_eio_posix/net.ml
@@ -109,7 +109,7 @@ let listen ~reuse_addr ~reuse_port ~backlog ~sw (listen_addr : Eio.Net.Sockaddr.
     | `Unix path         ->
       if reuse_addr then (
         let buf = Low_level.create_stat () in
-        match Low_level.fstatat ~buf ~follow:false path with
+        match Low_level.fstatat ~buf ~follow:false Fs path with
         | () -> if Low_level.kind buf = `Socket then Unix.unlink path
         | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
         | exception Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg

--- a/lib_eio_posix/path.ml
+++ b/lib_eio_posix/path.ml
@@ -1,0 +1,81 @@
+type token =
+  | Empty
+  | DotDot
+  | String of string
+
+let rec tokenise = function
+  | [] -> []
+  | ["."] -> [Empty]                  (* "path/." is the same as "path/" *)
+  | "." :: xs -> tokenise xs          (* Skip dot if not at end *)
+  | "" :: xs -> Empty :: tokenise xs
+  | ".." :: xs -> DotDot :: tokenise xs
+  | x :: xs -> String x :: tokenise xs
+
+module Rel = struct
+  type t =
+    | Leaf of { basename : string; trailing_slash : bool }
+    | Self    (* A final "." *)
+    | Child of string * t
+    | Parent of t
+
+  let rec parse = function
+    | [] -> Self
+    | [String basename; Empty] -> Leaf { basename; trailing_slash = true }
+    | [String basename] -> Leaf { basename; trailing_slash = false }
+    | [DotDot] -> Parent Self
+    | DotDot :: xs -> Parent (parse xs)
+    | String s :: xs -> Child (s, parse xs)
+    | Empty :: xs -> parse xs
+
+  let parse s = parse (tokenise s)
+
+  let rec concat a b =
+    match a with
+    | Leaf { basename; trailing_slash = _ } -> Child (basename, b)
+    | Child (name, xs) -> Child (name, concat xs b)
+    | Parent xs -> Parent (concat xs b)
+    | Self -> b
+
+  let rec dump f = function
+    | Child (x, xs) -> Fmt.pf f "%S / %a" x dump xs
+    | Parent xs -> Fmt.pf f ".. / %a" dump xs
+    | Self -> Fmt.pf f "."
+    | Leaf { basename; trailing_slash } ->
+      Fmt.pf f "%S" basename;
+      if trailing_slash then Fmt.pf f " /"
+
+  let rec segs = function
+    | Leaf { basename; trailing_slash } -> [if trailing_slash then basename ^ "/" else basename]
+    | Self -> [""]
+    | Child (x, xs) -> x :: segs xs
+    | Parent Self -> [".."]
+    | Parent xs -> ".." :: segs xs
+
+  let to_string = function
+    | Self -> "."
+    | t -> String.concat "/" (segs t)
+end
+
+type t =
+  | Relative of Rel.t
+  | Absolute of Rel.t
+
+let rec parse_abs = function
+  | "" :: [] -> Absolute Self
+  | "" :: xs -> parse_abs xs
+  | xs -> Absolute (Rel.parse xs)
+
+let parse = function
+  | "" -> Relative Self
+  | s ->
+    match String.split_on_char '/' s with
+    | "" :: path -> parse_abs path
+    | path -> Relative (Rel.parse path)
+
+let dump f = function
+  | Relative r -> Rel.dump f r
+  | Absolute r -> Fmt.pf f "/ %a" Rel.dump r
+
+let to_string = function
+  | Relative r -> Rel.to_string r
+  | Absolute r -> String.concat "/" ("" :: Rel.segs r)

--- a/lib_eio_posix/path.mli
+++ b/lib_eio_posix/path.mli
@@ -1,0 +1,26 @@
+module Rel : sig
+  type t =
+    | Leaf of { basename : string; trailing_slash : bool }
+    | Self    (* A final "." *)
+    | Child of string * t
+    | Parent of t
+
+  val concat : t -> t -> t
+
+  val to_string : t -> string
+
+  val dump : t Fmt.t
+end
+
+type t =
+  | Relative of Rel.t
+  | Absolute of Rel.t
+
+val parse : string -> t
+(** Note:
+    [parse "" = Relative Self]
+    [parse ".." = Relative (Parent Self)] *)
+
+val to_string : t -> string
+
+val dump : t Fmt.t

--- a/lib_eio_posix/primitives.h
+++ b/lib_eio_posix/primitives.h
@@ -10,6 +10,7 @@ CAMLprim value caml_eio_posix_writev(value, value);
 CAMLprim value caml_eio_posix_preadv(value, value, value);
 CAMLprim value caml_eio_posix_pwritev(value, value, value);
 CAMLprim value caml_eio_posix_openat(value, value, value, value);
+CAMLprim value caml_eio_posix_fdopendir(value);
 CAMLprim value caml_eio_posix_mkdirat(value, value, value);
 CAMLprim value caml_eio_posix_unlinkat(value, value, value);
 CAMLprim value caml_eio_posix_renameat(value, value, value, value);

--- a/lib_eio_posix/process.ml
+++ b/lib_eio_posix/process.ml
@@ -31,12 +31,11 @@ module Impl = struct
       let with_actions cwd fn = match cwd with
         | None -> fn actions
         | Some ((dir, path) : Eio.Fs.dir_ty Eio.Path.t) ->
-          match Fs.Handler.as_posix_dir dir with
+          match Fs.as_posix_dir dir with
           | None -> Fmt.invalid_arg "cwd is not an OS directory!"
-          | Some posix ->
-            Fs.Dir.with_parent_dir posix path @@ fun dirfd s ->
+          | Some dirfd ->
             Switch.run ~name:"spawn_unix" @@ fun launch_sw ->
-            let cwd = Low_level.openat ?dirfd ~sw:launch_sw ~mode:0 s Low_level.Open_flags.(rdonly + directory) in
+            let cwd = Low_level.openat ~sw:launch_sw ~mode:0 dirfd path Low_level.Open_flags.(rdonly + directory) in
             fn (Low_level.Process.Fork_action.fchdir cwd :: actions)
       in
       with_actions cwd @@ fun actions ->

--- a/lib_eio_posix/test/dune
+++ b/lib_eio_posix/test/dune
@@ -2,3 +2,9 @@
   (package eio_posix)
   (enabled_if (= %{os_type} "Unix"))
   (deps (package eio_posix)))
+
+(test
+  (name open_beneath)
+  (package eio_posix)
+  (build_if (= %{os_type} "Unix"))
+  (libraries eio_posix))

--- a/lib_eio_posix/test/open_beneath.ml
+++ b/lib_eio_posix/test/open_beneath.ml
@@ -1,0 +1,92 @@
+open Eio.Std
+
+let () = Printexc.record_backtrace true
+
+module L = Eio_posix.Low_level
+
+let check ~mode dirfd path flags =
+  Switch.run @@ fun sw ->
+  (* traceln "check %S" path; *)
+  let x =
+    let path = if path = "" then "." else path in
+    try Ok (L.Resolve.open_unconfined ~sw ~mode (Some dirfd) path flags) with Unix.Unix_error _ as e -> Error e in
+  let y =
+    Eio_unix.Fd.use_exn "check" dirfd @@ fun dirfd ->
+    try Ok (L.Resolve.open_beneath_fallback ~sw ~dirfd ~mode path flags) with Unix.Unix_error _ as e -> Error e
+  in
+  match x, y with
+  | Ok x, Ok y ->
+    let inode fd =
+      let buf = L.create_stat () in
+      L.fstat fd ~buf;
+      (L.dev buf, L.ino buf)
+    in
+    let x_info = inode x in
+    let y_info = inode y in
+    if x_info <> y_info then
+      Fmt.failwith "Got a different inode opening %S!" path
+  | Error (Unix.Unix_error (x, _, _) as e1),
+    Error (Unix.Unix_error (y, _, _) as e2) ->
+    if x <> y then (
+      Fmt.failwith "Different errors: %a vs %a" Fmt.exn e1 Fmt.exn e2
+    )
+  | Error _, Error _ -> assert false
+  | Error e, Ok _ -> Fmt.failwith "Only OS open failed: %a" Fmt.exn e
+  | Ok _, Error e -> Fmt.failwith "Only open_beneath failed: %a" Fmt.exn e
+
+let test base path =
+  check ~mode:0 base path L.Open_flags.rdonly;
+  if path <> "" then (
+    check ~mode:0 base (path ^ "/") L.Open_flags.rdonly;
+    (* This doesn't work on macos, which seems to allow opening files even with
+       a trailing "/" (but not with a trailing "/."): *)
+    (* check ~mode:0 base (path ^ "/.") L.Open_flags.rdonly *)
+  )
+    
+let test_denied base path =
+  match L.Open_flags.resolve_beneath with
+  | Some some_resolve_beneath ->
+    (* Check our behaviour matches the OS's *)
+    check ~mode:0 base path L.Open_flags.(rdonly + some_resolve_beneath)
+  | None ->
+    (* traceln "check-reject %S" path; *)
+    (* OS doesn't support resolve_beneath. Just check we reject it. *)
+    Switch.run @@ fun sw ->
+    Eio_unix.Fd.use_exn "check" base @@ fun base ->
+    match L.Resolve.open_beneath_fallback ~sw ~dirfd:base ~mode:0 path L.Open_flags.rdonly with
+    | (_fd : Eio_unix.Fd.t) -> Fmt.failwith "%S should have been rejected!" path
+    | exception Eio.Io (Eio.Fs.E Permission_denied _, _) -> ()
+
+let () =
+  try
+    Eio_posix.run @@ fun _env ->
+    Unix.mkdir "test_beneath" 0o700;
+    Unix.mkdir "test_beneath/subdir" 0o700;
+    Unix.symlink "subdir" "test_beneath/link_subdir";
+    Unix.symlink ".." "test_beneath/link_subdir/parent";
+    Unix.symlink ".." "test_beneath/parent";
+    Unix.symlink "loop2" "test_beneath/loop1";
+    Unix.symlink "loop1" "test_beneath/loop2";
+    Unix.symlink "file" "test_beneath/to-file";
+    Unix.symlink "file/" "test_beneath/to-file-slash";
+    Unix.symlink "subdir/" "test_beneath/to-dir-slash";
+    Switch.run @@ fun sw ->
+    let test_dir = L.Resolve.open_beneath_fallback ~sw "test_beneath" L.Open_flags.directory ~mode:0 in
+    let f = L.openat ~sw (Fd test_dir) "file" L.Open_flags.(creat + rdwr) ~mode:0o600 in
+    Eio_unix.Fd.close f;
+    test test_dir "file";
+    test test_dir "subdir";
+    test test_dir "link_subdir";
+    test test_dir "link_subdir/parent";
+    test_denied test_dir "link_subdir/parent/parent";
+    test test_dir "";
+    test test_dir ".";
+    test_denied test_dir "..";
+    test test_dir "loop1";
+    test test_dir "to-file";
+    test test_dir "to-file-slash";
+    test test_dir "to-dir-slash/file";
+  with Failure msg ->
+    Printexc.print_backtrace stderr;
+    Fmt.epr "Tests failed: %s" msg;
+    exit 1

--- a/lib_eio_posix/test/path.md
+++ b/lib_eio_posix/test/path.md
@@ -1,0 +1,58 @@
+```ocaml
+# #require "eio_posix"
+```
+```ocaml
+module P = Eio_posix__Path
+
+let dump f p =
+  Fmt.pf f "%a (%S)" P.dump p (P.to_string p)
+```
+
+```ocaml
+# #install_printer dump;;
+
+# P.parse "foo"
+- : P.t = "foo" ("foo")
+
+# P.parse "foo/bar"
+- : P.t = "foo" / "bar" ("foo/bar")
+
+# P.parse "foo//bar/"
+- : P.t = "foo" / "bar" / ("foo/bar/")
+
+# P.parse "foo/."
+- : P.t = "foo" / ("foo/")
+
+# P.parse "foo/./"
+- : P.t = "foo" / ("foo/")
+
+# P.parse ""
+- : P.t = . (".")
+
+# P.parse "."
+- : P.t = . (".")
+
+# P.parse ".."
+- : P.t = .. / . ("..")
+
+# P.parse "./../.././.."
+- : P.t = .. / .. / .. / . ("../../..")
+
+# P.parse "/"
+- : P.t = / . ("/")
+
+# P.parse "/etc"
+- : P.t = / "etc" ("/etc")
+
+# P.parse "/etc/passwd"
+- : P.t = / "etc" / "passwd" ("/etc/passwd")
+
+# P.parse "/."
+- : P.t = / . ("/")
+
+# P.parse "/.."
+- : P.t = / .. / . ("/..")
+
+# P.parse "//../"
+- : P.t = / .. / . ("/..")
+```

--- a/lib_eio_posix/test/spawn.md
+++ b/lib_eio_posix/test/spawn.md
@@ -46,7 +46,7 @@ Changing directory using a file descriptor:
 ```ocaml
 # Eio_posix.run @@ fun _env ->
   Switch.run @@ fun sw ->
-  let root = Eio_posix.Low_level.openat ~sw ~mode:0 "/" Eio_posix.Low_level.Open_flags.(rdonly + directory) in
+  let root = Eio_posix.Low_level.openat ~sw ~mode:0 Fs "/" Eio_posix.Low_level.Open_flags.(rdonly + directory) in
   let child = Process.spawn ~sw Process.Fork_action.[
     fchdir root;
     execve "/usr/bin/env"


### PR DESCRIPTION
realpath was an old hack from the libuv days and isn't safe against races with symlinks being updated.

This should be faster too in some cases.