### PR TITLE
Add lintcstubs-arity as a test dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -26,6 +26,7 @@
   (crowbar (and (>= 0.2) :with-test))
   (mtime (>= 2.0.0))
   (mdx (and (>= 2.4.1) :with-test))
+  (lintcstubs-arity :with-test)
   (dscheck (and (>= 0.1.0) :with-test))))
 (package
  (name eio_linux)
@@ -36,6 +37,7 @@
   (alcotest (and (>= 1.7.0) :with-test))
   (eio (= :version))
   (mdx (and (>= 2.4.1) :with-test))
+  (lintcstubs-arity :with-test)
   (logs (and (>= 0.7.0) :with-test))
   (fmt (>= 0.8.9))
   (cmdliner (and (>= 1.1.0) :with-test))
@@ -49,6 +51,7 @@
   (eio (= :version))
   (iomux (>= 0.2))
   (mdx (and (>= 2.4.1) :with-test))
+  (lintcstubs-arity :with-test)
   (conf-bash :with-test)
   (fmt (>= 0.8.9))))
 (package

--- a/eio.opam
+++ b/eio.opam
@@ -22,6 +22,7 @@ depends: [
   "crowbar" {>= "0.2" & with-test}
   "mtime" {>= "2.0.0"}
   "mdx" {>= "2.4.1" & with-test}
+  "lintcstubs-arity" {with-test}
   "dscheck" {>= "0.1.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/eio_linux.opam
+++ b/eio_linux.opam
@@ -13,6 +13,7 @@ depends: [
   "alcotest" {>= "1.7.0" & with-test}
   "eio" {= version}
   "mdx" {>= "2.4.1" & with-test}
+  "lintcstubs-arity" {with-test}
   "logs" {>= "0.7.0" & with-test}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}

--- a/eio_posix.opam
+++ b/eio_posix.opam
@@ -13,6 +13,7 @@ depends: [
   "eio" {= version}
   "iomux" {>= "0.2"}
   "mdx" {>= "2.4.1" & with-test}
+  "lintcstubs-arity" {with-test}
   "conf-bash" {with-test}
   "fmt" {>= "0.8.9"}
   "odoc" {with-doc}

--- a/lib_eio/unix/dune
+++ b/lib_eio/unix/dune
@@ -9,6 +9,7 @@
  (libraries eio eio.utils unix threads mtime.clock.os))
 
 (rule
+ (package eio)
  (enabled_if %{bin-available:lintcstubs_arity_cmt})
  (action
   (with-stdout-to
@@ -20,6 +21,7 @@
         %{dep:.eio_unix.objs/byte/eio_unix__Fork_action.cmt}))))
 
 (rule
+ (package eio)
  (enabled_if %{bin-available:lintcstubs_arity_cmt})
  (alias runtest)
  (action

--- a/lib_eio_linux/dune
+++ b/lib_eio_linux/dune
@@ -14,6 +14,7 @@
  (libraries eio eio.utils eio.unix uring fmt))
 
 (rule
+ (package eio_linux)
  (enabled_if
    (and
      %{bin-available:lintcstubs_arity_cmt}
@@ -27,6 +28,7 @@
    (run %{bin:lintcstubs_arity_cmt} %{dep:.eio_linux.objs/byte/eio_linux__Low_level.cmt} %{dep:.eio_linux.objs/byte/eio_linux__Sched.cmt}))))
 
 (rule
+ (package eio_linux)
  (enabled_if
    (and
      %{bin-available:lintcstubs_arity_cmt}

--- a/lib_eio_posix/dune
+++ b/lib_eio_posix/dune
@@ -16,6 +16,7 @@
 
 (rule
  (enabled_if (and (= %{os_type} "Unix") %{bin-available:lintcstubs_arity_cmt}))
+ (package eio_posix)
  (action
   (with-stdout-to
    primitives.h.new
@@ -23,6 +24,7 @@
 
 (rule
  (enabled_if (and (= %{os_type} "Unix") %{bin-available:lintcstubs_arity_cmt}))
+ (package eio_posix)
  (alias runtest)
  (action
   (diff primitives.h primitives.h.new)))


### PR DESCRIPTION
This will fail the CI tests if a C prototype is missing.

@avsm made the same change recently in uring: https://github.com/ocaml-multicore/ocaml-uring/pull/143