### PR TITLE
eio_linux: use "IORING_SETUP_DEFER_TASKRUN" for performance

### DIFF
--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -511,7 +511,7 @@ let with_eventfd fn =
     Printexc.raise_with_backtrace ex bt
 
 let uring_create ~queue_depth ?polling_timeout () =
-  let flags = Uring.Setup_flags.single_issuer in (* Requires Linux >= 6.0 *)
+  let flags = Uring.Setup_flags.(single_issuer + defer_taskrun + taskrun_flag) in (* Requires Linux >= 6.1 *)
   match Uring.create ~queue_depth ~flags ?polling_timeout () with
   | exception Unix.Unix_error(EINVAL, _, _) -> Uring.create ~queue_depth ?polling_timeout ()
   | x -> x


### PR DESCRIPTION
This shows a large speed improvement on the HTTP benchmark on my machine (from about 350k requests per second to about 450k!).

When a uring job is ready to run, there are three options:

- By default, the kernel sends an interrupt to the application, running the task immediately.

- With `IORING_SETUP_COOP_TASKRUN`, the kernel doesn't send an interrupt and instead waits until the next time the application enters the kernel.

- `IORING_SETUP_DEFER_TASKRUN` is similar, but waits for an `io_uring_enter` call (not just any syscall). The uring docs say "This flag should be considered the default mode for applications setting up a ring".

We also need to set `taskrun_flag` so that the kernel sets a flag letting us know when tasks need to run. `io_uring_peek_cqe` checks this flag and will enter the kernel if necessary (if there are no CQEs yet, but there are tasks that need to run).