### PR TITLE
eio_linux: use newer uring flags for performance

### DIFF
--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -510,9 +510,15 @@ let with_eventfd fn =
     close ();
     Printexc.raise_with_backtrace ex bt
 
+let uring_create ~queue_depth ?polling_timeout () =
+  let flags = Uring.Setup_flags.(single_issuer + coop_taskrun) in (* Requires Linux >= 6.0 *)
+  match Uring.create ~queue_depth ~flags ?polling_timeout () with
+  | exception Unix.Unix_error(EINVAL, _, _) -> Uring.create ~queue_depth ?polling_timeout ()
+  | x -> x
+
 let with_sched ?(fallback=no_fallback) config fn =
   let { queue_depth; n_blocks; block_size; polling_timeout } = config in
-  match Uring.create ~queue_depth ?polling_timeout () with
+  match uring_create ~queue_depth ?polling_timeout () with
   | exception Unix.Unix_error(ENOSYS, _, _) -> fallback (`Msg "io_uring is not available on this system")
   | exception Unix.Unix_error(EPERM, _, _) -> fallback (`Msg "io_uring is not available (permission denied)")
   | uring ->


### PR DESCRIPTION
This shows a large speed improvement on the HTTP benchmark on my machine (will be interesting to see what the benchmark CI says).

- `IORING_SETUP_DEFER_TASKRUN` only does completion work as part of `io_uring_enter`. This avoids interrupting the application. The uring docs say "This flag should be considered the default mode for applications setting up a ring"

- `IORING_SETUP_SINGLE_ISSUER` hints to uring to do some locking optimisations assuming that each ring is only written by one thread. Only a small improvement in the HTTP tests on my machine, but needed for `IORING_SETUP_DEFER_TASKRUN`.

`IORING_SETUP_COOP_TASKRUN` showed similar improvements, but preferring `DEFER_TASKRUN` as the docs say it's a good default.