### PR TITLE
eio_linux: remove logging

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (alcotest (and (>= 1.7.0) :with-test))
   (eio (= :version))
   (mdx (and (>= 2.2.0) :with-test))
-  (logs (>= 0.7.0))
+  (logs (and (>= 0.7.0) :with-test))
   (fmt (>= 0.8.9))
   (cmdliner (and (>= 1.1.0) :with-test))
   (uring (>= 0.7))))

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -13,7 +13,7 @@ depends: [
   "alcotest" {>= "1.7.0" & with-test}
   "eio" {= version}
   "mdx" {>= "2.2.0" & with-test}
-  "logs" {>= "0.7.0"}
+  "logs" {>= "0.7.0" & with-test}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
   "uring" {>= "0.7"}

--- a/lib_eio_linux/dune
+++ b/lib_eio_linux/dune
@@ -11,7 +11,7 @@
   (flags :standard -D_LARGEFILE64_SOURCE)
   (include_dirs ../lib_eio/unix/include)
   (names eio_stubs))
- (libraries eio eio.utils eio.unix uring logs fmt))
+ (libraries eio eio.utils eio.unix uring fmt))
 
 (rule
  (enabled_if

--- a/lib_eio_linux/log.ml
+++ b/lib_eio_linux/log.ml
@@ -1,2 +1,0 @@
-let src = Logs.Src.create "eio_linux" ~doc:"Effect-based IO system for Linux/io-uring"
-include (val Logs.src_log src : Logs.LOG)

--- a/lib_eio_linux/tests/dune
+++ b/lib_eio_linux/tests/dune
@@ -6,7 +6,7 @@
        (= %{system} "linux_elf")      ; Historically, Linux-x86_32
        (= %{system} "elf")))          ; Historically, Linux-ppc64
  (modules eurcp_lib)
- (libraries eio_linux))
+ (libraries eio_linux logs))
 
 (executable
  (name eurcp)
@@ -47,7 +47,7 @@
        (= %{system} "linux_elf")      ; Historically, Linux-x86_32
        (= %{system} "elf")))          ; Historically, Linux-ppc64
  (modules test)
- (libraries alcotest eio_linux))
+ (libraries alcotest eio_linux logs))
 
 (mdx
   (package eio_linux)


### PR DESCRIPTION
There were only two remaining uses, neither of which has proved useful. The warning about an unknown response to cancellation has never been seen, and the warning about being unable to allocate a fixed buffer just annoys people.

/cc @clecat