### PR TITLE
Fix to pass with both old and new Kcas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1608,10 +1608,8 @@ To demonstrate **kcas**
 let's first create a couple of shared memory locations
 
 ```ocaml
-# let x = Loc.make 0
-val x : int Loc.t = <abstr>
-# let y = Loc.make 0
-val y : int Loc.t = <abstr>
+let x = Loc.make 0
+let y = Loc.make 0
 ```
 
 and spawn a domain


### PR DESCRIPTION
The `Loc.t` type has changed in Kcas, which makes a MDX block fail with upcoming Kcas.  This changes the block such that it will pass with both old and future Kcas.