### PR TITLE
eio_linux: avoid triggering a TSan warning

### DIFF
--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -521,7 +521,10 @@ let with_sched ?(fallback=no_fallback) config fn =
       Uring.exit uring;
       fallback (`Msg "Linux >= 5.15 is required for io_uring support")
     ) else (
-      statx_works := Uring.op_supported probe Uring.Op.msg_ring;
+      (* The reason for an if here is to make sure we only set it once, when
+         the first domain is starting. This is just to avoid a tsan warning. *)
+      if not !statx_works && Uring.op_supported probe Uring.Op.msg_ring then
+        statx_works := true;
       match
         let mem =
           let fixed_buf_len = block_size * n_blocks in


### PR DESCRIPTION
TSan warns that setting `statx_works` races with users of it. This isn't really a problem, because we always set it to the same value, but it's distracting when looking for other bugs.

Reported by @avsm in #751.

Test-case:
```ocaml
open Eio.Std

let () =
  Eio_main.run @@ fun env ->
  Fiber.both
    (fun () ->
       Eio.Domain_manager.run env#domain_mgr (fun () -> Eio_unix.sleep 100.);
    )
    (fun () ->
       while true do
         ignore (Eio.Path.stat ~follow:false (Eio.Stdenv.cwd env) : Eio.File.Stat.t)
       done
    )
```