### PR TITLE
eio_posix: wait for a writer when first reading from a FIFO

### DIFF
--- a/lib_eio_posix/fs.ml
+++ b/lib_eio_posix/fs.ml
@@ -32,6 +32,26 @@ let as_posix_dir (Eio.Resource.T (t, ops)) =
   | None -> None
   | Some fn -> Some (fn t)
 
+module Fifo_reader = struct
+  include Flow.Impl
+
+  let single_read t buf =
+    Low_level.await_readable "single_read" t;
+    Flow.Impl.single_read t buf
+
+  let pread t ~file_offset bufs =
+    Low_level.await_readable "pread" t;
+    Flow.Impl.pread t ~file_offset bufs
+end
+
+(* After opening a FIFO with no writers, it is not readable according to select,
+   but [read] returns end-of-file rather than EAGAIN!
+   Therefore, use a slightly slower implementation that always checks readability first.
+   See https://github.com/ocaml-multicore/eio/issues/856 *)
+let fifo_reader =
+  let handler = Eio_unix.Pi.flow_handler (module Fifo_reader) in
+  fun fd -> (Eio.Resource.T (fd, handler) :> Eio.File.ro_ty Eio.Resource.t)
+
 module rec Dir : sig
   include Eio.Fs.Pi.DIR
 
@@ -51,7 +71,9 @@ end = struct
 
   let open_in t ~sw path =
     let fd = Err.run (Low_level.openat ~mode:0 ~sw t.fd path) Low_level.Open_flags.rdonly in
-    (Flow.of_fd fd :> Eio.File.ro_ty Eio.Resource.t)
+    let info = Fd.use_exn "fstat" fd Unix.fstat in
+    if info.st_kind = S_FIFO then fifo_reader fd
+    else (Flow.of_fd fd :> Eio.File.ro_ty Eio.Resource.t)
 
   let open_out t ~sw ~append ~create path =
     let mode, flags =

--- a/tests/flow.md
+++ b/tests/flow.md
@@ -174,6 +174,38 @@ Make sure we don't crash on SIGPIPE:
 - : unit = ()
 ```
 
+Opening a FIFO with no writer should not block,
+but reading from it will wait for the writer:
+
+```ocaml
+# Eio_main.run @@ fun env ->
+  let ( / ) = Eio.Path.( / ) in
+  let path = env#cwd / "fifo" in
+  Eio.Path.unlink ~missing_ok:true path;
+  Unix.mkfifo "fifo" 0o600;
+  Eio.Path.with_open_in path @@ fun r ->
+  traceln "Opened FIFO (even though there's no writer)";
+  Fiber.both
+    (fun () ->
+       traceln "Reading...";
+       let buf = Cstruct.create 2 in
+       Eio.Flow.read_exact r buf;
+       traceln "Read: %S" (Cstruct.to_string buf)
+    )
+    (fun () ->
+       Eio_unix.sleep 0.01;
+       traceln "Attaching writer";
+       Eio.Path.with_open_out path ~create:`Never (fun w ->
+         Eio.Flow.copy_string "hi" w
+       )
+    );;
++Opened FIFO (even though there's no writer)
++Reading...
++Attaching writer
++Read: "hi"
+- : unit = ()
+```
+
 ## IO_MAX
 
 Sending a very long vector over a flow should just send it in chunks, not fail:


### PR DESCRIPTION
This matches the ordinary blocking behaviour.

Without this, eio_posix would immediately return end-of-file.

Curiously, eio_linux (uring) had the open return immediately, but waited on the first read. Possibly that's a bug. I've added an explicit wait there too.

Fixes #856.