### PR TITLE
Disable dune subst

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,7 @@
 (lang dune 3.9)
 (name eio)
 (formatting disabled)
+(subst disabled)
 (generate_opam_files true)
 (source (github ocaml-multicore/eio))
 (license ISC)

--- a/eio.opam
+++ b/eio.opam
@@ -29,7 +29,6 @@ conflicts: [
   "seq" {< "0.3"}
 ]
 build: [
-  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -20,7 +20,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/eio_main.opam
+++ b/eio_main.opam
@@ -21,7 +21,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/eio_posix.opam
+++ b/eio_posix.opam
@@ -18,7 +18,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/eio_windows.opam
+++ b/eio_windows.opam
@@ -17,7 +17,6 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
It was always unnecessary, but with dune 3.17.0 it's causing the benchmarks to fail to install. The error is:

    Error: There is no dune-project file in the current directory, please add one
    with a (name <name>) field in it.
    Hint: 'dune subst' must be executed from the root of the project