### PR TITLE
eio_linux: don't record submit events when there's nothing to submit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ocaml/opam:debian-11-ocaml-5.1
+FROM ocaml/opam:debian-11-ocaml-5.2
 # Make sure we're using opam-2.1:
 RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 # Ensure opam-repository is up-to-date:
-RUN cd opam-repository && git pull -q origin 0ac3fc79fd11ee365dd46119d43e9763cf57da52 && opam update
+RUN cd opam-repository && git pull -q origin 97de3378749cf8d2d70a5d710d310e5cc17c9dea && opam update
 # Install utop for interactive use:
 RUN opam install utop fmt
 # Install Eio's dependencies (adding just the opam files first to help with caching):

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,8 +1,8 @@
-FROM ocaml/opam:debian-11-ocaml-5.1
+FROM ocaml/opam:debian-11-ocaml-5.2
 # Make sure we're using opam-2.1:
 RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 # Ensure opam-repository is up-to-date:
-RUN cd opam-repository && git pull -q origin 0ac3fc79fd11ee365dd46119d43e9763cf57da52 && opam update
+RUN cd opam-repository && git pull -q origin 97de3378749cf8d2d70a5d710d310e5cc17c9dea && opam update
 # Install Eio's dependencies (adding just the opam files first to help with caching):
 RUN mkdir eio
 WORKDIR eio

--- a/dune-project
+++ b/dune-project
@@ -38,7 +38,7 @@
   (logs (and (>= 0.7.0) :with-test))
   (fmt (>= 0.8.9))
   (cmdliner (and (>= 1.1.0) :with-test))
-  (uring (>= 0.7))))
+  (uring (>= 0.9))))
 (package
  (name eio_posix)
  (allow_empty)  ; Work-around for dune bug #6938

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -16,7 +16,7 @@ depends: [
   "logs" {>= "0.7.0" & with-test}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.7"}
+  "uring" {>= "0.9"}
   "odoc" {with-doc}
 ]
 build: [

--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -113,7 +113,10 @@ let enter op fn =
   Effect.perform (Enter fn)
 
 let submit uring =
-  Trace.with_span "submit" (fun () -> Uring.submit uring)
+  if Uring.sqe_ready uring > 0 then
+    Trace.with_span "submit" (fun () -> Uring.submit uring)
+  else
+    0
 
 let rec enqueue_job t fn =
   match fn () with


### PR DESCRIPTION
It reported that the domain was suspended during all calls to `submit`, but in fact uring doesn't make a syscall if there's nothing to submit. This leads to short bogus suspend regions on traces, which are distracting. e.g. tracing `examples/net` shows this bogus 100ns suspend:

![old](https://github.com/ocaml-multicore/eio/assets/554131/4b0640ab-a7c1-4cc9-9609-99e07939222a)
