### PR TITLE
eio_linux: handle ENOMEM from io_uring_queue_init

### DIFF
--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -449,6 +449,7 @@ let with_sched ?(fallback=no_fallback) config fn =
   match uring_create ~queue_depth ?polling_timeout () with
   | exception Unix.Unix_error(ENOSYS, _, _) -> fallback (`Msg "io_uring is not available on this system")
   | exception Unix.Unix_error(EPERM, _, _) -> fallback (`Msg "io_uring is not available (permission denied)")
+  | exception Unix.Unix_error(ENOMEM, _, _) -> fallback (`Msg "io_uring is not available (ENOMEM)")
   | uring ->
     let probe = Uring.get_probe uring in
     if not (Uring.op_supported probe Uring.Op.mkdirat) then (


### PR DESCRIPTION
We would already fall back to eio_posix if there wasn't enough lockable memory to add a fixed buffer, but didn't cope with not having enough memory for the ring itself.

Seen in a failing CI test for `lib_eio_linux/tests/fd_sharing.md`:

    Exception: Unix.Unix_error(Unix.ENOMEM, "io_uring_queue_init", "")