### PR TITLE
eio_linux: move read/write retries out of scheduler

### DIFF
--- a/lib_eio_linux/fixed.ml
+++ b/lib_eio_linux/fixed.ml
@@ -52,3 +52,5 @@ let to_string ?len (t, chunk) =
 let avail {freelist;_} = Queue.length freelist
 
 let to_offset (_,t) = t
+
+let shift (r, off) n = (r, off + n)

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -60,13 +60,19 @@ let uring_file_offset t =
   if Fd.is_seekable t then Optint.Int63.minus_one else Optint.Int63.zero
 
 let file_offset t = function
-  | Some x -> `Pos x
-  | None when Fd.is_seekable t -> `Seekable_current
-  | None -> `Nonseekable_current
+  | Some x -> x
+  | None when Fd.is_seekable t -> Optint.Int63.minus_one
+  | None -> Optint.Int63.zero
 
-let enqueue_read st action (file_offset,fd,buf,len) =
-  let req = { Sched.op=`R; file_offset; len; fd; cur_off = 0; buf; action } in
-  Sched.submit_rw_req st req
+let rec enqueue_read st action req =
+  let retry = Sched.with_cancel_hook ~action st (fun () ->
+      let (file_offset,fd,buf,len) = req in
+      let off = Fixed.to_offset buf in
+      Uring.read_fixed st.uring ~file_offset fd ~off ~len (Job action)
+    )
+  in
+  if retry then (* wait until an sqe is available *)
+    Queue.push (fun st -> enqueue_read st action req) st.io_q
 
 let rec enqueue_writev args st action =
   let (file_offset,fd,bufs) = args in
@@ -77,9 +83,15 @@ let rec enqueue_writev args st action =
   if retry then (* wait until an sqe is available *)
     Queue.push (fun st -> enqueue_writev args st action) st.io_q
 
