### PR TITLE
Support `chown` in eio_posix and eio_linux

### DIFF
--- a/lib_eio/fs.ml
+++ b/lib_eio/fs.ml
@@ -73,6 +73,7 @@ module Pi = struct
     val read_link : t -> path -> string
     val symlink : link_to:path -> t -> path -> unit
     val chmod : t -> follow:bool -> perm:File.Unix_perm.t -> path -> unit
+    val chown : follow:bool -> ?uid:int64 -> ?gid:int64 -> t -> path -> unit
     val pp : t Fmt.t
     val native : t -> string -> string option
   end

--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -266,3 +266,11 @@ let read_link t =
   with Exn.Io _ as ex ->
     let bt = Printexc.get_raw_backtrace () in
     Exn.reraise_with_context ex bt "reading target of symlink %a" pp t
+
+let chown ~follow ?uid ?gid t =
+  let (Resource.T (dir, ops), path) = t in
+  let module X = (val (Resource.get ops Fs.Pi.Dir)) in
+  try X.chown ~follow ?uid ?gid dir path
+  with Exn.Io _ as ex ->
+    let bt = Printexc.get_raw_backtrace () in
+    Exn.reraise_with_context ex bt "changing ownership of %a" pp t

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -247,3 +247,10 @@ val chmod : follow:bool -> perm:File.Unix_perm.t -> _ t -> unit
 (** [chmod ~follow ~perm t] allows you to change the file mode bits.
 
     @param follow If [true] and [t] is a symlink then change the target's mode bits. *)
+
+val chown : follow:bool -> ?uid:int64 -> ?gid:int64 -> _ t -> unit
+(** [chown ~follow ~uid ~gid t] changes the ownership of [t] to be [uid, gid].
+
+    [uid] or [gid] can be omitted to leave the current value unchanged.
+
+    @param follow If [t] is a symbolic link, change the ownership of its target. *)

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -133,6 +133,8 @@ module Private : sig
   val read_link_unix : Unix.file_descr option -> string -> string
   val chmod : Fd.t -> string -> flags:int -> mode:int -> unit
   val chmod_unix : Unix.file_descr -> string -> flags:int -> mode:int -> unit
+  val chown : flags:int -> uid:int64 -> gid:int64 -> Fd.t -> string -> unit
+  val chown_unix : flags:int -> uid:int64 -> gid:int64 -> Unix.file_descr -> string -> unit
 end
 
 module Pi = Pi

--- a/lib_eio/unix/eio_unix_stubs.c
+++ b/lib_eio/unix/eio_unix_stubs.c
@@ -91,3 +91,25 @@ CAMLprim value eio_unix_fchmodat(value v_fd, value v_path, value v_mode, value v
   CAMLreturn(Val_unit);
   #endif
 }
+
+CAMLprim value eio_unix_fchownat(value v_fd, value v_path, value v_uid, value v_gid, value v_flags) {
+#ifdef _WIN32
+  caml_unix_error(EOPNOTSUPP, "fchownat not supported on Windows", v_path);
+#else
+  CAMLparam3(v_path, v_uid, v_gid);
+  char *path;
+  int fd = Int_val(v_fd);
+  uid_t uid = Int64_val(v_uid);
+  gid_t gid = Int64_val(v_gid);
+  int ret;
+  caml_unix_check_path(v_path, "fchownat");
+  path = caml_stat_strdup(String_val(v_path));
+  caml_enter_blocking_section();
+  ret = fchownat(fd, path, uid, gid, Int_val(v_flags));
+  caml_leave_blocking_section();
+  caml_stat_free_preserving_errno(path);
+  if (ret == -1)
+    caml_uerror("fchownat", v_path);
+  CAMLreturn(Val_unit);
+#endif
+}

--- a/lib_eio/unix/primitives.h
+++ b/lib_eio/unix/primitives.h
@@ -19,4 +19,5 @@ CAMLprim value eio_unix_error_of_code(value);
 CAMLprim value eio_unix_cap_enter(value);
 CAMLprim value eio_unix_readlinkat(value, value, value);
 CAMLprim value eio_unix_fchmodat(value, value, value, value);
+CAMLprim value eio_unix_fchownat(value, value, value, value, value);
 CAMLprim value eio_unix_is_blocking(value);

--- a/lib_eio/unix/private.ml
+++ b/lib_eio/unix/private.ml
@@ -44,3 +44,11 @@ let chmod_unix fd path ~flags ~mode = eio_fchmodat fd path mode flags
 
 let chmod fd path ~flags ~mode =
   Fd.use_exn "chmod" fd (fun fd -> chmod_unix ~flags ~mode fd path)
+
+external eio_fchownat : Unix.file_descr -> string -> int64 -> int64 -> int -> unit = "eio_unix_fchownat"
+
+let chown_unix ~flags ~uid ~gid fd path =
+  eio_fchownat fd path uid gid flags
+
+let chown ~flags ~uid ~gid fd path =
+  Fd.use_exn "chown" fd (fun fd -> chown_unix ~uid ~gid ~flags fd path)

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -452,6 +452,9 @@ end = struct
 
   let read_link t path = Low_level.read_link t.fd path
 
+  let chown ~follow ?uid ?gid t path = 
+    Low_level.chown ~follow ?uid ?gid t.fd path
+
   let close t =
     match t.fd with
     | FD x -> Fd.close x

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -741,6 +741,15 @@ let chmod ~follow ~mode dir path =
     Eio_unix.run_in_systhread ~label:"chmod" (fun () -> Eio_unix.Private.chmod parent leaf ~mode ~flags)
   with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
 
+let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) fd path =
+  let module At = Uring.Linkat_flags in
+  let follow = if follow then At.(empty_path + symlink_follow) else At.empty_path in
+  let flags = (follow :> int) in
+  try
+    with_parent_dir_fd fd path @@ fun parent leaf ->
+    Eio_unix.run_in_systhread ~label:"chown" (fun () -> Eio_unix.Private.chown ~flags ~uid ~gid parent leaf)
+  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
+
 (* https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml *)
 let getaddrinfo ~service node =
   let to_eio_sockaddr_t {Unix.ai_family; ai_addr; ai_socktype; ai_protocol; _ } =

