### PR TITLE
Add Eio_unix.Stdenv.override for updating environments

### DIFF
--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -47,4 +47,25 @@ module Stdenv = struct
     debug : Eio.Debug.t;
     backend_id: string;
   >
+
+  let with_env
+    ?stdin ?stdout ?stderr ?net ?domain_mgr
+    ?process_mgr ?clock ?mono_clock ?fs ?cwd
+    ?secure_random ?debug ?backend_id (env : base) : base
+  =
+    object
+      method stdin = Option.value ~default:env#stdin stdin
+      method stdout = Option.value ~default:env#stdout stdout 
+      method stderr = Option.value ~default:env#stderr stderr 
+      method net = Option.value ~default:env#net net 
+      method domain_mgr = Option.value ~default:env#domain_mgr domain_mgr 
+      method process_mgr = Option.value ~default:env#process_mgr process_mgr
+      method clock = Option.value ~default:env#clock clock
+      method mono_clock = Option.value ~default:env#mono_clock mono_clock
+      method fs = Option.value ~default:env#fs fs
+      method cwd = Option.value ~default:env#cwd cwd
+      method secure_random = Option.value ~default:env#secure_random secure_random 
+      method debug = Option.value ~default:env#debug debug
+      method backend_id = Option.value ~default:env#backend_id backend_id
+    end
 end

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -47,4 +47,25 @@ module Stdenv = struct
     debug : Eio.Debug.t;
     backend_id: string;
   >
+
+  let override
+    ?stdin ?stdout ?stderr ?net ?domain_mgr
+    ?process_mgr ?clock ?mono_clock ?fs ?cwd
+    ?secure_random ?debug ?backend_id (env : <base; ..>) : base
+  =
+    object
+      method stdin = Option.value ~default:env#stdin stdin
+      method stdout = Option.value ~default:env#stdout stdout 
+      method stderr = Option.value ~default:env#stderr stderr 
+      method net = Option.value ~default:env#net net 
+      method domain_mgr = Option.value ~default:env#domain_mgr domain_mgr 
+      method process_mgr = Option.value ~default:env#process_mgr process_mgr
+      method clock = Option.value ~default:env#clock clock
+      method mono_clock = Option.value ~default:env#mono_clock mono_clock
+      method fs = Option.value ~default:env#fs fs
+      method cwd = Option.value ~default:env#cwd cwd
+      method secure_random = Option.value ~default:env#secure_random secure_random 
+      method debug = Option.value ~default:env#debug debug
+      method backend_id = Option.value ~default:env#backend_id backend_id
+    end
 end

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -89,6 +89,26 @@ module Stdenv : sig
   (** The common set of features provided by all traditional operating systems (BSDs, Linux, Mac, Windows).
 
       You can use the functions in {!Eio.Stdenv} to access these fields if you prefer. *)
+
+  val with_env :
+    ?stdin:source_ty r ->
+    ?stdout:sink_ty r ->
+    ?stderr:sink_ty r ->
+    ?net:[ `Generic | `Unix ] Eio.Net.ty r ->
+    ?domain_mgr:Eio.Domain_manager.ty r ->
+    ?process_mgr:Process.mgr_ty r ->
+    ?clock:float Eio.Time.clock_ty r ->
+    ?mono_clock:Eio.Time.Mono.ty r ->
+    ?fs:Eio.Fs.dir_ty Eio.Path.t ->
+    ?cwd:Eio.Fs.dir_ty Eio.Path.t ->
+    ?secure_random:Eio.Flow.source_ty r ->
+    ?debug:Eio.Debug.t ->
+    ?backend_id:string ->
+    base ->
+    base
+  (** [with_env env] allows you to replace parts of [env] with new resources.
+      
+      By default it will select the resource from [env]. *)
 end
 
 (** API for Eio backends only. *)

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -89,6 +89,26 @@ module Stdenv : sig
   (** The common set of features provided by all traditional operating systems (BSDs, Linux, Mac, Windows).
 
       You can use the functions in {!Eio.Stdenv} to access these fields if you prefer. *)
+
+  val override :
+    ?stdin:source_ty r ->
+    ?stdout:sink_ty r ->
+    ?stderr:sink_ty r ->
+    ?net:[ `Generic | `Unix ] Eio.Net.ty r ->
+    ?domain_mgr:Eio.Domain_manager.ty r ->
+    ?process_mgr:Process.mgr_ty r ->
+    ?clock:float Eio.Time.clock_ty r ->
+    ?mono_clock:Eio.Time.Mono.ty r ->
+    ?fs:Eio.Fs.dir_ty Eio.Path.t ->
+    ?cwd:Eio.Fs.dir_ty Eio.Path.t ->
+    ?secure_random:Eio.Flow.source_ty r ->
+    ?debug:Eio.Debug.t ->
+    ?backend_id:string ->
+    <base; ..> ->
+    base
+  (** [override env] allows you to replace parts of [env] with new resources.
+      
+      By default it will select the resource from [env]. *)
 end
 
 (** API for Eio backends only. *)


### PR DESCRIPTION
An increasingly popular style of using Eio is the following.

Instead of passing individual capabilities around, programs now define a environment that is a subtype of `Eio_unix.Stdenv.t`. For example, in [Shelter](https://github.com/fn06/shelter) I have:

```ocaml
type 'a env =
  < clock : [> float Eio.Time.clock_ty ] Eio.Resource.t
  ; fs : Eio.Fs.dir_ty Eio.Path.t
  ; net : [> [> `Generic | `Unix ] Eio.Net.ty ] Eio.Resource.t
  ; process_mgr : [> [> `Generic ] Eio.Process.mgr_ty ] Eio.Resource.t
  ; stdout : [> Eio.Flow.sink_ty ] Eio.Resource.t
  ; stdin : [> Eio.Flow.source_ty ] Eio.Resource.t
  ; .. >
  as
  'a
```

which is passed around internally carving out only the pieces I need in the right places. I ran into some bugs yesterday and I wanted to make full use of this capability-style and modify the process manager to _print_ the args before spawning a child process.

```ocaml
let debug_process_mgr (mgr : 'a Eio_unix.Process.mgr) : 'a Eio_unix.Process.mgr
    =
  let module D = struct
    type t = unit

    let spawn_unix () ~sw ?cwd ?pgid ?uid ?gid ~env ~fds ~executable args =
      Eio.traceln "Spawning subprocess... %a" Fmt.(list ~sep:(Fmt.any " ") string) args;
      Eio_unix.Process.spawn_unix ~sw ?cwd ?pgid ?uid ?gid mgr ~env ~fds ~executable args
  end in
  let module V = Eio_unix.Process.Make_mgr (D) in
  Eio.Resource.T ((), Eio_unix.Process.Pi.mgr_unix (module V))
```

At this point I just needed a way to update my `env` to use this debugger process manager, which with this function would be simple!

```ocaml
    Eventloop.run @@ fun env ->
    let cmd_file = Option.map (Eio.Path.( / ) env#fs) cmd_file in
    let dir = state_dir env#fs "shelter" in
    let env =
      Eio_unix.Stdenv.with_env ~process_mgr:(debug_process_mgr env#process_mgr) env
    in
    Shelter.main config (env :> _ Shelter.env) dir cmd_file
```

---

As an aside, I do wonder if it might be time to reconsider going back to objects for Eio's resources? The ergonomics, I think, are far superior to the `Eio.Resource.T` API. 
