### PR TITLE
Minor code cleanups

### DIFF
--- a/lib_eio/core/dune
+++ b/lib_eio/core/dune
@@ -1,4 +1,4 @@
 (library
   (name eio__core)
   (public_name eio.core)
-  (libraries hmap lwt-dllist fmt optint domain-local-await eio.runtime_events))
+  (libraries hmap lwt-dllist fmt optint eio.runtime_events))

--- a/lib_eio/core/dune
+++ b/lib_eio/core/dune
@@ -1,4 +1,4 @@
 (library
   (name eio__core)
   (public_name eio.core)
-  (libraries cstruct hmap lwt-dllist fmt optint domain-local-await eio.runtime_events))
+  (libraries hmap lwt-dllist fmt optint domain-local-await eio.runtime_events))

--- a/lib_eio/core/eio__core.ml
+++ b/lib_eio/core/eio__core.ml
@@ -19,6 +19,4 @@ module Private = struct
       | Fork = Fiber.Fork
       | Get_context = Cancel.Get_context
   end
-
-  module Dla = Dla
 end

--- a/lib_eio/core/eio__core.mli
+++ b/lib_eio/core/eio__core.mli
@@ -782,8 +782,4 @@ module Private : sig
     val v : t
     (** Backends should use this for {!Eio.Stdenv.debug}. *)
   end
-
-  module Dla : sig
-    val prepare_for_await : unit -> Domain_local_await.t
-  end
 end

--- a/lib_eio/mock/backend.ml
+++ b/lib_eio/mock/backend.ml
@@ -105,7 +105,7 @@ let run_full main =
   let result = ref None in
   let `Exit_scheduler =
     Domain_local_await.using
-      ~prepare_for_await:Eio.Private.Dla.prepare_for_await
+      ~prepare_for_await:Eio_utils.Dla.prepare_for_await
       ~while_running:(fun () ->
         fork ~new_fiber (fun () -> result := Some (main stdenv))) in
   match !result with

--- a/lib_eio/utils/dla.ml
+++ b/lib_eio/utils/dla.ml
@@ -7,10 +7,10 @@ let prepare_for_await () =
       | _ -> ()
   and await () =
     if Atomic.get state != `Released then
-      Suspend.enter "domain-local-await" @@ fun ctx enqueue ->
+      Eio.Private.Suspend.enter "domain-local-await" @@ fun ctx enqueue ->
       let awaiting = `Awaiting enqueue in
       if Atomic.compare_and_set state `Init awaiting then (
-        Cancel.Fiber_context.set_cancel_fn ctx (fun ex ->
+        Eio.Private.Fiber_context.set_cancel_fn ctx (fun ex ->
             if Atomic.compare_and_set state awaiting `Released then (
               enqueue (Error ex)
             )

--- a/lib_eio/utils/dla.mli
+++ b/lib_eio/utils/dla.mli
@@ -1,0 +1,1 @@
+val prepare_for_await : unit -> Domain_local_await.t

--- a/lib_eio/utils/dune
+++ b/lib_eio/utils/dune
@@ -1,4 +1,4 @@
 (library
  (name eio_utils)
  (public_name eio.utils)
- (libraries eio psq fmt optint))
+ (libraries eio psq fmt optint domain-local-await))

--- a/lib_eio/utils/eio_utils.ml
+++ b/lib_eio/utils/eio_utils.ml
@@ -5,3 +5,4 @@
 module Lf_queue = Lf_queue
 module Suspended = Suspended
 module Zzz = Zzz
+module Dla = Dla

--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -460,7 +460,7 @@ let run ~extra_effects st main arg =
   let `Exit_scheduler =
     let new_fiber = Fiber_context.make_root () in
     Domain_local_await.using
-      ~prepare_for_await:Eio.Private.Dla.prepare_for_await
+      ~prepare_for_await:Eio_utils.Dla.prepare_for_await
       ~while_running:(fun () ->
         fork ~new_fiber (fun () ->
             Switch.run_protected ~name:"eio_linux" (fun sw ->

--- a/lib_eio_posix/sched.ml
+++ b/lib_eio_posix/sched.ml
@@ -379,7 +379,7 @@ let run ~extra_effects t main x =
   let `Exit_scheduler =
     let new_fiber = Fiber_context.make_root () in
     Domain_local_await.using
-      ~prepare_for_await:Eio.Private.Dla.prepare_for_await
+      ~prepare_for_await:Eio_utils.Dla.prepare_for_await
       ~while_running:(fun () ->
           fork ~new_fiber (fun () ->
               Eio_unix.Private.Thread_pool.run t.thread_pool @@ fun () ->

--- a/lib_eio_windows/sched.ml
+++ b/lib_eio_windows/sched.ml
@@ -370,7 +370,7 @@ let run ~extra_effects t main x =
   let `Exit_scheduler =
     let new_fiber = Fiber_context.make_root () in
     Domain_local_await.using
-      ~prepare_for_await:Eio.Private.Dla.prepare_for_await
+      ~prepare_for_await:Eio_utils.Dla.prepare_for_await
       ~while_running:(fun () ->
           fork ~new_fiber (fun () ->
               Eio_unix.Private.Thread_pool.run t.thread_pool @@ fun () ->


### PR DESCRIPTION
Remove `cstruct` and `domain-local-await` dependencies from `eio.core`. Cstruct wasn't used at all, and it makes more sense to have Dla in `eio.utils` (shared utilities for backends).