--- a/lib_eio_linux/low_level.mli
+++ b/lib_eio_linux/low_level.mli
@@ -180,6 +180,12 @@ val symlink : link_to:string -> dir_fd -> string -> unit
 val chmod : follow:bool -> mode:int -> dir_fd -> string -> unit
 (** [chmod ~follow ~mode dir path] changes the file mode bits of [dir / path]. *)
 
+val chown : follow:bool -> ?uid:int64 -> ?gid:int64 -> dir_fd -> string -> unit
+(** [chown ~follow ~uid ~gid dir path] changes the ownership of [dir / path] to [uid, gid].
+
+    If [follow = true] and [dir / path] is a symlink, then the ownership of the {e target} is
+    changed. If it is [false] then the ownership of the symlink itself is changed. *)
+
 val pipe : sw:Switch.t -> fd * fd
 (** [pipe ~sw] returns a pair [r, w] with the readable and writeable ends of a new pipe. *)
 

--- a/lib_eio_posix/fs.ml
+++ b/lib_eio_posix/fs.ml
@@ -125,6 +125,9 @@ end = struct
   let chmod t ~follow ~perm path =
     Err.run (Low_level.chmod ~follow ~mode:perm t.fd) path
 
+  let chown ~follow ?uid ?gid t path =
+    Err.run (Low_level.chown ~follow ?uid ?gid t.fd) path
+
   let open_subtree t ~sw path =
     let flags = Low_level.Open_flags.(rdonly + directory +? path) in
     let fd = Err.run (Low_level.openat ~sw ~mode:0 t.fd path) flags in

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -477,6 +477,13 @@ let read_link dirfd path =
   Resolve.with_parent "read_link" dirfd path @@ fun dirfd path ->
   Eio_unix.Private.read_link_unix dirfd path
 
+let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) dirfd path =
+  let flags = if follow then 0 else Config.at_symlink_nofollow in
+  in_worker_thread "chown" @@ fun () ->
+  Resolve.with_parent "chown" dirfd path @@ fun dirfd path ->
+  let dirfd = Option.value dirfd ~default:at_fdcwd in
+  Eio_unix.Private.chown_unix ~flags ~uid ~gid dirfd path
+
 type stat
 external create_stat : unit -> stat = "caml_eio_posix_make_stat"
 external eio_fstatat : stat -> Unix.file_descr -> string -> int -> unit = "caml_eio_posix_fstatat"

--- a/lib_eio_posix/low_level.mli
+++ b/lib_eio_posix/low_level.mli
@@ -84,6 +84,10 @@ val symlink : link_to:string -> dir_fd -> string -> unit
 
 val chmod : follow:bool -> mode:int -> dir_fd -> string -> unit
 
