### PR TITLE
eio_linux: remove unused code

### DIFF
--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -177,10 +177,7 @@ let sleep_until time =
       Sched.enqueue_failed_thread t k ex
     )
 
-(* TODO bind from unixsupport *)
-let errno_is_retry = function -62 | -11 | -4 -> true |_ -> false
-
-let rec read_upto ?file_offset:off fd buf amount =
+let read_upto ?file_offset:off fd buf amount =
   let res = Sched.enter "read" (fun t k ->
       let off = file_offset fd off in
       Fd.use_exn "read" fd @@ fun fd ->
@@ -188,8 +185,7 @@ let rec read_upto ?file_offset:off fd buf amount =
     ) in
   if res = 0 then raise End_of_file
   else if res < 0 then (
-    if errno_is_retry res then read_upto ?file_offset:off fd buf amount
-    else raise @@ Err.wrap (Uring.error_of_errno res) "read" ""
+    raise @@ Err.wrap (Uring.error_of_errno res) "read" ""
   ) else res
 
 let rec read_exactly ?file_offset fd buf len =
@@ -265,15 +261,14 @@ let await_writable fd =
     raise (Err.unclassified (Eio_unix.Unix_error (Uring.error_of_errno res, "await_writable", "")))
   )
 
-let rec write_single ?file_offset:off fd buf len =
+let write_single ?file_offset:off fd buf len =
   let res = Sched.enter "write" (fun t k ->
       let off = file_offset fd off in
       Fd.use_exn "write" fd @@ fun fd ->
       enqueue_write t k (off, fd, buf, len)
     ) in
   if res < 0 then (
-    if errno_is_retry res then write_single ?file_offset:off fd buf len
-    else raise @@ Err.wrap (Uring.error_of_errno res) "write" ""
+    raise @@ Err.wrap (Uring.error_of_errno res) "write" ""
   ) else res
 
 let rec write ?file_offset fd buf len =

--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -13,15 +13,6 @@ let statx_works = ref false     (* Before Linux 5.18, statx is unreliable *)
 
 type exit = [`Exit_scheduler]
 
-type rw_req = {
-  op : [`R|`W];
-  file_offset : Optint.Int63.t;
-  fd : Unix.file_descr;
-  len : int;
-  buf : Fixed.chunk;
-  action : int Suspended.t;
-}
-
 (* Type of user-data attached to jobs. *)
 type io_job =
   | Job_no_cancel : int Suspended.t -> io_job


### PR DESCRIPTION
The fixed-buffer read and write operations automatically retried on EAGAIN, etc, but there's no reason why the kernel should return that.

There is a uring bug (#788) that can cause some operations to fail with EINTR, but that shouldn't happen now that we use `DEFER_TASKRUN`.