### PR TITLE
Simplify custom "env" type in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1840,7 +1840,7 @@ module Status : sig
     net : _ Eio.Net.t;             (** To connect to the servers *)
     clock : _ Eio.Time.clock;      (** Needed for timeouts *)
     ..
-  > as 'a
+  >
 
   val check : _ env -> bool
 end


### PR DESCRIPTION
Since we are already using the "constraint 'a =" syntax, the "as 'a" at the end is not needed, and even confusing.