-let enqueue_write st action (file_offset,fd,buf,len) =
-  let req = { Sched.op=`W; file_offset; len; fd; cur_off = 0; buf; action } in
-  Sched.submit_rw_req st req
+let rec enqueue_write st action req =
+  let retry = Sched.with_cancel_hook ~action st (fun () ->
+      let (file_offset,fd,buf,len) = req in
+      let off = Fixed.to_offset buf in
+      Uring.write_fixed st.uring ~file_offset fd ~off ~len (Job action)
+    )
+  in
+  if retry then (* wait until an sqe is available *)
+    Queue.push (fun st -> enqueue_write st action req) st.io_q
 
 let rec enqueue_splice ~src ~dst ~len st action =
   let retry = Sched.with_cancel_hook ~action st (fun () ->
@@ -165,19 +177,27 @@ let sleep_until time =
       Sched.enqueue_failed_thread t k ex
     )
 
-let read ?file_offset:off fd buf amount =
-  let off = file_offset fd off in
-  Fd.use_exn "read" fd @@ fun fd ->
-  let res = Sched.enter "read" (fun t k -> enqueue_read t k (off, fd, buf, amount)) in
-  if res < 0 then (
-    raise @@ Err.wrap (Uring.error_of_errno res) "read" ""
+(* TODO bind from unixsupport *)
+let errno_is_retry = function -62 | -11 | -4 -> true |_ -> false
+
+let rec read_upto ?file_offset:off fd buf amount =
+  let res = Sched.enter "read" (fun t k ->
+      let off = file_offset fd off in
+      Fd.use_exn "read" fd @@ fun fd ->
+      enqueue_read t k (off, fd, buf, amount)
+    ) in
+  if res = 0 then raise End_of_file
+  else if res < 0 then (
+    if errno_is_retry res then read_upto ?file_offset:off fd buf amount
+    else raise @@ Err.wrap (Uring.error_of_errno res) "read" ""
   ) else res
 
-let read_exactly ?file_offset fd buf len =
-  ignore (read ?file_offset fd buf (Exactly len) : int)
-
-let read_upto ?file_offset fd buf len =
-  read ?file_offset fd buf (Upto len)
+let rec read_exactly ?file_offset fd buf len =
+  let got = read_upto ?file_offset fd buf len in
+  if got < len then (
+    let file_offset = Option.map (Optint.Int63.(add (of_int got))) file_offset in
+    read_exactly ?file_offset fd (Fixed.shift buf got) (len - got)
+  )
 
 let rec enqueue_readv args st action =
   let (file_offset,fd,bufs) = args in
@@ -245,12 +265,22 @@ let await_writable fd =
     raise (Err.unclassified (Eio_unix.Unix_error (Uring.error_of_errno res, "await_writable", "")))
   )
 
-let write ?file_offset:off fd buf len =
-  let off = file_offset fd off in
-  Fd.use_exn "write" fd @@ fun fd ->
-  let res = Sched.enter "write" (fun t k -> enqueue_write t k (off, fd, buf, Exactly len)) in
+let rec write_single ?file_offset:off fd buf len =
+  let res = Sched.enter "write" (fun t k ->
+      let off = file_offset fd off in
+      Fd.use_exn "write" fd @@ fun fd ->
+      enqueue_write t k (off, fd, buf, len)
+    ) in
   if res < 0 then (
-    raise @@ Err.wrap (Uring.error_of_errno res) "write" ""
+    if errno_is_retry res then write_single ?file_offset:off fd buf len
+    else raise @@ Err.wrap (Uring.error_of_errno res) "write" ""
+  ) else res
+
+let rec write ?file_offset fd buf len =
+  let wrote = write_single ?file_offset fd buf len in
+  if wrote < len then (
+    let file_offset = Option.map (Optint.Int63.(add (of_int wrote))) file_offset in
+    write ?file_offset fd (Fixed.shift buf wrote) (len - wrote)
   )
 
 let splice src ~dst ~len =

--- a/lib_eio_linux/low_level.mli
+++ b/lib_eio_linux/low_level.mli
@@ -95,14 +95,14 @@ val read_upto : ?file_offset:Optint.Int63.t -> fd -> Fixed.chunk -> int -> int
 (** [read_upto fd chunk len] reads at most [len] bytes from [fd],
     returning as soon as some data is available.
 
-    @param file_offset Read from the given position in [fd] (default: 0).
+    @param file_offset Read from the given position in [fd] (default: current position).
     @raise End_of_file Raised if all data has already been read. *)
 
 val read_exactly : ?file_offset:Optint.Int63.t -> fd -> Fixed.chunk -> int -> unit
 (** [read_exactly fd chunk len] reads exactly [len] bytes from [fd],
     performing multiple read operations if necessary.
 
-    @param file_offset Read from the given position in [fd] (default: 0).
+    @param file_offset Read from the given position in [fd] (default: current position).
     @raise End_of_file Raised if the stream ends before [len] bytes have been read. *)
 
 val readv : ?file_offset:Optint.Int63.t -> fd -> Cstruct.t list -> int

--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -13,31 +13,20 @@ let statx_works = ref false     (* Before Linux 5.18, statx is unreliable *)
 
 type exit = [`Exit_scheduler]
 
-type file_offset = [
-  | `Pos of Optint.Int63.t
-  | `Seekable_current
-  | `Nonseekable_current
-]
-
-type amount = Exactly of int | Upto of int
-
 type rw_req = {
   op : [`R|`W];
-  file_offset : file_offset;    (* Read from here + cur_off (unless using current pos) *)
+  file_offset : Optint.Int63.t;
   fd : Unix.file_descr;
-  len : amount;
+  len : int;
   buf : Fixed.chunk;
-  mutable cur_off : int;
   action : int Suspended.t;
 }
 
 (* Type of user-data attached to jobs. *)
 type io_job =
-  | Read : rw_req -> io_job
   | Job_no_cancel : int Suspended.t -> io_job
   | Cancel_job : io_job
   | Job : int Suspended.t -> io_job     (* A negative result indicates error, and may report cancellation *)
-  | Write : rw_req -> io_job
   | Job_fn : 'a Suspended.t * (int -> [`Exit_scheduler]) -> io_job
   (* When done, remove the cancel_fn from [Suspended.t] and call the callback (unless cancelled). *)
 
@@ -173,32 +162,6 @@ let submit_pending_io st =
     Trace.log "submit_pending_io";
     fn st
 
