### PR TITLE
Relax return types of Eio.Process.Pipe

### DIFF
--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -149,7 +149,10 @@ let run t ?cwd ?stdin ?stdout ?stderr ?(is_success = Int.equal 0) ?env ?executab
 
 let pipe (type tag) ~sw ((Resource.T (v, ops)) : [> tag mgr_ty] r) =
   let module X = (val (Resource.get ops Pi.Mgr)) in
-  X.pipe v ~sw
+  let r, w = X.pipe v ~sw in
+  let r = (r : [Flow.source_ty | Resource.close_ty] r :> [< Flow.source_ty | Resource.close_ty] r) in
+  let w = (w : [Flow.sink_ty   | Resource.close_ty] r :> [< Flow.sink_ty   | Resource.close_ty] r) in
+  r, w
 
 let parse_out (type tag) (t : [> tag mgr_ty] r) parse ?cwd ?stdin ?stderr ?is_success ?env ?executable args =
   Switch.run ~name:"Process.parse_out" @@ fun sw ->

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -143,7 +143,7 @@ val parse_out :
 
 (** {2 Pipes} *)
 
-val pipe : sw:Switch.t -> _ mgr -> [Flow.source_ty | Resource.close_ty] r * [Flow.sink_ty | Resource.close_ty] r
+val pipe : sw:Switch.t -> _ mgr -> [< Flow.source_ty | Resource.close_ty] r * [< Flow.sink_ty | Resource.close_ty] r
 (** [pipe ~sw mgr] creates a pipe backed by the OS.
 
     The flows can be used by {!spawn} without the need for extra fibers to copy the data.

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -58,7 +58,7 @@ val run_in_systhread : ?label:string -> (unit -> 'a) -> 'a
 
     @param label The operation name to use in trace output. *)
 
-val pipe : Switch.t -> source_ty r * sink_ty r
+val pipe : Switch.t -> [< source_ty] r * [< sink_ty] r
 (** [pipe sw] returns a connected pair of flows [src] and [sink]. Data written to [sink]
     can be read from [src].
     Note that, like all FDs created by Eio, they are both marked as close-on-exec by default. *)

--- a/lib_eio/unix/private.ml
+++ b/lib_eio/unix/private.ml
@@ -12,7 +12,11 @@ type _ Effect.t +=
 let await_readable fd = Effect.perform (Await_readable fd)
 let await_writable fd = Effect.perform (Await_writable fd)
 
-let pipe sw = Effect.perform (Pipe sw)
+let pipe sw =
+  let r, w = Effect.perform (Pipe sw) in
+  let r = (r : source_ty r :> [< source_ty] r) in
+  let w = (w : sink_ty r :> [< sink_ty] r) in
+  r, w
 
 module Rcfd = Rcfd
 module Fork_action = Fork_action


### PR DESCRIPTION
This PR relaxes the return types of the pipe function in Eio.Process to make the code more flexible. The main goal was to allow the pipe function to handle a broader range of types for input and output flows, while still maintaining compatibility with the rest of the codebase.

**Changes:**

- **Relaxed Type Definitions**: I’ve updated the return types for pipe so they can accept any subtype of `Flow.source_ty` and `Flow.sink_ty`. This will give us more flexibility when working with processes that require different types of flows.

- **Polymorphic Variants**: I used polymorphic variants (`[< .. ]`) to allow for more flexible types, ensuring that the code still works with the broader variants expected in other parts of the system.

**Testing:**
I ran dune runtest and confirmed that all tests are passing with these changes. The new types work fine, and the tests ensure everything is still functioning as expected.

> **Relaxing the types for pipe allows us to work with a wider variety of process setups and flows, without being too restrictive about the types we return. It also makes the code easier to extend in the future.**

This addresses issue https://github.com/ocaml-multicore/eio/issues/750, improving flexibility when working with various APIs that use stricter type definitions for sources and sinks.