### PR TITLE
Add _BSD_SOURCE flag to fix eio_posix on OpenBSD.

### DIFF
--- a/lib_eio_posix/include/discover.ml
+++ b/lib_eio_posix/include/discover.ml
@@ -8,7 +8,7 @@ let optional_flags = [
 
 let () =
   C.main ~name:"discover" (fun c ->
-      let c_flags = ["-D_LARGEFILE64_SOURCE"; "-D_XOPEN_SOURCE=700"; "-D_DARWIN_C_SOURCE"; "-D_GNU_SOURCE"] in
+      let c_flags = ["-D_LARGEFILE64_SOURCE"; "-D_XOPEN_SOURCE=700"; "-D_DARWIN_C_SOURCE"; "-D_GNU_SOURCE"; "-D_BSD_SOURCE"] in
       let includes = ["sys/types.h"; "sys/stat.h"; "fcntl.h"] in
       let extra_flags, missing_defs =
         C.C_define.import c ~c_flags ~includes


### PR DESCRIPTION
eio_posix currently fails to build on OpenBSD 7.4 due to `O_NOFOLLOW` not being exposed:

```
#=== ERROR while compiling eio_posix.1.0 ======================================#
# context     2.0.10 | openbsd/x86_64 | ocaml-base-compiler.5.1.1 | https://opam.ocaml.org#a92d9dfb
# path        ~/.opam/5.1.1/.opam-switch/build/eio_posix.1.0
# command     ~/.opam/5.1.1/bin/dune build -p eio_posix -j 1 @install
# exit-code   1
# env-file    ~/.opam/log/eio_posix-34687-68bbf5.env
# output-file ~/.opam/log/eio_posix-34687-68bbf5.out
### output ###
# -> stderr:
# [...]
#  | /tmp/build_550fc6_dune/ocaml-configuratorf7473a/c-test-2/test.c:105:12: error: use of undeclared identifier 'O_NOFOLLOW'
#  | /tmp/build_550fc6_dune/ocaml-configuratorf7473a/c-test-2/test.c:105:12: error: use of undeclared identifier 'O_NOFOLLOW'
#  | /tmp/build_550fc6_dune/ocaml-configuratorf7473a/c-test-2/test.c:105:12: error: use of undeclared identifier 'O_NOFOLLOW'
#  | /tmp/build_550fc6_dune/ocaml-configuratorf7473a/c-test-2/test.c:105:12: error: use of undeclared identifier 'O_NOFOLLOW'
#  | /tmp/build_550fc6_dune/ocaml-configuratorf7473a/c-test-2/test.c:105:12: error: use of undeclared identifier 'O_NOFOLLOW'
#  | /tmp/build_550fc6_dune/ocaml-configuratorf7473a/c-test-2/test.c:105:12: error: use of undeclared identifier 'O_NOFOLLOW'
#  | /tmp/build_550fc6_dune/ocaml-configuratorf7473a/c-test-2/test.c:105:12: error: use of undeclared identifier 'O_NOFOLLOW'
#  | /tmp/build_550fc6_dune/ocaml-configuratorf7473a/c-test-2/test.c:105:12: error: use of undeclared identifier 'O_NOFOLLOW'
#  | fatal error: too many errors emitted, stopping now [-ferror-limit=]
#  | 20 errors generated.
# Error: failed to compile program
```
Adding the `-D_BSD_SOURCE` compiler flag fixes the issue.