### PR TITLE
Bound MDX version on all packages

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,7 @@
  (depends
   (alcotest (and (>= 1.7.0) :with-test))
   (eio (= :version))
-  (mdx (and (>= 2.2.0) :with-test))
+  (mdx (and (>= 2.2.0) (< 2.4.0) :with-test))
   (logs (and (>= 0.7.0) :with-test))
   (fmt (>= 0.8.9))
   (cmdliner (and (>= 1.1.0) :with-test))
@@ -47,7 +47,7 @@
  (depends
   (eio (= :version))
   (iomux (>= 0.2))
-  (mdx (and (>= 2.2.0) :with-test))
+  (mdx (and (>= 2.2.0) (< 2.4.0) :with-test))
   (fmt (>= 0.8.9))))
 (package
  (name eio_windows)
@@ -64,7 +64,7 @@
  (synopsis "Effect-based direct-style IO mainloop for OCaml")
  (description "Selects an appropriate Eio backend for the current platform.")
  (depends
-  (mdx (and (>= 2.2.0) :with-test))
+  (mdx (and (>= 2.2.0) (< 2.4.0) :with-test))
   (kcas (and (>= 0.3.0) :with-test))
   (yojson (and (>= 2.0.2) :with-test))
   (eio_linux (and

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.9"}
   "alcotest" {>= "1.7.0" & with-test}
   "eio" {= version}
-  "mdx" {>= "2.2.0" & with-test}
+  "mdx" {>= "2.2.0" & < "2.4.0" & with-test}
   "logs" {>= "0.7.0" & with-test}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "3.9"}
-  "mdx" {>= "2.2.0" & with-test}
+  "mdx" {>= "2.2.0" & < "2.4.0" & with-test}
   "kcas" {>= "0.3.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux"

--- a/eio_posix.opam
+++ b/eio_posix.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.9"}
   "eio" {= version}
   "iomux" {>= "0.2"}
-  "mdx" {>= "2.2.0" & with-test}
+  "mdx" {>= "2.2.0" & < "2.4.0" & with-test}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
#706 only added the bound in one place, but when releasing it's needed on all packages.