### PR TITLE
eio_windows: improve openat error handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
       - run: opam exec -- dune build
       - run: opam exec -- dune runtest
       - run: opam exec -- dune exec -- ./examples/net/main.exe
+      - run: opam exec -- dune exec -- ./examples/fs/main.exe
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/lib_eio_windows/eio_windows_stubs.c
+++ b/lib_eio_windows/eio_windows_stubs.c
@@ -237,7 +237,7 @@ CAMLprim value caml_eio_windows_unlinkat(value v_dirfd, value v_pathname, value 
 
   if (!NT_SUCCESS(r)) {
     caml_win32_maperr(RtlNtStatusToDosError(r));
-    uerror("openat", Nothing);
+    uerror("openat", v_pathname);
   }
 
   // Now close the file to delete it

--- a/lib_eio_windows/fs.ml
+++ b/lib_eio_windows/fs.ml
@@ -82,7 +82,7 @@ end = struct
         let dir = resolve t dir in
         Switch.run @@ fun sw ->
         let open Low_level in
-        let dirfd = Low_level.openat ~sw ~nofollow:true dir Flags.Open.(generic_read + synchronise) Flags.Disposition.(open_if) Flags.Create.(directory) in
+        let dirfd = Err.run (Low_level.openat ~sw ~nofollow:true dir Flags.Open.(generic_read + synchronise) Flags.Disposition.(open_if)) Flags.Create.(directory) in
         fn (Some dirfd) leaf
       )
     ) else fn None path


### PR DESCRIPTION
@kentookura reported on #eio seeing this when doing `Eio.Path.load`:

> Fatal error: exception Unix.Unix_error(Unix.ENOENT, "openat", "")

This patch adds the failing path argument to the `Unix_error` and wraps it as an Eio exception.

Also, the `fs` example is now run by the Windows CI (though I don't expect it to show this problem as it doesn't use `open_dir`).