+val chown : follow:bool -> ?uid:int64 -> ?gid:int64 -> dir_fd -> string -> unit
+(** [chown ~follow ~uid ~gid dir path] will change the ownership of [dir / path]
+    to [uid, gid]. *)
+
 val readdir : dir_fd -> string -> string array
 val with_dir_entries : dir_fd -> string -> ((Eio.File.Stat.kind * string) Seq.t -> 'a) -> 'a
 

--- a/lib_eio_windows/fs.ml
+++ b/lib_eio_windows/fs.ml
@@ -175,6 +175,10 @@ end = struct
     with_parent_dir t path @@ fun dirfd path ->
     Err.run (Low_level.read_link ?dirfd) path
 
+  let chown ~follow ?uid ?gid t path =
+    with_parent_dir t path @@ fun dirfd path ->
+    Err.run (fun () -> Low_level.chown ?dirfd ~follow ?uid ?gid path) ()
+
   let rename t old_path new_dir new_path =
     match Handler.as_posix_dir new_dir with
     | None -> invalid_arg "Target is not an eio_windows directory!"

--- a/lib_eio_windows/low_level.ml
+++ b/lib_eio_windows/low_level.ml
@@ -146,6 +146,12 @@ let read_link ?dirfd path =
   in_worker_thread @@ fun () ->
   Eio_unix.Private.read_link dirfd path
 
+let chown ?dirfd ~follow:_ ?(uid=(-1L)) ?(gid=(-1L)) path =
+  in_worker_thread @@ fun () ->
+  match dirfd with
+  | None -> failwith "Chown is unsupported on Windows"
+  | Some dirfd -> Eio_unix.Private.chown ~flags:0 ~uid ~gid dirfd path
+
 external eio_readv : Unix.file_descr -> Cstruct.t array -> int = "caml_eio_windows_readv"
 
 external eio_preadv : Unix.file_descr -> Cstruct.t array -> Optint.Int63.t -> int = "caml_eio_windows_preadv"

--- a/lib_eio_windows/low_level.mli
+++ b/lib_eio_windows/low_level.mli
@@ -44,6 +44,7 @@ val lstat : string -> Unix.LargeFile.stats
 
 val realpath : string -> string
 val read_link : ?dirfd:fd -> string -> string
+val chown : ?dirfd:fd -> follow:bool -> ?uid:int64 -> ?gid:int64 -> string -> unit
 
 val mkdir : ?dirfd:fd -> ?nofollow:bool -> mode:int -> string -> unit
 val unlink : ?dirfd:fd -> dir:bool -> string -> unit

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -939,6 +939,57 @@ Reading at the end of a file:
 - : unit = ()
 ```
 
+# Changing Ownership
+
+<!-- This test is written a little obscurely as we only want to
+     run it on macOS, but MDX only supports os_type (Unix, Win, Cygwin) -->
+```ocaml
+# run @@ fun env ->
+  let cwd = Eio.Stdenv.cwd env in
+  let everyone = try Some (Unix.getgrnam "everyone") with Not_found -> None in
+  let stat_uid_gid path =
+    let stat = Eio.Path.stat ~follow:false path in
+    stat.uid, stat.gid
+  in
+  match everyone with
+    | None -> ()
+    | Some entry ->
+      let everybody = Int64.of_int entry.gr_gid in
+
+      let path = cwd / "owner.txt" in
+      let link = cwd / "link.txt" in
+      let symlink = cwd / "symlink.txt" in
+
+      (* Normal chown to everyone group *)
+      Path.with_open_out path ~create:(`Or_truncate 0o644) ignore;
+      let uid_before, _gid_before = stat_uid_gid path in
+      Eio.Path.chown ~follow:false ~uid:uid_before ~gid:everybody path;
+      let uid_after, gid_after = stat_uid_gid path in
+      assert (uid_before = uid_after);
+      assert (everybody = gid_after);
+
+      (* Chowning through a symlink *)
+      Path.with_open_out link ~create:(`Or_truncate 0o644) ignore;
+      Eio.Path.symlink ~link_to:"link.txt" symlink;
+      let luid1, lgid1 = stat_uid_gid link in
+      let suid1, sgid1 = stat_uid_gid symlink in
+
+      (* Only chown the symlink, not the target *)
+      Eio.Path.chown ~follow:false ~gid:everybody symlink;
+      let luid2, lgid2 = stat_uid_gid link in
+      let suid2, sgid2 = stat_uid_gid symlink in
+      assert (luid1 = luid2 && lgid1 = lgid2 && suid1 = suid2 && Int64.to_int sgid2 = entry.gr_gid);
+
+      (* Now chown the target too *)
+      Eio.Path.chown ~follow:true ~gid:everybody symlink;
+      let luid3, lgid3 = stat_uid_gid link in
+      let suid3, sgid3 = stat_uid_gid symlink in
+      assert (suid3 = luid3);
+      assert (Int64.to_int lgid3 = entry.gr_gid);
+      assert (Int64.to_int sgid3 = entry.gr_gid);;
+- : unit = ()
+```
+
 # Cancelling while readable
 
 Ensure reads can be cancelled promptly, even if there is no need to wait:


### PR DESCRIPTION
This PR adds support to Eio for changing the ownership of a path using `fchownat`.