### PR TITLE
eio_posix: fix filesystem tests on OpenBSD

### DIFF
--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -263,7 +263,8 @@ module Resolve = struct
       | new_base ->
         state.dir_stack <- Tmp (new_base, state.dir_stack);
         resolve state xs
-      | exception (Unix.Unix_error ((ENOTDIR | EMLINK | EUNKNOWNERR _), _, _) as e) ->
+      | exception (Unix.Unix_error ((ELOOP | ENOTDIR | EMLINK | EUNKNOWNERR _), _, _) as e) ->
+        (* Note: Linux uses ELOOP or ENOTDIR. FreeBSD uses EMLINK. NetBSD uses EFTYPE. *)
         match Eio_unix.Private.read_link_unix base x with
         | target ->
           decr_max_follows state x;


### PR DESCRIPTION
Looks like someone beat me to it on OpenBSD compilation (#722), but I did see some failures in the test suite and found a solution. This fix seems reasonable to me, but I definitely might have missed something - these two functions have differed on this check since they were first introduced in #694.

---

In the 'resolve' function there is a check for items being symlinks which was missing ELOOP as an indicator. This patch adds ELOOP, to match the similar check in 'open_beneath_fallback'.

This fixes filesystem tests on OpenBSD.