### PR TITLE
Eio.Pool.use: move never_block argument

### DIFF
--- a/lib_eio/pool.ml
+++ b/lib_eio/pool.ml
@@ -133,7 +133,7 @@ let run_new_and_dispose t f =
     t.dispose x;
     Printexc.raise_with_backtrace ex bt
 
-let use t ?(never_block=false) f =
+let use ?(never_block=false) t f =
   let segment, cell = Q.next_suspend t.q in
   match Atomic.get cell with
   | Finished | Request _ -> assert false

--- a/lib_eio/pool.mli
+++ b/lib_eio/pool.mli
@@ -35,7 +35,7 @@ val create :
                    If it raises, the exception is passed on to the user,
                    but resource is still considered to have been disposed. *)
 
-val use : 'a t -> ?never_block:bool -> ('a -> 'b) -> 'b
+val use : ?never_block:bool -> 'a t -> ('a -> 'b) -> 'b
 (** [use t fn] waits for some resource [x] to be available and then runs [f x].
     Afterwards (on success or error), [x] is returned to the pool.
 


### PR DESCRIPTION
Optional arguments should go first so that it's obvious to the compiler when they're not being used. Example of a program where this makes a difference:

```ocaml
let run use = use ignore

let () =
  let p = Eio.Pool.create 1 ignore in
  run (Eio.Pool.use p)
```