### PR TITLE
Eio.Process: match Unix search behaviour

### DIFF
--- a/lib_eio/unix/process.ml
+++ b/lib_eio/unix/process.ml
@@ -1,7 +1,7 @@
 open Eio.Std
 
 let resolve_program name =
-  if Filename.is_implicit name then (
+  if not (String.contains name '/') then (
     Sys.getenv_opt "PATH"
     |> Option.value ~default:"/bin:/usr/bin"
     |> String.split_on_char ':'


### PR DESCRIPTION
Don't search path if the name contains a `/`. https://pubs.opengroup.org/onlinepubs/9799919799/ says:

> If the file argument contains a `<slash>` character, the file argument
> shall be used as the pathname for this file. Otherwise, the path
> prefix for this file is obtained by a search of the directories passed
> as the environment variable PATH