### PR TITLE
eio_posix: add O_DIRECTORY when opening with a trailing slash

### DIFF
--- a/lib_eio_posix/test/open_beneath.ml
+++ b/lib_eio_posix/test/open_beneath.ml
@@ -38,9 +38,7 @@ let test base path =
   check ~mode:0 base path L.Open_flags.rdonly;
   if path <> "" then (
     check ~mode:0 base (path ^ "/") L.Open_flags.rdonly;
-    (* This doesn't work on macos, which seems to allow opening files even with
-       a trailing "/" (but not with a trailing "/."): *)
-    (* check ~mode:0 base (path ^ "/.") L.Open_flags.rdonly *)
+    check ~mode:0 base (path ^ "/.") L.Open_flags.rdonly
   )
     
 let test_denied base path =


### PR DESCRIPTION
Most systems do this anyway, but macos doesn't seem to. This makes things consistent.

I noticed this in #694, but put it in a separate PR as it seems a bit odd. Maybe someone on macos could confirm this is the problem?