### PR TITLE
eio_linux: allow alloc_fixed_or_wait to be cancelled

### DIFF
--- a/lib_eio/core/fiber.ml
+++ b/lib_eio/core/fiber.ml
@@ -226,7 +226,7 @@ module List = struct
 
     let release t =
       t.free_fibers <- t.free_fibers + 1;
-      if t.free_fibers = 1 then Single_waiter.wake t.cond (Ok ())
+      if t.free_fibers = 1 then Single_waiter.wake_if_sleeping t.cond
 
     let use t fn x =
       await_free t;

--- a/lib_eio/core/single_waiter.mli
+++ b/lib_eio/core/single_waiter.mli
@@ -1,0 +1,25 @@
+(** Allows a single fiber to wait to be notified by another fiber in the same domain.
+    If multiple fibers need to wait at once, or the notification comes from another domain,
+    this can't be used. *)
+
+type 'a t
+(** A handle representing a fiber that might be sleeping.
+    It is either in the Running or Sleeping state. *)
+
+val create : unit -> 'a t
+(** [create ()] is a new waiter, initially in the Running state. *)
+
+val wake : 'a t -> ('a, exn) result -> bool
+(** [wake t v] resumes [t]'s fiber with value [v] and returns [true] if it was sleeping.
+    If [t] is Running then this just returns [false]. *)
+
+val wake_if_sleeping : unit t -> unit
+(** [wake_if_sleeping] is [ignore (wake t (Ok ()))]. *)
+
+val await : 'a t -> string -> Trace.id -> 'a
+(** [await t op id] suspends the calling fiber, changing [t]'s state to Sleeping.
+    If the fiber is cancelled, a cancel exception is raised.
+    [op] and [id] are used for tracing. *)
+
+val await_protect : 'a t -> string -> Trace.id -> 'a
+(** [await_protect] is like {!await}, but the sleep cannot be cancelled. *)

--- a/lib_eio/core/switch.ml
+++ b/lib_eio/core/switch.ml
@@ -72,7 +72,7 @@ let dec_fibers t =
   if t.daemon_fibers > 0 && t.fibers = t.daemon_fibers then
     Cancel.cancel t.cancel Exit;
   if t.fibers = 0 then
-    Single_waiter.wake t.waiter (Ok ())
+    Single_waiter.wake_if_sleeping t.waiter
 
 let with_op t fn =
   inc_fibers t;


### PR DESCRIPTION
As noted in #752, waiting for a fixed buffer couldn't be cancelled. This adds support for that.

I'm using this PR to test out the Picos style of cancellation. Normally, Eio programs set a cancel function to be invoked immediately when the fiber is cancelled, but Picos instead just schedules the cancelled fiber to be resumed and the clean-up actions happen later.

The new style introduces an annoying extra state, where the operation is half-cancelled (the cancellation has happened, but the fiber is still registered as waiting for a buffer), and we need to handle that by retrying. On the other hand, it means no user code runs in the scheduler's context, and potentially allows cancellation from another domain.