### PR TITLE
implement native for windows

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -58,6 +58,7 @@
   (eio (= :version))
   (fmt (>= 0.8.9))
   (kcas (and (>= 0.3.0) :with-test))
+  (mdx (and (>= 2.4.1) :with-test))
   (alcotest (and (>= 1.7.0) :with-test))))
 (package
  (name eio_main)

--- a/eio_windows.opam
+++ b/eio_windows.opam
@@ -13,6 +13,7 @@ depends: [
   "eio" {= version}
   "fmt" {>= "0.8.9"}
   "kcas" {>= "0.3.0" & with-test}
+  "mdx" {>= "2.4.1" & with-test}
   "alcotest" {>= "1.7.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/lib_eio_windows/fs.ml
+++ b/lib_eio_windows/fs.ml
@@ -187,8 +187,20 @@ end = struct
 
   let pp f t = Fmt.string f (String.escaped t.label)
 
-  let native _t _path =
-    failwith "TODO: Windows native"
+  let native_internal t path =
+    if Filename.is_relative path then (
+      let p =
+        if t.dir_path = "." then path
+        else Filename.concat t.dir_path path
+      in
+      if p = "" then "."
+      else if p = "." then p
+      else if Filename.is_implicit p then ".\\" ^ p
+      else p
+    ) else path
+
+  let native t path =
+    Some (native_internal t path)
 end
 and Handler : sig
   val v : (Dir.t, [`Dir | `Close]) Eio.Resource.handler

--- a/lib_eio_windows/test/dune
+++ b/lib_eio_windows/test/dune
@@ -1,3 +1,8 @@
+(mdx
+  (package eio_windows)
+  (enabled_if (= %{os_type} "Win32"))
+  (deps (package eio_windows)))
+
 (test
   (name test)
   (package eio_windows)


### PR DESCRIPTION
The implementation is copied from `lib_eio_posix/fs.ml`, simply replacing a forward slash.

I added the test case to the windows directory since the cross-platform test has some hard-coded forward slashes.

The output of the test reads
```
+<fs> -> Some .
+<fs:\\> -> Some \
+<fs:\\etc\\hosts> -> Some \etc\hosts
+<fs:.> -> Some .
+<fs:foo\\bar> -> Some .\foo\bar
+<cwd> -> Some .
+<cwd:..> -> Some .\..
+<native-sub> -> Some
+                  \??\C:\Users\asdf\eio\_build\default\lib_eio_windows\test\native-sub\
+<native-sub:foo.txt> -> Some
+                          \??\C:\Users\asdf\eio\_build\default\lib_eio_windows\test\native-sub\foo.txt
+<native-sub:.> -> Some
+                    \??\C:\Users\asdf\eio\_build\default\lib_eio_windows\test\native-sub\.
+<native-sub:..> -> Some
+                     \??\C:\Users\asdf\eio\_build\default\lib_eio_windows\test\native-sub\..
+<native-sub:\\etc\\passwd> -> Some \etc\passwd
```

I don't quite understand what `\??\` is all about.

https://github.com/ocaml-multicore/eio/blob/77d881014d0abb3246dda6f7af8178e86f05061a/lib_eio_windows/fs.ml#L60
