### PR TITLE
Eio_unix.Net: make some return types more polymorphic

### DIFF
--- a/lib_eio/unix/net.ml
+++ b/lib_eio/unix/net.ml
@@ -68,9 +68,9 @@ type _ Effect.t +=
   | Socketpair_datagram : Switch.t * Unix.socket_domain * int ->
       ([`Unix_fd | datagram_socket_ty] r * [`Unix_fd | datagram_socket_ty] r) Effect.t
 
-let open_stream s = (s : _ stream_socket :> [< `Unix_fd | stream_socket_ty] r)
-let open_listening s = (s : _ listening_socket :> [< `Unix_fd | listening_socket_ty] r)
-let open_datagram s = (s : _ datagram_socket :> [< `Unix_fd | datagram_socket_ty] r)
+let open_stream s = (s : [`Unix_fd | stream_socket_ty] r :> [< `Unix_fd | stream_socket_ty] r)
+let open_listening s = (s : [`Unix_fd | listening_socket_ty] r :> [< `Unix_fd | listening_socket_ty] r)
+let open_datagram s = (s : [`Unix_fd | datagram_socket_ty] r :> [< `Unix_fd | datagram_socket_ty] r)
 
 let import_socket_stream ~sw ~close_unix fd =
   open_stream @@ Effect.perform (Import_socket_stream (sw, close_unix, fd))
@@ -86,7 +86,8 @@ let socketpair_stream ~sw ?(domain=Unix.PF_UNIX) ?(protocol=0) () =
   (open_stream a, open_stream b)
 
 let socketpair_datagram ~sw ?(domain=Unix.PF_UNIX) ?(protocol=0) () =
-  Effect.perform (Socketpair_datagram (sw, domain, protocol))
+  let a, b = Effect.perform (Socketpair_datagram (sw, domain, protocol)) in
+  (open_datagram a, open_datagram b)
 
 let fd socket =
   Option.get (Resource.fd_opt socket)

--- a/lib_eio/unix/net.mli
+++ b/lib_eio/unix/net.mli
@@ -55,7 +55,7 @@ end
 
 (** {2 Creating or importing sockets} *)
 
-val import_socket_stream : sw:Switch.t -> close_unix:bool -> Unix.file_descr -> [`Unix_fd | stream_socket_ty] r
+val import_socket_stream : sw:Switch.t -> close_unix:bool -> Unix.file_descr -> [< `Unix_fd | stream_socket_ty] r
 (** [import_socket_stream ~sw ~close_unix fd] is an Eio flow that uses [fd].
 
     It can be cast to e.g. {!source} for a one-way flow.
@@ -63,14 +63,14 @@ val import_socket_stream : sw:Switch.t -> close_unix:bool -> Unix.file_descr -> 
 
     The [close_unix] and [sw] arguments are passed to {!Fd.of_unix}. *)
 
-val import_socket_listening : sw:Switch.t -> close_unix:bool -> Unix.file_descr -> [`Unix_fd | listening_socket_ty] r
+val import_socket_listening : sw:Switch.t -> close_unix:bool -> Unix.file_descr -> [< `Unix_fd | listening_socket_ty] r
 (** [import_socket_listening ~sw ~close_unix fd] is an Eio listening socket that uses [fd].
 
     The socket object will be closed when [sw] finishes.
 
     The [close_unix] and [sw] arguments are passed to {!Fd.of_unix}. *)
 
-val import_socket_datagram : sw:Switch.t -> close_unix:bool -> Unix.file_descr -> [`Unix_fd | datagram_socket_ty] r
+val import_socket_datagram : sw:Switch.t -> close_unix:bool -> Unix.file_descr -> [< `Unix_fd | datagram_socket_ty] r
 (** [import_socket_datagram ~sw ~close_unix fd] is an Eio datagram socket that uses [fd].
 
     The socket object will be closed when [sw] finishes.
@@ -82,7 +82,7 @@ val socketpair_stream :
   ?domain:Unix.socket_domain ->
   ?protocol:int ->
   unit ->
-  [`Unix_fd | stream_socket_ty] r * [`Unix_fd | stream_socket_ty] r
+  [< `Unix_fd | stream_socket_ty] r * [< `Unix_fd | stream_socket_ty] r
 (** [socketpair_stream ~sw ()] returns a connected pair of flows, such that writes to one can be read by the other.
 
     This creates OS-level resources using [socketpair(2)].
@@ -93,7 +93,7 @@ val socketpair_datagram :
   ?domain:Unix.socket_domain ->
   ?protocol:int ->
   unit ->
-  [`Unix_fd | datagram_socket_ty] r * [`Unix_fd | datagram_socket_ty] r
+  [< `Unix_fd | datagram_socket_ty] r * [< `Unix_fd | datagram_socket_ty] r
 (** [socketpair_datagram ~sw ()] returns a connected pair of flows, such that writes to one can be read by the other.
 
     This creates OS-level resources using [socketpair(2)].


### PR DESCRIPTION
This allows e.g. using the result of the `import_socket_stream` as a `stream_socket_ty` without needing a cast.