### PR TITLE
eio_linux: refactor fixed buffer code

### DIFF
--- a/lib_eio/core/eio__core.ml
+++ b/lib_eio/core/eio__core.ml
@@ -7,6 +7,7 @@ module Private = struct
   module Suspend = Suspend
   module Cells = Cells
   module Broadcast = Broadcast
+  module Single_waiter = Single_waiter
   module Trace = Trace
   module Fiber_context = Cancel.Fiber_context
   module Debug = Debug

--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -606,6 +606,7 @@ module Private : sig
 
   module Cells = Cells
   module Broadcast = Broadcast
+  module Single_waiter = Single_waiter
 
   (** Every fiber has an associated context. *)
   module Fiber_context : sig


### PR DESCRIPTION
Instead of having separate `Alloc`, `Alloc_or_wait` and `Free` effects, the scheduler now provides a single `Get` effect to return itself, and the actual work is now done in the calling fiber. This is a first step to align better with Picos's trigger mechanism (it actually uses `Single_waiter`, Eio's non-thread-safe equivalent, which is fine here). It seems to be slightly faster too, though that could just be noise.

It would be possible to use DLS to store the scheduler rather than using an effect. However, the improvement in speed is minimal and there are some complications with sys-threads, so probably better to wait for OCaml to support thread-local-storage first.

Note that the wait is non-cancellable at the moment (it was like that before too).