### PR TITLE
Rename Path.open_dir to open_subtree

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,12 +809,12 @@ The checks also apply to following symlinks:
 - : unit = ()
 ```
 
-You can use `open_dir` (or `with_open_dir`) to create a restricted capability to a subdirectory:
+You can use `open_subtree` (or `with_subtree`) to create a restricted capability to a subdirectory:
 
 ```ocaml
 # Eio_main.run @@ fun env ->
   let cwd = Eio.Stdenv.cwd env in
-  Eio.Path.with_open_dir (cwd / "dir1") @@ fun dir1 ->
+  Eio.Path.with_subtree (cwd / "dir1") @@ fun dir1 ->
   try_save (dir1 / "file4") "D";
   try_save (dir1 / "../file5") "E";;
 +save <dir1:file4> : ok
@@ -822,13 +822,13 @@ You can use `open_dir` (or `with_open_dir`) to create a restricted capability to
 - : unit = ()
 ```
 
-You only need to use `open_dir` if you want to create a new sandboxed environment.
+You only need to use `subtree` if you want to create a new sandboxed environment.
 You can use a single base directory object to access all paths beneath it,
 and this allows following symlinks within that subtree.
 
 A program that operates on the current directory will probably want to use `cwd`,
 whereas a program that accepts a path from the user will probably want to use `fs`,
-perhaps with `open_dir` to constrain all access to be within that directory.
+perhaps with `open_subtree` to constrain all access to be within that directory.
 
 On systems that provide the [cap_enter][] system call, you can ask the OS to reject accesses
 that don't use capabilities.

--- a/examples/capsicum/main.ml
+++ b/examples/capsicum/main.ml
@@ -28,7 +28,7 @@ let () =
   in 
   if not (Eio.Path.is_directory path) then Fmt.failwith "%a is not a directory" Eio.Path.pp path;
   (* Get access to resources before calling cap_enter: *)
-  Eio.Path.with_open_dir path @@ fun dir ->
+  Eio.Path.with_subtree path @@ fun dir ->
   traceln "Opened directory %a" Eio.Path.pp path;
   (* Switch to capability mode, if possible: *)
   begin match Eio_unix.Cap.enter () with

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -197,7 +197,7 @@ module Stdenv : sig
       {[
         let () =
           Eio_main.run @@ fun env ->
-          Eio.Path.with_open_dir env#fs "/srv/www" @@ fun www ->
+          Eio.Path.with_subtree env#fs "/srv/www" @@ fun www ->
           serve_files www
             ~net:env#net
       ]}

--- a/lib_eio/fs.ml
+++ b/lib_eio/fs.ml
@@ -63,7 +63,7 @@ module Pi = struct
       path -> File.rw_ty r
 
     val mkdir : t -> perm:File.Unix_perm.t -> path -> unit
-    val open_dir : t -> sw:Switch.t -> path -> [`Close | dir_ty] r
+    val open_subtree : t -> sw:Switch.t -> path -> [`Close | dir_ty] r
     val read_dir : t -> path -> string list
     val with_dir_entries : t -> path -> ((File.Stat.kind * string) Seq.t -> 'a) -> 'a
     val stat : t -> follow:bool -> string -> File.Stat.t

--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -80,15 +80,17 @@ let open_out ~sw ?(append=false) ~create t =
     let bt = Printexc.get_raw_backtrace () in
     Exn.reraise_with_context ex bt "opening %a" pp t
 
-let open_dir ~sw t =
+let open_subtree ~sw t =
   let (Resource.T (dir, ops), path) = t in
   let module X = (val (Resource.get ops Fs.Pi.Dir)) in
   try
-    let sub = X.open_dir dir ~sw path, "" in
+    let sub = X.open_subtree dir ~sw path, "" in
     (sub : [`Close | `Dir] t :> [< `Close | `Dir] t)
   with Exn.Io _ as ex ->
     let bt = Printexc.get_raw_backtrace () in
     Exn.reraise_with_context ex bt "opening directory %a" pp t
+
+let open_dir = open_subtree
 
 let mkdir ~perm t =
   let (Resource.T (dir, ops), path) = t in
@@ -144,8 +146,10 @@ let with_open_in path fn =
 let with_open_out ?append ~create path fn =
   Switch.run ~name:"with_open_out" @@ fun sw -> fn (open_out ~sw ?append ~create path)
 
-let with_open_dir path fn =
-  Switch.run ~name:"with_open_dir" @@ fun sw -> fn (open_dir ~sw path)
+let with_subtree path fn =
+  Switch.run ~name:"with_subtree" @@ fun sw -> fn (open_subtree ~sw path)
+
+let with_open_dir = with_subtree
 
 let with_lines path fn =
   with_open_in path @@ fun flow ->
@@ -203,7 +207,7 @@ let rec rmtree ~missing_ok t =
   | `Directory ->
     Switch.run ~name:"rmtree" (fun sw ->
         match
-          let t = open_dir ~sw t in
+          let t = open_subtree ~sw t in
           t, read_dir t
         with
         | t, items -> List.iter (fun x -> rmtree ~missing_ok (t / x)) items

--- a/lib_eio/path.mli
+++ b/lib_eio/path.mli
@@ -50,7 +50,7 @@ val native : _ t -> string option
     This is intended for interoperability with non-Eio libraries.
 
     This does not check for confinement (the resulting path might not be accessible
-    via [t] itself). Also, if a directory was opened with {!open_dir} and later
+    via [t] itself). Also, if a directory was opened with {!open_subtree} and later
     renamed, this might use the old name.
 
     Using strings as paths is not secure if components in the path can be
@@ -139,14 +139,24 @@ val mkdirs : ?exists_ok:bool -> perm:File.Unix_perm.t -> _ t -> unit
 
     @param exist_ok If [false] (the default) then we raise {! Fs.Already_exists} if [t] is already a directory. *)
 
