### PR TITLE
Propagate errno back from fork_actions into Eio.Process

### DIFF
--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -28,11 +28,11 @@ let () =
     | E e ->
       Fmt.string f "Process ";
       begin match e with
-        | Executable_not_found e -> Fmt.pf f "Executable %S not found" e;
+        | Executable_not_found e -> Fmt.pf f "Executable_not_found %S" e;
         | Child_error e -> Fmt.pf f "Child_error %a" pp_status e;
-        | Argument_list_too_long -> Fmt.pf f "Argument list too long"
-        | Permission_denied e -> Fmt.pf f "Permission denied when executing %S" e
-        | Executable_format_error e -> Fmt.pf f "Executable %S has an invalid format" e
+        | Argument_list_too_long -> Fmt.pf f "Argument_list_too_long"
+        | Permission_denied e -> Fmt.pf f "Permission_denied %S" e
+        | Executable_format_error e -> Fmt.pf f "Executable_format_error %S" e
       end;
       true
     | _ -> false

--- a/lib_eio/process.ml
+++ b/lib_eio/process.ml
@@ -15,6 +15,9 @@ let pp_status ppf = function
 type error =
   | Executable_not_found of string
   | Child_error of exit_status
+  | Argument_list_too_long
+  | Permission_denied of string
+  | Executable_format_error of string
 
 type Exn.err += E of error
 
@@ -27,6 +30,9 @@ let () =
       begin match e with
         | Executable_not_found e -> Fmt.pf f "Executable %S not found" e;
         | Child_error e -> Fmt.pf f "Child_error %a" pp_status e;
+        | Argument_list_too_long -> Fmt.pf f "Argument list too long"
+        | Permission_denied e -> Fmt.pf f "Permission denied when executing %S" e
+        | Executable_format_error e -> Fmt.pf f "Executable %S has an invalid format" e
       end;
       true
     | _ -> false

--- a/lib_eio/process.mli
+++ b/lib_eio/process.mli
@@ -25,6 +25,9 @@ val pp_status : [< status] Fmt.t
 type error =
   | Executable_not_found of string      (** The requested executable does not exist. *)
   | Child_error of exit_status          (** The process exited with an error status. *)
+  | Argument_list_too_long              (** The arguments passed were too long. *)
+  | Permission_denied of string         (** The executable exists but could not be run. *)
+  | Executable_format_error of string   (** The executable exists but is not in a runnable format. *)
 
 type Exn.err += E of error
 

--- a/lib_eio/unix/fork_action.c
+++ b/lib_eio/unix/fork_action.c
@@ -6,6 +6,7 @@
 
 #include "primitives.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -47,9 +48,10 @@ static void try_write_all(int fd, char *buf) {
   }
 }
 
