### PR TITLE
Add batched copy for regular and block device files

### DIFF
--- a/bench/bench_copy.ml
+++ b/bench/bench_copy.ml
@@ -6,6 +6,22 @@ let chunk_size = 1 lsl 16
 let n_chunks = 10000
 let n_bytes = n_chunks * chunk_size
 
+let rec await pid =
+  match Unix.waitpid [] pid with
+  | (_pid, status) -> status
+  | exception Unix.Unix_error (Unix.EINTR, _, _) -> await pid
+
+let run prog args =
+  await (Unix.create_process prog (Array.of_list (prog :: args)) Unix.stdin Unix.stdout Unix.stderr)
+
+let check_status = function
+  | Unix.WEXITED 0 -> ()
+  | _ -> assert false
+
+let generate_file name =
+  run "fallocate" [ "-l"; string_of_int n_bytes; name ]
+  |> check_status
+
 let run_client sock =
   Fiber.both
     (fun () ->
@@ -35,8 +51,26 @@ let time name service =
   traceln "%s: %.2f MB/s" name (bytes_per_second /. 1024. /. 1024.);
   Metric.create name (`Float bytes_per_second) "bytes/s" (name ^ " Flow.copy")
 
-let run _env =
+let time_fs fs name service =
+  let ( / ) = Eio.Path.(/) in
+  let fname_in = "cptest.in" in
+  let fname_out ="cptest.out" in
+  if not (Sys.file_exists fname_in) then generate_file fname_in;
+  Eio.Path.with_open_in (fs / fname_in) @@ fun inflow ->
+  Eio.Path.with_open_out ~create:(`Exclusive 0o644) (fs / fname_out) @@ fun outflow ->
+  let t0 = Unix.gettimeofday () in
+  service inflow outflow;
+  let t1 = Unix.gettimeofday () in
+  let time = t1 -. t0 in
+  let bytes_per_second = float n_bytes /. time in
+  traceln "%s: %.2f MB/s" name (bytes_per_second /. 1024. /. 1024.);
+  at_exit (fun () -> try Sys.remove fname_in with _ -> ());
+  Sys.remove fname_out;
+  Metric.create name (`Float bytes_per_second) "bytes/s" (name ^ " Flow.copy")
+
+let run env =
   [
+    time_fs env#fs "default_fs" (fun inflow outflow -> Eio.Flow.copy inflow outflow);
     time "default" (fun sock -> Eio.Flow.copy sock sock);
     time "buf_read" (fun sock ->
         let r = Eio.Buf_read.of_flow sock ~initial_size:(64 * 1024) ~max_size:(64 * 1024) |> Eio.Buf_read.as_flow in


### PR DESCRIPTION
The default behavior of `Flow.copy` in the uring backend doesn't leverage batching syscalls to be sent in one shot. In principle, files that are bounded in size can use this batched submission pattern to reduce context switching overhead. The batched copy implementation is taken directly from `lib_eio_linux/tests/eurcp.ml`. 

Old behaviour:
![trace_old](https://github.com/user-attachments/assets/0887bf39-e604-41b5-b9d2-9fb7561cac8f)

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 33.44    0.000418          13        30           io_uring_enter
```

New behaviour:
![trace_new](https://github.com/user-attachments/assets/90d4e99b-7e63-462b-9e6f-97c82b46313f)

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
  0.00    0.000000           0         7           io_uring_enter
```

Tests:
```json

#OLD
+default_fs: 288.79 MB/s
{
  "config": {
    "uname": "Linux debian-thinkpad 6.1.0-23-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.99-1 (2024-07-15) x86_64 GNU/Linux",
    "backend": "linux",
    "recommended_domain_count": 4
  },
  "results": [
    {
      "name": "Flow.copy",
      "metrics": [
        {
          "name": "default_fs",
          "value": 302819851.7110036,
          "units": "bytes/s",
          "description": "default_fs Flow.copy"
        }
      ]
    }
  ]
}

#NEW
+default_fs: 462.35 MB/s
{
  "config": {
    "uname": "Linux debian-thinkpad 6.1.0-23-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.99-1 (2024-07-15) x86_64 GNU/Linux",
    "backend": "linux",
    "recommended_domain_count": 4
  },
  "results": [
    {
      "name": "Flow.copy",
      "metrics": [
        {
          "name": "default_fs",
          "value": 484808364.3907238,
          "units": "bytes/s",
          "description": "default_fs Flow.copy"
        }
      ]
    }
  ]
}
```