-val open_dir : sw:Switch.t -> _ t -> [< `Close | dir_ty] t
-(** [open_dir ~sw t] opens [t].
+val open_subtree : sw:Switch.t -> _ t -> [< `Close | dir_ty] t
+(** [open_subtree ~sw t] returns a path that grants access only to the subtree at [t].
 
-    This can be passed to functions to grant access only to the subtree [t]. *)
+    The returned path will not allow use of ".." or symlinks to escape the subtree.
+
+    @since 1.4 *)
+
+val open_dir : sw:Switch.t -> _ t -> [< `Close | dir_ty] t
+(** Deprecated alias of {!open_subtree}. *)
+
+val with_subtree : _ t -> ([< `Close | dir_ty] t -> 'a) -> 'a
+(** [with_subtree] is like [open_subtree], but calls [fn dir] with the new directory and closes
+    it automatically when [fn] returns (if it hasn't already been closed by then).
+
+    @since 1.4 *)
 
 val with_open_dir : _ t -> ([< `Close | dir_ty] t -> 'a) -> 'a
-(** [with_open_dir] is like [open_dir], but calls [fn dir] with the new directory and closes
-    it automatically when [fn] returns (if it hasn't already been closed by then). *)
+(** Deprecated alias of {!with_subtree}. *)
 
 val read_dir : _ t -> string list
 (** [read_dir t] reads directory entry names for [t].

--- a/lib_eio/unix/cap.mli
+++ b/lib_eio/unix/cap.mli
@@ -7,5 +7,5 @@ val enter : unit -> (unit, [`Not_supported]) result
     to prevent accidental access to other resources.
 
     The standard environment directories {!Eio.Stdenv.fs} and {!Eio.Stdenv.cwd} cannot
-    be used after calling this, but directories opened from them via {!Eio.Path.with_open_dir}
+    be used after calling this, but directories opened from them via {!Eio.Path.with_subtree}
     will continue to work. *)

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -386,7 +386,7 @@ end = struct
       else p
     ) else path
 
-  let open_dir t ~sw path =
+  let open_subtree t ~sw path =
     let fd = Low_level.openat ~sw ~seekable:false t.fd (if path = "" then "." else path)
         ~access:`R
         ~flags:Uring.Open_flags.(cloexec + path + directory)

--- a/lib_eio_posix/fs.ml
+++ b/lib_eio_posix/fs.ml
@@ -100,7 +100,7 @@ end = struct
   let symlink ~link_to t path =
     Err.run (Low_level.symlink ~link_to t.fd) path
 
-  let open_dir t ~sw path =
+  let open_subtree t ~sw path =
     let flags = Low_level.Open_flags.(rdonly + directory +? path) in
     let fd = Err.run (Low_level.openat ~sw ~mode:0 t.fd path) flags in
     let label = Filename.basename path in

--- a/lib_eio_windows/fs.ml
+++ b/lib_eio_windows/fs.ml
@@ -189,7 +189,7 @@ end = struct
 
   let close t = t.closed <- true
 
-  let open_dir t ~sw path =
+  let open_subtree t ~sw path =
     Switch.check sw;
     let label = Filename.basename path in
     let d = v ~label (resolve t path) ~sandbox:true in

--- a/lib_eio_windows/test/test_fs.ml
+++ b/lib_eio_windows/test/test_fs.ml
@@ -167,7 +167,7 @@ let test_symlink env () =
   Unix.symlink ~to_dir:true "subdir" "sandbox\\to-subdir";
   Unix.symlink ~to_dir:true "foo" "sandbox\\dangle";
   try_mkdir (cwd / "tmp");
-  Eio.Path.with_open_dir (cwd / "sandbox") @@ fun sandbox ->
+  Eio.Path.with_subtree (cwd / "sandbox") @@ fun sandbox ->
   try_mkdir (sandbox / "subdir");
   try_mkdir (sandbox / "to-subdir\\nested");
   let () =

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -532,7 +532,7 @@ Create a sandbox, write a file with it, then read it from outside:
   Switch.run @@ fun sw ->
   let cwd = Eio.Stdenv.cwd env in
   try_mkdir (cwd / "sandbox");
-  let subdir = Path.open_dir ~sw (cwd / "sandbox") in
+  let subdir = Path.open_subtree ~sw (cwd / "sandbox") in
   Path.save ~create:(`Exclusive 0o600) (subdir / "test-file") "data";
   try_mkdir (subdir / "../new-sandbox");
   traceln "Got %S" @@ Path.load (cwd / "sandbox/test-file");;
