### PR TITLE
Prioritize returning Fiber.any value over cancelling quickly

### DIFF
--- a/lib_eio/core/fiber.ml
+++ b/lib_eio/core/fiber.ml
@@ -150,8 +150,8 @@ let any_gen ~return ~combine fs =
       )
   in
   match !r, Cancel.get_error parent_c with
-  | OK r, None -> r
-  | (OK _ | New), Some ex -> raise ex
+  | OK r, _ -> r
+  | New, Some ex -> raise ex
   | Ex (ex, bt), None -> Printexc.raise_with_backtrace ex bt
   | Ex ex1, Some ex2 ->
     let bt2 = Printexc.get_raw_backtrace () in

--- a/tests/fiber.md
+++ b/tests/fiber.md
@@ -191,21 +191,23 @@ Cancelled from parent:
 Exception: Failure "Parent cancel".
 ```
 
-Cancelled from parent while already cancelling:
+Cancelled from parent while already cancelling
+(we return the value despite the cancellation):
 
 ```ocaml
 # run @@ fun () ->
   Fiber.both
     (fun () ->
-      let _ = Fiber.first
+      traceln "%s" @@ Fiber.first
         (fun () -> "a")
-        (fun () -> Fiber.yield (); failwith "cancel-b")
-      in
+        (fun () -> Fiber.yield (); failwith "cancel-b");
+      Fiber.check ();
       traceln "Parent cancel failed"
     )
     (fun () -> traceln "Cancelling parent"; failwith "Parent cancel");
   "not-reached";;
 +Cancelling parent
++a
 Exception: Failure "Parent cancel".
 ```
 


### PR DESCRIPTION
This makes changes in `Fiber.any` to prioritize returning the value rather than cancelling the whole `Fiber.any` from the outside if we already have the value from one of it's functions. A sample code showing a specific scenario and more detailed explanation are in the issue #805.

Let me know if this is reasonable to merge.