### PR TITLE
Preserve backtraces in fork_daemon and fork_promise_exn

### DIFF
--- a/lib_eio/core/fiber.ml
+++ b/lib_eio/core/fiber.ml
@@ -39,7 +39,8 @@ let fork_daemon ~sw f =
       (* The daemon was cancelled because all non-daemon fibers are finished. *)
       ()
     | exception ex ->
-      Switch.fail sw ex;  (* The [with_daemon] ensures this will succeed *)
+      let bt = Printexc.get_raw_backtrace () in
+      Switch.fail ~bt sw ex;  (* The [with_daemon] ensures this will succeed *)
   ) (* else the fiber should report the error to [sw], but [sw] is failed anyway *)
 
 let fork_promise ~sw f =
@@ -65,7 +66,8 @@ let fork_promise_exn ~sw f =
       match Switch.with_op sw f with
       | x -> Promise.resolve r x
       | exception ex ->
-        Switch.fail sw ex  (* The [with_op] ensures this will succeed *)
+        let bt = Printexc.get_raw_backtrace () in
+        Switch.fail ~bt sw ex  (* The [with_op] ensures this will succeed *)
     );
   p
 


### PR DESCRIPTION
If the fiber fails, record the backtrace when failing the switch. `fork` itself already did this, but `fork_daemon` and `fork_promise_exn` didn't.

This caused unhelpful errors such as:
```
Fatal error: exception Not_found
Raised at Eio__core__Switch.maybe_raise_exs in file "lib_eio/core/switch.ml", line 119, characters 21-56
```