### PR TITLE
README: explain that read_all reads until shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ let run_client ~net ~addr =
   Switch.run ~name:"client" @@ fun sw ->
   traceln "Client: connecting to server";
   let flow = Eio.Net.connect ~sw net addr in
+  (* Read all data until end-of-stream (shutdown): *)
   traceln "Client: received %S" (Eio.Flow.read_all flow)
 ```
 


### PR DESCRIPTION
Fixes #714, reported by @Wenke-D (is that clearer?).