-void eio_unix_fork_error(int fd, char *fn, char *buf) {
+void eio_unix_fork_error(int fd, char *fn, int err) {
+  char buf[32];
+  snprintf(buf, sizeof buf, ":%d", err);
   try_write_all(fd, fn);
-  try_write_all(fd, ": ");
   try_write_all(fd, buf);
 }
 
@@ -109,7 +111,7 @@ static void action_execve(int errors, value v_config) {
   fill_string_array(envp, Field(v_config, 5));
 
   execve(String_val(v_exe), argv, envp);
-  eio_unix_fork_error(errors, "execve", strerror(errno));
+  eio_unix_fork_error(errors, "execve", errno);
   _exit(1);
 }
 
@@ -117,15 +119,20 @@ CAMLprim value eio_unix_fork_execve(value v_unit) {
   return Val_fork_fn(action_execve);
 }
 
+/* Convert a C [errno] code to an OCaml [Unix.error] value. */
+CAMLprim value eio_unix_error_of_code(value v_code) {
+  return caml_unix_error_of_code(Int_val(v_code));
+}
+
 static void action_fchdir(int errors, value v_config) {
   #ifdef _WIN32
-  eio_unix_fork_error(errors, "action_fchdir", "Unsupported operation on windows");
+  eio_unix_fork_error(errors, "action_fchdir", ENOSYS);
   #else
   value v_fd = Field(v_config, 1);
   int r;
   r = fchdir(Int_val(v_fd));
   if (r != 0) {
-    eio_unix_fork_error(errors, "fchdir", strerror(errno));
+    eio_unix_fork_error(errors, "fchdir", errno);
     _exit(1);
   }
   #endif
@@ -140,7 +147,7 @@ static void action_chdir(int errors, value v_config) {
   int r;
   r = chdir(String_val(v_path));
   if (r != 0) {
-    eio_unix_fork_error(errors, "chdir", strerror(errno));
+    eio_unix_fork_error(errors, "chdir", errno);
     _exit(1);
   }
 }
@@ -151,7 +158,7 @@ CAMLprim value eio_unix_fork_chdir(value v_unit) {
 
 static void set_blocking(int errors, int fd, int blocking) {
   #ifdef _WIN32
-  eio_unix_fork_error(errors, "set_blocking", "Unsupported operation on windows");
+  eio_unix_fork_error(errors, "set_blocking", ENOSYS);
   #else
   int r = fcntl(fd, F_GETFL, 0);
   if (r != -1) {
@@ -163,7 +170,7 @@ static void set_blocking(int errors, int fd, int blocking) {
     }
   }
   if (r == -1) {
-    eio_unix_fork_error(errors, "fcntl", strerror(errno));
+    eio_unix_fork_error(errors, "fcntl", errno);
     _exit(1);
   }
   #endif
@@ -171,7 +178,7 @@ static void set_blocking(int errors, int fd, int blocking) {
 
 static void set_cloexec(int errors, int fd, int cloexec) {
   #ifdef _WIN32
-  eio_unix_fork_error(errors, "set_cloexec", "Unsupported operation on windows");
+  eio_unix_fork_error(errors, "set_cloexec", ENOSYS);
   #else
   int r = fcntl(fd, F_GETFD, 0);
   if (r != -1) {
@@ -183,7 +190,7 @@ static void set_cloexec(int errors, int fd, int cloexec) {
     }
   }
   if (r == -1) {
-    eio_unix_fork_error(errors, "fcntl", strerror(errno));
+    eio_unix_fork_error(errors, "fcntl", errno);
     _exit(1);
   }
   #endif
@@ -203,13 +210,13 @@ static void action_dups(int errors, value v_config) {
       if (tmp == -1) {
 	tmp = dup(src);
 	if (tmp < 0) {
-	  eio_unix_fork_error(errors, "dup-tmp", strerror(errno));
+	  eio_unix_fork_error(errors, "dup-tmp", errno);
 	  _exit(1);
 	}
       } else {
 	int r = dup2(src, tmp);
 	if (r < 0) {
-	  eio_unix_fork_error(errors, "dup2-tmp", strerror(errno));
+	  eio_unix_fork_error(errors, "dup2-tmp", errno);
 	  _exit(1);
 	}
       }
@@ -219,7 +226,7 @@ static void action_dups(int errors, value v_config) {
     } else {
       int r = dup2(src, dst);
       if (r < 0) {
-	eio_unix_fork_error(errors, "dup2", strerror(errno));
+	eio_unix_fork_error(errors, "dup2", errno);
 	_exit(1);
       }
     }
@@ -240,7 +247,7 @@ CAMLprim value eio_unix_fork_dups(value v_unit) {
 
 static void action_setpgid(int errors, value v_config) {
   #ifdef _WIN32
-  eio_unix_fork_error(errors, "setpgid", "Unsupported operation on windows");
+  eio_unix_fork_error(errors, "setpgid", ENOSYS);
   _exit(1);
   #else
   value vpid = Field(v_config, 1);
@@ -249,7 +256,7 @@ static void action_setpgid(int errors, value v_config) {
   int r;
   r = setpgid(Int_val(vpid), Int_val(vpgid));
   if (r != 0) {
-    eio_unix_fork_error(errors, "setpgid", strerror(errno));
+    eio_unix_fork_error(errors, "setpgid", errno);
     _exit(1);
   }
   #endif
@@ -261,14 +268,14 @@ CAMLprim value eio_unix_fork_setpgid(value v_unit) {
 
 static void action_setuid(int errors, value v_config) {
   #ifdef _WIN32
-  eio_unix_fork_error(errors, "action_setuid", "Unsupported operation on windows");
+  eio_unix_fork_error(errors, "action_setuid", ENOSYS);
   _exit(1);
   #else
   value v_uid = Field(v_config, 1);
   int r;
   r = setuid(Int_val(v_uid));
   if (r != 0) {
-    eio_unix_fork_error(errors, "setuid", strerror(errno));
+    eio_unix_fork_error(errors, "setuid", errno);
     _exit(1);
   }
   #endif
@@ -280,14 +287,14 @@ CAMLprim value eio_unix_fork_setuid(value v_unit) {
 
 static void action_setgid(int errors, value v_config) {
   #ifdef _WIN32
-  eio_unix_fork_error(errors, "action_setgid", "Unsupported operation on windows");
+  eio_unix_fork_error(errors, "action_setgid", ENOSYS);
   _exit(1);
   #else
   value v_gid = Field(v_config, 1);
   int r;
   r = setgid(Int_val(v_gid));
   if (r != 0) {
-    eio_unix_fork_error(errors, "setgid", strerror(errno));
+    eio_unix_fork_error(errors, "setgid", errno);
     _exit(1);
   }
   #endif

--- a/lib_eio/unix/fork_action.ml
+++ b/lib_eio/unix/fork_action.ml
@@ -83,3 +83,11 @@ external action_setgid : unit -> fork_fn = "eio_unix_fork_setgid"
 let action_setgid = action_setgid ()
 let setgid gid = {
   run = fun k -> k (Obj.repr (action_setgid, gid)) }
+
+external error_of_code : int -> Unix.error = "eio_unix_error_of_code"
+
+let report_spawn_error msg =
+  (* A failed fork action writes "<fn>:<errno>" to the errors pipe. *)
+  match Scanf.sscanf_opt msg "%[^:]:%d" (fun fn code -> (fn, error_of_code code)) with
+  | Some (fn, err) -> raise (Unix.Unix_error (err, fn, ""))
+  | None -> failwith msg

--- a/lib_eio/unix/fork_action.mli
+++ b/lib_eio/unix/fork_action.mli
@@ -70,3 +70,10 @@ val setuid : int -> t
 
 val setgid : int -> t
 (** [setgid gid] sets the group ID to [gid]. *)
+
+val report_spawn_error : string -> 'a
+(** [report_spawn_error msg] raises an exception describing a failed spawn.
+
+    [msg] is the message read from the errors pipe written by a failed fork
+    action, of the form ["<fn>:<errno>"]. The [errno] is turned back into a
+    {!Unix.Unix_error}. A message that can't be parsed is raised as a {!Failure}. *)

--- a/lib_eio/unix/include/fork_action.h
+++ b/lib_eio/unix/include/fork_action.h
@@ -17,7 +17,7 @@ Caml_inline value Val_fork_fn(fork_fn *fn) {
  */
 void eio_unix_run_fork_actions(int errors, value v_actions);
 
-/* Write "$fn: $msg" to fd.
- * fd must be blocking.
+/* Write "$fn:$err" to a blocking fd, where $err is the [errno] int.
+ * Encoding the number lets the parent reconstruct a [Unix.Unix_error].
  * Ignores failure. */
-void eio_unix_fork_error(int fd, char *fn, char *msg);
+void eio_unix_fork_error(int fd, char *fn, int err);

--- a/lib_eio/unix/primitives.h
+++ b/lib_eio/unix/primitives.h
@@ -10,6 +10,7 @@ CAMLprim value eio_unix_fork_dups(value);
 CAMLprim value eio_unix_fork_setpgid(value);
 CAMLprim value eio_unix_fork_setuid(value);
 CAMLprim value eio_unix_fork_setgid(value);
+CAMLprim value eio_unix_error_of_code(value);
 CAMLprim value eio_unix_cap_enter(value);
 CAMLprim value eio_unix_readlinkat(value, value, value);
 CAMLprim value eio_unix_is_blocking(value);

--- a/lib_eio/unix/process.ml
+++ b/lib_eio/unix/process.ml
@@ -69,6 +69,17 @@ let get_env = function
   | Some e -> e
   | None -> Unix.environment ()
 
+let translate_execve_error ~executable f =
+  try f () with
+  | Unix.Unix_error (Unix.E2BIG, "execve", _) ->
+    raise (Eio.Process.err Eio.Process.Argument_list_too_long)
+  | Unix.Unix_error (Unix.ENOENT, "execve", _) ->
+    raise (Eio.Process.err (Executable_not_found executable))
+  | Unix.Unix_error (Unix.EACCES, "execve", _) ->
+    raise (Eio.Process.err (Permission_denied executable))
+  | Unix.Unix_error (Unix.ENOEXEC, "execve", _) ->
+    raise (Eio.Process.err (Executable_format_error executable))
+
 type ty = [ `Generic | `Unix ] Eio.Process.ty
 type 'a t = ([> ty] as 'a) r
 
@@ -139,6 +150,7 @@ end) = struct
       1, stdout_fd, `Blocking;
       2, stderr_fd, `Blocking;
     ] in
+    translate_execve_error ~executable @@ fun () ->
     X.spawn_unix v ~sw ?cwd ~env ~fds ~executable args
 
   let spawn_unix = X.spawn_unix
@@ -148,6 +160,7 @@ let spawn_unix ~sw (Eio.Resource.T (v, ops)) ?cwd ?pgid ?uid ?gid ~fds ?env ?exe
   let module X = (val (Eio.Resource.get ops Pi.Mgr_unix)) in
   let executable = get_executable executable ~args in
   let env = get_env env in
+  translate_execve_error ~executable @@ fun () ->
   X.spawn_unix v ~sw ?cwd ?pgid ?uid ?gid ~fds ~env ~executable args
 
 let sigchld = Eio.Condition.create ()

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -659,5 +659,5 @@ module Process = struct
     (* Check for errors starting the process. *)
     match read_response errors_r with
     | "" -> t                       (* Success! Execing the child closed [errors_w] and we got EOF. *)
-    | err -> failwith err
+    | err -> Fork_action.report_spawn_error err
 end

--- a/lib_eio_linux/tests/spawn.md
+++ b/lib_eio_linux/tests/spawn.md
@@ -94,9 +94,9 @@ Failure starting child:
       ]
     in
     assert false
-  with Failure ex ->
-    String.sub ex 0 7
-- : string = "chdir: "
+  with Unix.Unix_error (Unix.ENOENT, fn, _) ->
+    fn
+- : string = "chdir"
 ```
 
 Signalling a running child:

--- a/lib_eio_linux/tests/spawn.md
+++ b/lib_eio_linux/tests/spawn.md
@@ -84,19 +84,13 @@ Failure starting child:
 ```ocaml
 # Eio_linux.run @@ fun _env ->
   Switch.run @@ fun sw ->
-  try
-    let _child =
-      Process.spawn ~sw Process.Fork_action.[
-        chdir "/idontexist";
-        execve "/usr/bin/env"
-          ~argv:[| "env"; "pwd" |]
-          ~env:(Unix.environment ())
-      ]
-    in
-    assert false
-  with Unix.Unix_error (Unix.ENOENT, fn, _) ->
-    fn
-- : string = "chdir"
+  Process.spawn ~sw Process.Fork_action.[
+    chdir "/idontexist";
+    execve "/usr/bin/env"
+      ~argv:[| "env"; "pwd" |]
+      ~env:(Unix.environment ())
+  ]
+Exception: Unix.Unix_error(Unix.ENOENT, "chdir", "")
 ```
 
 Signalling a running child:

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -624,5 +624,5 @@ module Process = struct
     (* Check for errors starting the process. *)
     match read_response errors_r with
     | "" -> t                       (* Success! Execing the child closed [errors_w] and we got EOF. *)
-    | err -> failwith err
+    | err -> Fork_action.report_spawn_error err
 end

--- a/lib_eio_posix/test/spawn.md
+++ b/lib_eio_posix/test/spawn.md
@@ -87,9 +87,9 @@ Failure starting child:
       ]
     in
     assert false
-  with Failure ex ->
-    String.sub ex 0 7
-- : string = "chdir: "
+  with Unix.Unix_error (Unix.ENOENT, fn, _) ->
+    fn
+- : string = "chdir"
 ```
 
 Signalling a running child:

--- a/lib_eio_posix/test/spawn.md
+++ b/lib_eio_posix/test/spawn.md
@@ -77,19 +77,13 @@ Failure starting child:
 ```ocaml
 # Eio_posix.run @@ fun _env ->
   Switch.run @@ fun sw ->
-  try
-    let _child =
-      Process.spawn ~sw Process.Fork_action.[
-        chdir "/idontexist";
-        execve "/usr/bin/env"
-          ~argv:[| "env"; "pwd" |]
-          ~env:(Unix.environment ())
-      ]
-    in
-    assert false
-  with Unix.Unix_error (Unix.ENOENT, fn, _) ->
-    fn
-- : string = "chdir"
+  Process.spawn ~sw Process.Fork_action.[
+    chdir "/idontexist";
+    execve "/usr/bin/env"
+      ~argv:[| "env"; "pwd" |]
+      ~env:(Unix.environment ())
+  ]
+Exception: Unix.Unix_error(Unix.ENOENT, "chdir", "")
 ```
 
 Signalling a running child:

--- a/tests/process.md
+++ b/tests/process.md
@@ -157,7 +157,7 @@ Passing too many arguments reports a dedicated error rather than a generic failu
 # run @@ fun mgr _env ->
   let big = String.make (1024 * 1024) 'x' in
   Process.run mgr ("echo" :: List.init 8 (fun _ -> big));;
-Exception: Eio.Io Process Argument list too long
+Exception: Eio.Io Process Argument_list_too_long
 ```
 
 Failures relating to the executable itself also report dedicated errrors.
@@ -168,7 +168,7 @@ A file that exists but isn't executable:
   let f = Eio.Stdenv.cwd env / "ocamlrocks" in
   Eio.Path.save f "#!/bin/sh\necho hi\n" ~create:(`Exclusive 0o600);
   Fun.protect ~finally:(fun () -> Eio.Path.unlink f) (fun () -> Process.run mgr ["./ocamlrocks"]);;
-Exception: Eio.Io Process Permission denied when executing "./ocamlrocks"
+Exception: Eio.Io Process Permission_denied "./ocamlrocks"
 ```
 
 A file that is executable but not in a runnable format:
@@ -178,7 +178,7 @@ A file that is executable but not in a runnable format:
   let f = Eio.Stdenv.cwd env / "badfmt" in
   Eio.Path.save f "\000\001 not a binary \255" ~create:(`Exclusive 0o700);
   Fun.protect ~finally:(fun () -> Eio.Path.unlink f) (fun () -> Process.run mgr ["./badfmt"]);;
-Exception: Eio.Io Process Executable "./badfmt" has an invalid format
+Exception: Eio.Io Process Executable_format_error "./badfmt"
 ```
 
 A script whose interpreter is missing reports the executable as not found:
@@ -188,7 +188,7 @@ A script whose interpreter is missing reports the executable as not found:
   let f = Eio.Stdenv.cwd env / "badinterp" in
   Eio.Path.save f "#!/nonexistent/interpreter\n" ~create:(`Exclusive 0o700);
   Fun.protect ~finally:(fun () -> Eio.Path.unlink f) (fun () -> Process.run mgr ["./badinterp"]);;
-Exception: Eio.Io Process Executable "./badinterp" not found
+Exception: Eio.Io Process Executable_not_found "./badinterp"
 ```
 
 Exit code success can be determined by is_success (Process.run):

--- a/tests/process.md
+++ b/tests/process.md
@@ -151,6 +151,46 @@ Eio.Io Process Child_error Exited (code 3),
   running command: sh -c "exit 3" "" foo "\"bar\""
 ```
 
+Passing too many arguments reports a dedicated error rather than a generic failure:
+
+```ocaml
+# run @@ fun mgr _env ->
+  let big = String.make (1024 * 1024) 'x' in
+  Process.run mgr ("echo" :: List.init 8 (fun _ -> big));;
+Exception: Eio.Io Process Argument list too long
+```
+
+Failures relating to the executable itself also report dedicated errrors.
+A file that exists but isn't executable:
+
+```ocaml
+# run ~clear:["ocamlrocks"] @@ fun mgr env ->
+  let f = Eio.Stdenv.cwd env / "ocamlrocks" in
+  Eio.Path.save f "#!/bin/sh\necho hi\n" ~create:(`Exclusive 0o600);
+  Fun.protect ~finally:(fun () -> Eio.Path.unlink f) (fun () -> Process.run mgr ["./ocamlrocks"]);;
+Exception: Eio.Io Process Permission denied when executing "./ocamlrocks"
+```
+
+A file that is executable but not in a runnable format:
+
+```ocaml
+# run ~clear:["badfmt"] @@ fun mgr env ->
+  let f = Eio.Stdenv.cwd env / "badfmt" in
+  Eio.Path.save f "\000\001 not a binary \255" ~create:(`Exclusive 0o700);
+  Fun.protect ~finally:(fun () -> Eio.Path.unlink f) (fun () -> Process.run mgr ["./badfmt"]);;
+Exception: Eio.Io Process Executable "./badfmt" has an invalid format
+```
+
+A script whose interpreter is missing reports the executable as not found:
+
+```ocaml
+# run ~clear:["badinterp"] @@ fun mgr env ->
+  let f = Eio.Stdenv.cwd env / "badinterp" in
+  Eio.Path.save f "#!/nonexistent/interpreter\n" ~create:(`Exclusive 0o700);
+  Fun.protect ~finally:(fun () -> Eio.Path.unlink f) (fun () -> Process.run mgr ["./badinterp"]);;
+Exception: Eio.Io Process Executable "./badinterp" not found
+```
+
 Exit code success can be determined by is_success (Process.run):
 
 ```ocaml


### PR DESCRIPTION
The idea follows @talex5's review of #561 by @Innf107.  When a fork action fails, the child now reports the errno rather than the strerror. The parent decodes it and raises a Unix.Unix_error instead of a Failure (7f01035a2df0c29d1c0b42a66f61e36d4f81ae7c)

The subsequent commits then add a Eio.Process.Argument_list_too_long (fixes #556 and #561) from E2BIG, and we also map ENOENT/EACCES/ENOEXEC to new Eio.Process errors (d42c0ef8dec3b145450e562970418d3798e06f64).
