### PR TITLE
Require MDX < 2.4.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,7 @@
   (domain-local-await (>= 0.1.0))
   (crowbar (and (>= 0.2) :with-test))
   (mtime (>= 2.0.0))
-  (mdx (and (>= 2.2.0) :with-test))
+  (mdx (and (>= 2.2.0) (< 2.4.0) :with-test))
   (dscheck (and (>= 0.1.0) :with-test))))
 (package
  (name eio_linux)

--- a/eio.opam
+++ b/eio.opam
@@ -21,7 +21,7 @@ depends: [
   "domain-local-await" {>= "0.1.0"}
   "crowbar" {>= "0.2" & with-test}
   "mtime" {>= "2.0.0"}
-  "mdx" {>= "2.2.0" & with-test}
+  "mdx" {>= "2.2.0" & < "2.4.0" & with-test}
   "dscheck" {>= "0.1.0" & with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
The MDX devs have decided to change the behaviour of includes. What was previously a request to copy some text from one file to another now, in mdx 2.4.0, will also execute it!!

See https://github.com/realworldocaml/mdx/pull/446