### PR TITLE
Incremental directory reading

### DIFF
--- a/lib_eio/fs.ml
+++ b/lib_eio/fs.ml
@@ -65,6 +65,7 @@ module Pi = struct
     val mkdir : t -> perm:File.Unix_perm.t -> path -> unit
     val open_dir : t -> sw:Switch.t -> path -> [`Close | dir_ty] r
     val read_dir : t -> path -> string list
+    val with_dir_entries : t -> path -> ((File.Stat.kind * string) Seq.t -> 'a) -> 'a
     val stat : t -> follow:bool -> string -> File.Stat.t
     val unlink : t -> path -> unit
     val rmdir : t -> path -> unit

--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -106,6 +106,14 @@ let read_dir t =
     let bt = Printexc.get_raw_backtrace () in
     Exn.reraise_with_context ex bt "reading directory %a" pp t
 
+let walk t fn =
+  let (Resource.T (dir, ops), path) = t in
+  let module X = (val (Resource.get ops Fs.Pi.Dir)) in
+  try X.with_dir_entries dir path fn
+  with Exn.Io _ as ex ->
+    let bt = Printexc.get_raw_backtrace () in
+    Exn.reraise_with_context ex bt "walking directory %a" pp t
+
 let stat ~follow t =
   let (Resource.T (dir, ops), path) = t in
   let module X = (val (Resource.get ops Fs.Pi.Dir)) in

--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -106,13 +106,19 @@ let read_dir t =
     let bt = Printexc.get_raw_backtrace () in
     Exn.reraise_with_context ex bt "reading directory %a" pp t
 
-let walk t fn =
+let with_dir_entries t fn =
   let (Resource.T (dir, ops), path) = t in
   let module X = (val (Resource.get ops Fs.Pi.Dir)) in
-  try X.with_dir_entries dir path fn
+  (* Note: we don't handle exceptions here as that would include the user's [fn]
+     (and this is likely to be called recursively). *)
+  X.with_dir_entries dir path fn
+
+let read_dir_entries t =
+  try
+    with_dir_entries t List.of_seq |> List.sort (fun (_, a) (_, b) -> String.compare a b)
   with Exn.Io _ as ex ->
     let bt = Printexc.get_raw_backtrace () in
-    Exn.reraise_with_context ex bt "walking directory %a" pp t
+    Exn.reraise_with_context ex bt "reading directory %a" pp t
 
 let stat ~follow t =
   let (Resource.T (dir, ops), path) = t in

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -155,6 +155,9 @@ val read_dir : _ t -> string list
 
     Note: The special Unix entries "." and ".." are not included in the results. *)
 
+val walk : _ t -> ((File.Stat.kind * string) Seq.t -> 'a) -> 'a
+(** [walk t] traverses the directory [t] producing a sequence of results. *)
+
 (** {1 Metadata} *)
 
 val stat : follow:bool -> _ t -> File.Stat.t

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -149,14 +149,23 @@ val with_open_dir : _ t -> ([< `Close | dir_ty] t -> 'a) -> 'a
     it automatically when [fn] returns (if it hasn't already been closed by then). *)
 
 val read_dir : _ t -> string list
-(** [read_dir t] reads directory entries for [t].
+(** [read_dir t] reads directory entry names for [t].
 
     The entries are sorted using {! String.compare}.
 
     Note: The special Unix entries "." and ".." are not included in the results. *)
 
-val walk : _ t -> ((File.Stat.kind * string) Seq.t -> 'a) -> 'a
-(** [walk t] traverses the directory [t] producing a sequence of results. *)
+val read_dir_entries : _ t -> (File.Stat.kind * string) list
+(** [read_dir_entries] is like {!read_dir}, but also includes the kind of each entry.
+
+    This is typically much faster than calling {!kind} on each entry individually. *)
+
+val with_dir_entries : _ t -> ((File.Stat.kind * string) Seq.t -> 'a) -> 'a
+(** [with_dir_entries t fn] runs [fn items], where [items] is the entries as a sequence.
+
+    This is like {!read_dir_entries}, but loads the entries incrementally,
+    which may be more efficient. Unlike {!read_dir_entries}, it does not sort
+    the results, which may be returned in any order. *)
 
 (** {1 Metadata} *)
 

--- a/lib_eio/unix/dune
+++ b/lib_eio/unix/dune
@@ -1,11 +1,11 @@
 (library
  (name eio_unix)
  (public_name eio.unix)
- (public_headers include/fork_action.h)
+ (public_headers include/fork_action.h include/eio_unix_stubs.h)
  (foreign_stubs
   (language c)
   (include_dirs include)
-  (names fork_action stubs cap))
+  (names fork_action eio_unix_stubs cap))
  (libraries eio eio.utils unix threads mtime.clock.os))
 
 (rule

--- a/lib_eio/unix/eio_unix_stubs.c
+++ b/lib_eio/unix/eio_unix_stubs.c
@@ -11,8 +11,6 @@
 #include <caml/bigarray.h>
 #include <caml/alloc.h>
 
-#define BUF_SIZE 4096
-
 static void caml_stat_free_preserving_errno(void *ptr) {
   int saved = errno;
   caml_stat_free(ptr);
@@ -58,6 +56,9 @@ CAMLprim value eio_unix_readlinkat(value v_fd, value v_path, value v_cs) {
 }
 
 CAMLprim value eio_unix_file_type_of_dtype (int d_type) {
+  #ifdef _WIN32
+  return caml_hash_variant("Unknown");
+  #else
   switch (d_type) {
     case DT_REG: return caml_hash_variant("Regular_file");
     case DT_DIR: return caml_hash_variant("Directory");
@@ -69,4 +70,5 @@ CAMLprim value eio_unix_file_type_of_dtype (int d_type) {
 	default:
       return caml_hash_variant("Unknown");
   }
+  #endif
 }

--- a/lib_eio/unix/include/eio_unix_stubs.h
+++ b/lib_eio/unix/include/eio_unix_stubs.h
@@ -1,0 +1,7 @@
+#include <caml/mlvalues.h>
+
+/* A function to convert directory entry kinds into
+ * Unix.file_kind options.
+ */
+CAMLprim value eio_unix_file_type_of_dtype(int d_type);
+

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -414,7 +414,9 @@ end = struct
     Switch.run ~name:"with_dir_entries" @@ fun sw ->
     let path = if path = "" then "." else path in
     let fd =
-      Low_level.openat ~sw t.fd path ~seekable:false ~access:`R
+      Low_level.openat ~sw t.fd path
+        ~seekable:false
+        ~access:`R
         ~flags:Uring.Open_flags.(cloexec + directory)
         ~perm:0
     in
@@ -430,7 +432,6 @@ end = struct
           loop es
     in
     fn (read_entries fd)
-
 
   let read_link t path = Low_level.read_link t.fd path
 

--- a/lib_eio_linux/eio_stubs.c
+++ b/lib_eio_linux/eio_stubs.c
@@ -14,6 +14,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <string.h>
 #include <unistd.h>
 
 // We need caml_convert_signal_number
@@ -150,16 +151,19 @@ CAMLprim value caml_eio_getdents(value v_fd) {
 
   for (pos = 0; pos < nread;) {
     d = (struct dirent64 *) (buf + pos);
+    pos += d->d_reclen;
 
-	ventry = caml_alloc(2, 0);
+    if (strcmp(d->d_name, ".") == 0 || strcmp(d->d_name, "..") == 0)
+      continue;
+
+    ventry = caml_alloc(2, 0);
     Store_field(ventry, 0, eio_unix_file_type_of_dtype(d->d_type));
     Store_field(ventry, 1, caml_copy_string_of_os(d->d_name));
 
-	cons = caml_alloc(2, 0);
-    Store_field(cons, 0, ventry);                              // Head
-    Store_field(cons, 1, result);                              // Tail
+    cons = caml_alloc(2, 0);
+    Store_field(cons, 0, ventry);  // Head
+    Store_field(cons, 1, result);  // Tail
     result = cons;
-    pos += d->d_reclen;
   }
 
   CAMLreturn(result);

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -542,7 +542,7 @@ let read_dir fd =
     match eio_getdents fd with
     | [] -> acc
     | files ->
-      let files = List.filter_map (function (_, "..") | (_, ".") -> None | (_, f) -> Some f) files in
+      let files = List.map snd files in
       read_all (files @ acc) fd
   in
   Eio_unix.run_in_systhread ~label:"read_dir" (fun () -> read_all [] fd)
@@ -550,8 +550,7 @@ let read_dir fd =
 let read_some_dir fd =
   Fd.use_exn "read_some_dir" fd @@ fun fd ->
   Eio_unix.run_in_systhread ~label:"read_some_dir" @@ fun () ->
-  let files = eio_getdents fd in
-  List.filter_map (function _, ".." | _, "." -> None | v -> Some v) files
+  eio_getdents fd
 
 let read_link fd path =
   try

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -391,7 +391,7 @@ external eio_symlinkat : string -> Unix.file_descr -> string -> unit = "caml_eio
 
 external eio_getrandom : Cstruct.buffer -> int -> int -> int = "caml_eio_getrandom"
 
-external eio_getdents : Unix.file_descr -> string list = "caml_eio_getdents"
+external eio_getdents : Unix.file_descr -> (Eio.File.Stat.kind * string) list = "caml_eio_getdents"
 
 let lseek fd off cmd =
   Fd.use_exn "lseek" fd @@ fun fd ->
@@ -542,10 +542,16 @@ let read_dir fd =
     match eio_getdents fd with
     | [] -> acc
     | files ->
-      let files = List.filter (function ".." | "." -> false | _ -> true) files in
+      let files = List.filter_map (function (_, "..") | (_, ".") -> None | (_, f) -> Some f) files in
       read_all (files @ acc) fd
   in
   Eio_unix.run_in_systhread ~label:"read_dir" (fun () -> read_all [] fd)
+
+let read_some_dir fd =
+  Fd.use_exn "read_some_dir" fd @@ fun fd ->
+  Eio_unix.run_in_systhread ~label:"read_some_dir" @@ fun () ->
+  let files = eio_getdents fd in
+  List.filter_map (function _, ".." | _, "." -> None | v -> Some v) files
 
 let read_link fd path =
   try

--- a/lib_eio_linux/low_level.mli
+++ b/lib_eio_linux/low_level.mli
@@ -185,6 +185,11 @@ val read_dir : fd -> string list
     The entries are not returned in any particular order
     (not even necessarily the order in which Linux returns them). *)
 
+val read_some_dir : fd -> (Eio.File.Stat.kind * string) list
+(** [read_some_dir dir] reads some of the directory entries from [dir], including their kind.
+    The entries are not returned in any particular order
+    (not even necessarily the order in which Linux returns them). *)
+
 val lseek : fd -> Optint.Int63.t -> [`Set | `Cur | `End] -> Optint.Int63.t
 (** Set and/or get the current file position.
 

--- a/lib_eio_posix/eio_posix_stubs.c
+++ b/lib_eio_posix/eio_posix_stubs.c
@@ -570,11 +570,17 @@ CAMLprim value caml_eio_posix_readdir(value v_dir_handle) {
   dir = DIR_Val(v_dir_handle);
   if (!dir) caml_unix_error(EBADF, "readdir", Nothing);
 
+  errno = 0;
   caml_enter_blocking_section();
   ent = readdir(dir);
   caml_leave_blocking_section();
 
-  if (!ent) caml_raise_end_of_file();
+  if (!ent) {
+    if (errno == 0)
+      caml_raise_end_of_file();
+    else
+      uerror("readdir", Nothing);
+  }
 
   v_result = caml_alloc(2, 0);
   Store_field(v_result, 0, eio_unix_file_type_of_dtype(ent->d_type));

--- a/lib_eio_posix/fs.ml
+++ b/lib_eio_posix/fs.ml
@@ -86,6 +86,9 @@ end = struct
     Err.run (Low_level.readdir t.fd) path
     |> Array.to_list
 
+  let with_dir_entries t path fn =
+    Err.run (Low_level.with_dir_entries t.fd path) fn
+
   let read_link t path =
     Err.run (Low_level.read_link t.fd) path
 

--- a/lib_eio_posix/fs.ml
+++ b/lib_eio_posix/fs.ml
@@ -87,7 +87,7 @@ end = struct
     |> Array.to_list
 
   let with_dir_entries t path fn =
-    Err.run (Low_level.with_dir_entries t.fd path) fn
+    Low_level.with_dir_entries t.fd path fn
 
   let read_link t path =
     Err.run (Low_level.read_link t.fd) path

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -370,66 +370,66 @@ let openat ~sw ~mode fd path flags =
 external eio_fdopendir : Unix.file_descr -> Unix.dir_handle = "caml_eio_posix_fdopendir"
 external eio_readdir : Unix.dir_handle -> Eio.File.Stat.kind * string = "caml_eio_posix_readdir"
 
-let readdir dirfd path =
-  in_worker_thread "readdir" @@ fun () ->
-  let use h =
-    match read_entries h with
-    | r -> Unix.closedir h; r
-    | exception ex ->
-      let bt = Printexc.get_raw_backtrace () in
-      Unix.closedir h;
-      Printexc.raise_with_backtrace ex bt
-  in
+let open_dir_handle label dirfd path =
   let use_confined dirfd =
     Resolve.with_parent_loop ?dirfd path @@ fun dirfd path ->
     match eio_openat dirfd path Open_flags.(rdonly + directory + nofollow) 0 with
-    | fd -> Ok (use (eio_fdopendir fd))
+    | fd -> Ok (eio_fdopendir fd)
     | exception (Unix.Unix_error ((ELOOP | ENOTDIR | EMLINK | EUNKNOWNERR _), _, _) as e) -> Error (`Symlink (Some e))
   in
   match dirfd with
-  | Fs -> use (Unix.opendir path)
+  | Fs -> Unix.opendir path
   | Cwd -> use_confined None
   | Fd dirfd ->
-    Fd.use_exn "readdir" dirfd @@ fun dirfd ->
+    Fd.use_exn label dirfd @@ fun dirfd ->
     use_confined (Some dirfd)
 
-let with_dir_entries dirfd path fn =
-  let rec read_entry h =
-    match eio_readdir h with _, "." | _, ".." -> read_entry h | v -> v
-  in
-  let it h () =
-    match in_worker_thread "with_dir_entries" @@ fun () -> read_entry h with
-    | r -> Some r
-    | exception End_of_file -> None
-    | exception ex ->
-        let bt = Printexc.get_raw_backtrace () in
-        Unix.closedir h;
-        Printexc.raise_with_backtrace ex bt
-  in
-  let use h =
-    let seq = Seq.of_dispenser (it h) in
-    let v = fn seq in
+let readdir dirfd path =
+  in_worker_thread "readdir" @@ fun () ->
+  let h = open_dir_handle "readdir" dirfd path in
+  match read_entries h with
+  | r -> Unix.closedir h; r
+  | exception ex ->
+    let bt = Printexc.get_raw_backtrace () in
     Unix.closedir h;
-    v
-  in
-  let use_confined dirfd =
-    Resolve.with_parent_loop ?dirfd path @@ fun dirfd path ->
-    match
-      eio_openat dirfd path Open_flags.(rdonly + directory + nofollow) 0
-    with
-    | fd -> Ok (use (eio_fdopendir fd))
-    | exception
-        (Unix.Unix_error ((ELOOP | ENOTDIR | EMLINK | EUNKNOWNERR _), _, _) as e)
-      ->
-        Error (`Symlink (Some e))
-  in
-  match dirfd with
-  | Fs -> use (Unix.opendir path)
-  | Cwd -> use_confined None
-  | Fd dirfd ->
-      Fd.use_exn "with_dir_entries" dirfd @@ fun dirfd ->
-      use_confined (Some dirfd)
+    Printexc.raise_with_backtrace ex bt
 
+let rec read_entry h =
+  match eio_readdir h with
+  | exception End_of_file -> None
+  | _, ("." | "..") -> read_entry h
+  | v -> Some v
+
+let dir_entry_seq h =
+  let read_dir_batch_size = 100 in
+  let read_batch () =
+    in_worker_thread "with_dir_entries" @@ fun () ->
+    Seq.of_dispenser (fun () -> Err.run read_entry h)
+    |> Seq.take read_dir_batch_size
+    |> List.of_seq
+  in
+  let rec aux () =
+    let items = read_batch () in
+    let maybe_more = (List.length items = read_dir_batch_size) in
+    if maybe_more then (
+      Seq.append (List.to_seq items) aux ()
+    ) else (
+      List.to_seq items ()
+    )
+  in
+  aux
+
+let with_dir_entries dirfd path fn =
+  let h =
+    in_worker_thread "readdir" @@ fun () ->
+    Err.run (open_dir_handle "readdir" dirfd) path
+  in
+  match fn @@ dir_entry_seq h with
+  | v -> Unix.closedir h; v
+  | exception ex ->
+    let bt = Printexc.get_raw_backtrace () in
+    Unix.closedir h;
+    Printexc.raise_with_backtrace ex bt
 
 external eio_mkdirat : Unix.file_descr -> string -> Unix.file_perm -> unit = "caml_eio_posix_mkdirat"
 

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -368,6 +368,7 @@ let openat ~sw ~mode fd path flags =
   | Fd dirfd -> Resolve.open_beneath ~sw ~mode ~dirfd path flags
 
 external eio_fdopendir : Unix.file_descr -> Unix.dir_handle = "caml_eio_posix_fdopendir"
+external eio_readdir : Unix.dir_handle -> Eio.File.Stat.kind * string = "caml_eio_posix_readdir"
 
 let readdir dirfd path =
   in_worker_thread "readdir" @@ fun () ->
@@ -391,6 +392,44 @@ let readdir dirfd path =
   | Fd dirfd ->
     Fd.use_exn "readdir" dirfd @@ fun dirfd ->
     use_confined (Some dirfd)
+
+let with_dir_entries dirfd path fn =
+  let rec read_entry h =
+    match eio_readdir h with _, "." | _, ".." -> read_entry h | v -> v
+  in
+  let it h () =
+    match in_worker_thread "with_dir_entries" @@ fun () -> read_entry h with
+    | r -> Some r
+    | exception End_of_file -> None
+    | exception ex ->
+        let bt = Printexc.get_raw_backtrace () in
+        Unix.closedir h;
+        Printexc.raise_with_backtrace ex bt
+  in
+  let use h =
+    let seq = Seq.of_dispenser (it h) in
+    let v = fn seq in
+    Unix.closedir h;
+    v
+  in
+  let use_confined dirfd =
+    Resolve.with_parent_loop ?dirfd path @@ fun dirfd path ->
+    match
+      eio_openat dirfd path Open_flags.(rdonly + directory + nofollow) 0
+    with
+    | fd -> Ok (use (eio_fdopendir fd))
+    | exception
+        (Unix.Unix_error ((ELOOP | ENOTDIR | EMLINK | EUNKNOWNERR _), _, _) as e)
+      ->
+        Error (`Symlink (Some e))
+  in
+  match dirfd with
+  | Fs -> use (Unix.opendir path)
+  | Cwd -> use_confined None
+  | Fd dirfd ->
+      Fd.use_exn "with_dir_entries" dirfd @@ fun dirfd ->
+      use_confined (Some dirfd)
+
 
 external eio_mkdirat : Unix.file_descr -> string -> Unix.file_perm -> unit = "caml_eio_posix_mkdirat"
 

--- a/lib_eio_posix/low_level.mli
+++ b/lib_eio_posix/low_level.mli
@@ -83,6 +83,7 @@ val symlink : link_to:string -> dir_fd -> string -> unit
     linking to [link_to]. *)
 
 val readdir : dir_fd -> string -> string array
+val with_dir_entries : dir_fd -> string -> ((Eio.File.Stat.kind * string) Seq.t -> 'a) -> 'a
 
 val readv : fd -> Cstruct.t array -> int
 val writev : fd -> Cstruct.t array -> int

--- a/lib_eio_posix/primitives.h
+++ b/lib_eio_posix/primitives.h
@@ -11,6 +11,7 @@ CAMLprim value caml_eio_posix_preadv(value, value, value);
 CAMLprim value caml_eio_posix_pwritev(value, value, value);
 CAMLprim value caml_eio_posix_openat(value, value, value, value);
 CAMLprim value caml_eio_posix_fdopendir(value);
+CAMLprim value caml_eio_posix_readdir(value);
 CAMLprim value caml_eio_posix_mkdirat(value, value, value);
 CAMLprim value caml_eio_posix_unlinkat(value, value, value);
 CAMLprim value caml_eio_posix_renameat(value, value, value, value);

--- a/lib_eio_windows/fs.ml
+++ b/lib_eio_windows/fs.ml
@@ -160,6 +160,17 @@ end = struct
     Err.run Low_level.readdir path
     |> Array.to_list
 
+  let with_dir_entries t path fn =
+    let entries =
+      read_dir t path
+      |> List.map (fun name ->
+          match stat ~follow:false t (Filename.concat path name) with
+          | info -> (info.kind, name)
+          | exception Eio.Exn.Io _ -> (`Unknown, name)
+        )
+    in
+    fn (List.to_seq entries)
+
   let read_link t path =
     with_parent_dir t path @@ fun dirfd path ->
     Err.run (Low_level.read_link ?dirfd) path

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -48,9 +48,16 @@ let try_rename p1 p2 =
   | () -> traceln "rename %a to %a -> ok" Path.pp p1 Path.pp p2
   | exception ex -> traceln "@[<h>%a@]" Eio.Exn.pp ex
 
+let dir_entry f (k, name) =
+  Fmt.pf f "%S%s" name (match k with `Regular_file -> "" | `Directory -> "(dir)" | _ -> "(special)")
+
 let try_read_dir path =
-  match Path.read_dir path with
-  | names -> traceln "read_dir %a -> %a" Path.pp path Fmt.Dump.(list string) names
+  match Path.read_dir_entries path with
+  | entries ->
+    traceln "read_dir %a -> %a" Path.pp path Fmt.Dump.(list dir_entry) entries;
+    let names = Path.read_dir path in
+    let entry_names = List.map snd entries in
+    if names <> entry_names then traceln "But read_dir returned %a!" Fmt.Dump.(list string) names
   | exception ex -> traceln "@[<h>%a@]" Eio.Exn.pp ex
 
 let try_read_link path =
@@ -627,8 +634,8 @@ Reading directory entries under `cwd` and outside of `cwd`.
 +mkdir <readdir:test-1> -> ok
 +mkdir <readdir:test-2> -> ok
 +write <readdir:test-1/file> -> ok
-+read_dir <readdir> -> ["test-1"; "test-2"]
-+read_dir <readdir:.> -> ["test-1"; "test-2"]
++read_dir <readdir> -> ["test-1"(dir); "test-2"(dir)]
++read_dir <readdir:.> -> ["test-1"(dir); "test-2"(dir)]
 +Eio.Io Fs Permission_denied _, reading directory <readdir:..>
 +Eio.Io Fs Not_found _, reading directory <readdir:test-3>
 +read_dir <readdir:link-1> -> ["file"]


### PR DESCRIPTION
When first providing `readdir` we shelved an incremental version. This PR starts the ball rolling on adding support for something like [`with_dir_entries`](https://github.com/ocaml-multicore/eio/pull/207#pullrequestreview-987295774). Opening early to get some feedback on how it should look, should `Eio.Path.walk` walk directory tree recursively or just a single directory, leaving it to the user to descend should they want to. We should perhaps have a `type entry` too.

I wrote a small benchmark:

```ocaml
open Eio.Std

let ( / ) = Eio.Path.( / )

let dirname i = Fmt.str "dir-%i" i
let filename i = Fmt.str "file-%i" i

let make_bench_dir ?(depth=1) ?(width=1000) dir =
  let rec loop dir depth =
    if depth <= 0 then ()
    else (
      Eio.Path.mkdir ~perm:0o700 (dir / dirname depth);
      Fiber.List.iter ~max_fibers:10 (fun fname ->
        Eio.Path.save ~create:(`If_missing 0o644) (dir / fname) "hello world"
      ) (List.init width filename);
      loop (dir / dirname depth) (depth - 1)
    )
  in
  loop dir depth

let read_dir_walk ~f dir =
  let rec aux acc path =
    match Eio.Path.kind ~follow:true path with
    | `Directory as k ->
       let acc2 = f acc (k, path) in
       let files = Eio.Path.read_dir path in
       List.fold_left (fun acc f -> aux acc (path / f)) acc2 files
    | k -> f acc (k, path)
    in
  let files = Eio.Path.read_dir dir in
  List.fold_left (fun acc f -> aux acc (dir / f)) [] files

let rec walk ~f acc dir =
  Eio.Path.walk dir @@ fun seq ->
  Seq.fold_left (fun acc -> function
    | (`Directory, path) ->
      let acc2 = f acc (`Directory, dir / path) in
      walk ~f acc2 (dir / path)
    | (kind, fname) -> f acc (kind, dir / fname)) acc seq

let time fn =
  let now = Mtime_clock.now_ns () in
  let v = fn () in
  let stop = Mtime_clock.now_ns () in 
  Eio.traceln "Took: %a" Fmt.uint64_ns_span (Int64.sub stop now);
  v

module Path = struct
  include Eio.Path
  type t = Eio.Fs.dir_ty Eio.Path.t 

  let compare a b = String.compare (Eio.Path.native_exn a) (Eio.Path.native_exn b)
end

module S = Set.Make (Path)

let () = 
  Eio_main.run @@ fun env ->
  let tmpdirf = Filename.temp_dir "eio-walk-" "-bench" in
  let tmpdir = env#fs / tmpdirf in
  make_bench_dir ~depth:15 ~width:20_000 tmpdir;
  let f acc (_, path) = path :: acc in
  let files2 = time (fun () -> walk ~f [] tmpdir) |> S.of_list in
  let files1 = time (fun () -> read_dir_walk ~f tmpdir) |> S.of_list in
  Eio.traceln "Files 1: %i\n" (S.cardinal files1);
  Eio.traceln "Files 2: %i\n" (S.cardinal files2);
  Eio.traceln "Same files? %b\n" (S.equal files1 files2);
  let _ : int = Sys.command (Fmt.str "rm -r %s" tmpdirf) in
  ()
```

It is far from perfect and we should take into account FS caching, but on my machine I'm getting the following.

For Eio_linux: 1.46s to 110ms
For Eio_posix: 2.02s to 1.58s 