@@ -551,8 +551,8 @@ Create a sandbox, write a file with it, then read it from outside:
     Eio.Exn.Backend.show := succeeds;
     try
       Switch.run @@ fun sw ->
-      let _ : _ Path.t = Path.open_dir ~sw path in
-      traceln "open_dir %a -> OK" Path.pp path
+      let _ : _ Path.t = Path.open_subtree ~sw path in
+      traceln "open_subtree %a -> OK" Path.pp path
     with ex ->
       traceln "@[<h>%a@]" Eio.Exn.pp ex
   in
@@ -569,13 +569,13 @@ Create a sandbox, write a file with it, then read it from outside:
   Path.symlink ~link_to:"/" (cwd / "foo/root");
   reject (cwd / "foo/root/..");
   reject (cwd / "missing");
-+open_dir <cwd:foo/bar> -> OK
++open_subtree <cwd:foo/bar> -> OK
 +Eio.Io Fs Permission_denied _, opening directory <cwd:..>
-+open_dir <cwd:.> -> OK
++open_subtree <cwd:.> -> OK
 +Eio.Io Fs Permission_denied _, opening directory <cwd:/>
-+open_dir <cwd:foo/bar/..> -> OK
-+open_dir <fs:foo/bar> -> OK
-+open_dir <cwd:foo/up/foo/bar> -> OK
++open_subtree <cwd:foo/bar/..> -> OK
++open_subtree <fs:foo/bar> -> OK
++open_subtree <cwd:foo/up/foo/bar> -> OK
 +Eio.Io Fs Permission_denied _, opening directory <cwd:foo/up/../bar>
 +Eio.Io Fs Permission_denied _, opening directory <cwd:foo/root/..>
 +Eio.Io Fs Not_found _, opening directory <cwd:missing>
@@ -620,7 +620,7 @@ Reading directory entries under `cwd` and outside of `cwd`.
 # run ~clear:["readdir"] @@ fun env ->
   let cwd = Eio.Stdenv.cwd env in
   try_mkdir (cwd / "readdir");
-  Path.with_open_dir (cwd / "readdir") @@ fun tmpdir ->
+  Path.with_subtree (cwd / "readdir") @@ fun tmpdir ->
   try_mkdir (tmpdir / "test-1");
   try_mkdir (tmpdir / "test-2");
   try_write_file ~create:(`Exclusive 0o600) (tmpdir / "test-1/file") "data";
@@ -751,7 +751,7 @@ In that case, `with_open_in` will no longer close it on exit:
 
 ```ocaml
 # run @@ fun env ->
-  let closed = Switch.run (fun sw -> Path.open_dir ~sw env#cwd) in
+  let closed = Switch.run (fun sw -> Path.open_subtree ~sw env#cwd) in
   try
     failwith (Path.read_dir closed |> String.concat ",")
   with Invalid_argument _ -> traceln "Got Invalid_argument for closed FD";;
@@ -768,7 +768,7 @@ let try_rename t =
   try_write_file (t / "foo") "FOO" ~create:(`Exclusive 0o600);
   try_rename (t / "foo") (t / "dir/bar");
   try_read_file (t / "dir/bar");
-  Path.with_open_dir (t / "dir") @@ fun dir ->
+  Path.with_subtree (t / "dir") @@ fun dir ->
   try_rename (dir / "bar") (t / "foo");
   try_read_file (t / "foo");
   Unix.chdir "dir";
@@ -952,7 +952,7 @@ Exception: Failure "Simulated error".
   test (env#cwd / "..");
   let sub = env#cwd / "native-sub" in
   Eio.Path.mkdir sub ~perm:0o700;
-  Eio.Path.with_open_dir sub @@ fun sub ->
+  Eio.Path.with_subtree sub @@ fun sub ->
   test sub;
   test (sub / "foo.txt");
   test (sub / ".");

--- a/tests/process.md
+++ b/tests/process.md
@@ -126,7 +126,7 @@ Changing directory (confined):
   let cwd = Eio.Stdenv.cwd env in
   let subdir = cwd / "proc-sub-dir" in
   Eio.Path.mkdir subdir ~perm:0o700;
-  Eio.Path.with_open_dir subdir @@ fun subdir ->
+  Eio.Path.with_subtree subdir @@ fun subdir ->
   Eio.Path.save (subdir / "test-cwd") "test-data" ~create:(`Exclusive 0o600);
   Process.run mgr ~cwd:subdir [ "cat"; "test-cwd" ];;
 test-data


### PR DESCRIPTION
This more accurately describes what it's for (every time I show some code with the old names, I feel I have to explain what it does).