-let rec submit_rw_req st ({op; file_offset; fd; buf; len; cur_off; action} as req) =
-  let {uring;io_q;_} = st in
-  let off = Fixed.to_offset buf + cur_off in
-  let len = match len with Exactly l | Upto l -> l in
-  let len = len - cur_off in
-  let retry = with_cancel_hook ~action st (fun () ->
-      let file_offset =
-        match file_offset with
-        | `Pos x -> Optint.Int63.add x (Optint.Int63.of_int cur_off)
-        | `Seekable_current -> Optint.Int63.minus_one
-        | `Nonseekable_current -> Optint.Int63.zero
-      in
-      match op with
-      |`R -> Uring.read_fixed uring ~file_offset fd ~off ~len (Read req)
-      |`W -> Uring.write_fixed uring ~file_offset fd ~off ~len (Write req)
-    )
-  in
-  if retry then (
-    Trace.log "await-sqe";
-    (* wait until an sqe is available *)
-    Queue.push (fun st -> submit_rw_req st req) io_q
-  )
-
-(* TODO bind from unixsupport *)
-let errno_is_retry = function -62 | -11 | -4 -> true |_ -> false
-
 (* Switch control to the next ready continuation.
    If none is ready, wait until we get an event to wake one and then switch.
    Returns only if there is nothing to do and no queued operations. *)
@@ -286,10 +249,6 @@ let rec schedule ({run_q; sleep_q; mem_q; uring; _} as st) : [`Exit_scheduler] =
 and handle_complete st ~runnable result =
   submit_pending_io st;                       (* If something was waiting for a slot, submit it now. *)
   match runnable with
-  | Read req ->
-    complete_rw_req st req result
-  | Write req ->
-    complete_rw_req st req result
   | Job k ->
     Fiber_context.clear_cancel_fn k.fiber;
     if result >= 0 then Suspended.continue k result
@@ -313,31 +272,9 @@ and handle_complete st ~runnable result =
     Fiber_context.clear_cancel_fn k.fiber;
     (* Should we only do this on error, to avoid losing the return value?
        We already do that with rw jobs. *)
-    begin match Fiber_context.get_error k.fiber with
-      | None -> f result
-      | Some e -> Suspended.discontinue k e
-    end
-and complete_rw_req st ({len; cur_off; action; _} as req) res =
-  Fiber_context.clear_cancel_fn action.fiber;
-  match res, len with
-  | 0, _ -> Suspended.discontinue action End_of_file
-  | e, _ when e < 0 ->
-    begin match Fiber_context.get_error action.fiber with
-      | Some e -> Suspended.discontinue action e        (* If cancelled, report that instead. *)
-      | None ->
-        if errno_is_retry e then (
-          submit_rw_req st req;
-          schedule st
-        ) else (
-          Suspended.continue action e
-        )
-    end
-  | n, Exactly len when n < len - cur_off ->
-    req.cur_off <- req.cur_off + n;
-    submit_rw_req st req;
-    schedule st
-  | _, Exactly len -> Suspended.continue action len
-  | n, Upto _ -> Suspended.continue action n
+    match Fiber_context.get_error k.fiber with
+    | None -> f result
+    | Some e -> Suspended.discontinue k e
 
 let rec enqueue_poll_add fd poll_mask st action =
   Trace.log "poll_add";


### PR DESCRIPTION
The goal here is to simplify the scheduler by removing some special cases that are only used for fixed-buffer reads and writes.

Before, a fiber could ask to read exactly n bytes, and the scheduler would keep issuing reads until that many had been read. It would also resubmit on EINTR, etc.

Now, the scheduler simply returns the number of bytes read or written and lets the fiber make another call if it wants more.

This adds a couple of fiber switches and delays the issuing of the next request. However, fiber switches are fast and if the kernel does a short read or write then it's because it's not ready to do more yet anyway.

It simplifies the code in several ways:

- The scheduler no longer needs to know about fixed-buffer operations.

- The `Read` and `Write` job types are gone; the regular `Job` works fine.

- We no longer need to distinguish between "read at offset 0" and "read on non-seekable FD", since the action doesn't need to update it. This avoids the need for the `file_offset` type.

- The `amount` type is gone too.