### PR TITLE
eio_linux: require Linux >= 5.15

### DIFF
--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -154,16 +154,9 @@ module Flow = struct
 
   let close = Eio_unix.Fd.close
 
-  let is_tty t = Fd.use_exn "isatty" t Unix.isatty
-
   let stat = Low_level.fstat
 
   let single_read t buf =
-    if is_tty t then (
-      (* Work-around for https://github.com/axboe/liburing/issues/354
-         (should be fixed in Linux 5.14) *)
-      Low_level.await_readable t
-    );
     Low_level.readv t [buf]
 
   let pread t ~file_offset bufs =

--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -536,9 +536,9 @@ let with_sched ?(fallback=no_fallback) config fn =
   | exception Unix.Unix_error(EPERM, _, _) -> fallback (`Msg "io_uring is not available (permission denied)")
   | uring ->
     let probe = Uring.get_probe uring in
-    if not (Uring.op_supported probe Uring.Op.shutdown) then (
+    if not (Uring.op_supported probe Uring.Op.mkdirat) then (
       Uring.exit uring;
-      fallback (`Msg "Linux >= 5.11 is required for io_uring support")
+      fallback (`Msg "Linux >= 5.15 is required for io_uring support")
     ) else (
       statx_works := Uring.op_supported probe Uring.Op.msg_ring;
       match


### PR DESCRIPTION
This allows removing a work-around that required checking whether every flow was a tty (and which was doing this on every read).

On my machine, this doesn't seem to have much effect on the benchmarks, but it does clean up the strace output.