### PR TITLE
Ignore ECONNRESET on close

### DIFF
--- a/lib_eio/tests/dscheck/unix.ml
+++ b/lib_eio/tests/dscheck/unix.ml
@@ -1,3 +1,7 @@
+type error = ECONNRESET
+
+exception Unix_error of error * string * string
+
 type file_descr = [`Open | `Closed] Atomic.t
 
 let make () = Atomic.make `Open

--- a/lib_eio/unix/rcfd.ml
+++ b/lib_eio/unix/rcfd.ml
@@ -98,7 +98,13 @@ let get t =
     None
 
 let close_fd fd =
-  Eio.Private.Trace.with_span "close" (fun () -> Unix.close fd)
+  Eio.Private.Trace.with_span "close" (fun () ->
+      try
+        Unix.close fd
+      with Unix.Unix_error (ECONNRESET, _, _) ->
+        (* For FreeBSD. See https://github.com/ocaml-multicore/eio/issues/786 *)
+        ()
+    )
 
 (* Note: we could simplify this a bit by incrementing [t.ops], as [remove] does.
    However, that makes dscheck too slow. *)


### PR DESCRIPTION
FreeBSD returns ECONNRESET in certain (unclear) circumstances, but it does still close the FD successfully. If you care about this case, you should probably use `shutdown` instead and check for it there.

Python and Ruby at least both explicitly check for and ignore this error too.

Fixes #786 I hope, though I can't reproduce it locally.