### PR TITLE
Fix tests on OpenBSD

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -48,6 +48,7 @@
   (eio (= :version))
   (iomux (>= 0.2))
   (mdx (and (>= 2.4.1) :with-test))
+  (conf-bash :with-test)
   (fmt (>= 0.8.9))))
 (package
  (name eio_windows)

--- a/eio_posix.opam
+++ b/eio_posix.opam
@@ -13,6 +13,7 @@ depends: [
   "eio" {= version}
   "iomux" {>= "0.2"}
   "mdx" {>= "2.4.1" & with-test}
+  "conf-bash" {with-test}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}
 ]

--- a/tests/network.md
+++ b/tests/network.md
@@ -620,7 +620,9 @@ Exception: Eio.Io Fs Not_found _,
 ```ocaml
 # Eio_main.run @@ fun env ->
   let sockaddr = `Tcp (Eio.Net.Ipaddr.V4.loopback, 80) in
-  Eio.Net.getnameinfo env#net sockaddr;;
+  let (host, service) = Eio.Net.getnameinfo env#net sockaddr in
+  let service = if service = "www" then "http" else service in (* OpenBSD *)
+  (host, service)
 - : string * string = ("localhost", "http")
 ```
 

--- a/tests/process.md
+++ b/tests/process.md
@@ -145,24 +145,24 @@ If a command fails, we get shown the arguments (quoted if necessary):
 
 ```ocaml
 # run @@ fun mgr env ->
-  Process.run mgr ["bash"; "-c"; "exit 3"; ""; "foo"; "\"bar\""];;
+  Process.run mgr ["sh"; "-c"; "exit 3"; ""; "foo"; "\"bar\""];;
 Exception:
 Eio.Io Process Child_error Exited (code 3),
-  running command: bash -c "exit 3" "" foo "\"bar\""
+  running command: sh -c "exit 3" "" foo "\"bar\""
 ```
 
 Exit code success can be determined by is_success (Process.run):
 
 ```ocaml
 # run @@ fun mgr env ->
-  Process.run ~is_success:(Int.equal 3) mgr ["bash"; "-c"; "exit 3"];;
+  Process.run ~is_success:(Int.equal 3) mgr ["sh"; "-c"; "exit 3"];;
 - : unit = ()
 
 # run @@ fun mgr env ->
-  Process.run ~is_success:(Int.equal 3) mgr ["bash"; "-c"; "exit 0"];;
+  Process.run ~is_success:(Int.equal 3) mgr ["sh"; "-c"; "exit 0"];;
 Exception:
 Eio.Io Process Child_error Exited (code 0),
-  running command: bash -c "exit 0"
+  running command: sh -c "exit 0"
 ```
 
 Exit code success can be determined by is_success (Process.parse_out):


### PR DESCRIPTION
- Add test dependency on bash.
- Allow www instead of http as the service name for port 80.