### PR TITLE
Introduce HOFs that wrap functions to run with a locked mutex

### DIFF
--- a/lib_eio/eio_mutex.ml
+++ b/lib_eio/eio_mutex.ml
@@ -119,3 +119,18 @@ let use_rw ~protect t fn =
     (* {mutex t R * locked t} *)
     poison t ex;
     raise ex
+
+let wrap_ro t f x =
+  lock t;
+  match f x with
+  | y -> unlock t; y
+  | exception ex -> unlock t; raise ex
+
+let wrap_rw ~protect t f x =
+  lock t;
+  match if protect then Cancel.protect f else f x with
+  | y -> unlock t; y
+  | exception ex ->
+    poison t ex;
+    raise ex
+

--- a/lib_eio/eio_mutex.ml
+++ b/lib_eio/eio_mutex.ml
@@ -128,7 +128,8 @@ let wrap_ro t f x =
 
 let wrap_rw ~protect t f x =
   lock t;
-  match if protect then Cancel.protect f else f x with
+  let f () = f x in
+  match if protect then Cancel.protect f else f () with
   | y -> unlock t; y
   | exception ex ->
     poison t ex;

--- a/lib_eio/eio_mutex.mli
+++ b/lib_eio/eio_mutex.mli
@@ -38,6 +38,9 @@ val use_ro : t -> (unit -> 'a) -> 'a
     Note: a mutex still only allows one fiber to have the mutex locked at a time,
     even if all operations are "read-only". *)
 
+val wrap_rw : protect:bool -> t -> ('a -> 'b) -> 'a -> 'b
+val wrap_ro : t -> ('a -> 'b) -> 'a -> 'b
+
 (** {2 Low-level API}
 
     Care must be taken when locking a mutex manually. It is easy to forget to unlock it in some cases,


### PR DESCRIPTION
Introduce wrappers that can turn any function `f : a -> b` into a new function that runs with a wrapped mutex. `a` can even be a mutable value that can then be modified only while the mutex is held.

Fix #336