### PR TITLE
Make fork_action.h a public_header

### DIFF
--- a/lib_eio/unix/dune
+++ b/lib_eio/unix/dune
@@ -1,6 +1,7 @@
 (library
  (name eio_unix)
  (public_name eio.unix)
+ (public_headers include/fork_action.h)
  (foreign_stubs
   (language c)
   (include_dirs include)


### PR DESCRIPTION
For other libraries that depend on Eio and wish to provide new fork actions, it would be useful to install the `fork_action.h` header. 