### PR TITLE
Long dash in README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [API reference][Eio API] | [#eio Matrix chat](https://matrix.to/#/#eio:roscidus.com) | [Dev meetings][]
 
-# Eio -- Effects-Based Parallel IO for OCaml
+# Eio &mdash; Effects-Based Parallel IO for OCaml
 
 Eio provides an effects-based direct-style IO stack for OCaml 5.
 For example, you can use Eio to read and write files, make network connections,


### PR DESCRIPTION
Just a little aesthetic thing.

<img width="600" alt="image" src="https://github.com/ocaml-multicore/eio/assets/1523104/2fab1c51-5092-4ca2-b1ec-9785a947c58e">
