### PR TITLE
Initial support for setting/getting socket options

### DIFF
--- a/lib_eio/mock/flow.ml
+++ b/lib_eio/mock/flow.ml
@@ -108,6 +108,9 @@ module Mock_flow = struct
     done;
     traceln "%s: closed" t.label
 
+  let setsockopt t opt v = Sockopt.setsockopt t.label opt v
+  let getsockopt t opt = Sockopt.getsockopt t.label opt
+
   let make ?(pp=pp_default) label =
     {
       pp;

--- a/lib_eio/mock/net.ml
+++ b/lib_eio/mock/net.ml
@@ -123,6 +123,9 @@ module Listening_socket = struct
 
   let listening_addr { listening_addr; _ } = listening_addr
 
+  let setsockopt t opt v = Sockopt.setsockopt t.label opt v
+  let getsockopt t opt = Sockopt.getsockopt t.label opt
+
   type (_, _, _) Eio.Resource.pi += Type : ('t, 't -> t, listening_socket_ty) Eio.Resource.pi
   let raw (Eio.Resource.T (t, ops)) = Eio.Resource.get ops Type t
 end

--- a/lib_eio/mock/sockopt.ml
+++ b/lib_eio/mock/sockopt.ml
@@ -1,0 +1,4 @@
+open Eio.Std
+
+let setsockopt label opt v = traceln "%s: setsockopt %a" label Eio.Net.Sockopt.pp_binding (opt, v)
+let getsockopt _label _opt = raise (Eio.Net.err Invalid_option)

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -8,6 +8,7 @@ type connection_failure =
 type error =
   | Connection_reset of Exn.Backend.t
   | Connection_failure of connection_failure
+  | Invalid_option
 
 type Exn.err += E of error
 
@@ -22,6 +23,7 @@ let () =
           | Connection_failure Refused e -> Fmt.pf f "Connection_failure Refused %a" Exn.Backend.pp e
           | Connection_failure Timeout -> Fmt.pf f "Connection_failure Timeout"
           | Connection_failure No_matching_addresses -> Fmt.pf f "Connection_failure No_matching_addresses"
+          | Invalid_option -> Fmt.string f "Invalid_option"
         end;
         true
       | _ -> false
@@ -159,6 +161,40 @@ module Sockaddr = struct
       Format.fprintf f "udp:%a:%d" Ipaddr.pp_for_uri addr port
 end
 
+module Sockopt = struct
+  type _ t = ..
+
+  type printer_fn = {
+    get : 'a. 'a t -> (string * 'a Fmt.t) option
+  } [@@unboxed]
+
+  let printers = Atomic.make []
+
+  let rec register_printer fn =
+    let prev = Atomic.get printers in
+    let next = fn :: prev in
+    if not (Atomic.compare_and_set printers prev next) then
+      register_printer fn
+
+  let find_printer x =
+    let rec aux = function
+      | [] -> "UNKNOWN", Fmt.any "?"
+      | { get } :: tl ->
+        match get x with
+         | None -> aux tl
+         | Some s -> s
+    in
+    aux (Atomic.get printers)
+
+  let pp f opt =
+    let name, _ = find_printer opt in
+    Fmt.string f name
+
+  let pp_binding f (opt, v) =
+    let name, pp = find_printer opt in
+    Fmt.pf f "%s = %a" name pp v
+end
+
 type socket_ty = [`Socket | `Close]
 type 'a socket = ([> socket_ty] as 'a) r
 
@@ -181,22 +217,34 @@ type 'a t = 'a r
   constraint 'a = [> [> `Generic] ty]
 
 module Pi = struct
+  module type SOCKET = sig
+    type t
+    val setsockopt : t -> 'a Sockopt.t -> 'a -> unit
+    val getsockopt : t -> 'a Sockopt.t -> 'a
+  end
+
+  type (_, _, _) Resource.pi +=
+    | Socket : ('t, (module SOCKET with type t = 't), [> `Socket]) Resource.pi
+
   module type STREAM_SOCKET = sig
     type tag
     include Flow.Pi.SHUTDOWN
     include Flow.Pi.SOURCE with type t := t
     include Flow.Pi.SINK with type t := t
+    include SOCKET with type t := t
     val close : t -> unit
   end
 
   let stream_socket (type t tag) (module X : STREAM_SOCKET with type t = t and type tag = tag) =
     Resource.handler @@
     H (Resource.Close, X.close) ::
+    H (Socket, (module X)) ::
     Resource.bindings (Flow.Pi.two_way (module X))
 
   module type DATAGRAM_SOCKET = sig
     type tag
     include Flow.Pi.SHUTDOWN
+    include SOCKET with type t := t
     val send : t -> ?dst:Sockaddr.datagram -> Cstruct.t list -> unit
     val recv : t -> Cstruct.t -> Sockaddr.datagram * int
     val close : t -> unit
@@ -208,6 +256,7 @@ module Pi = struct
   let datagram_socket (type t tag) (module X : DATAGRAM_SOCKET with type t = t and type tag = tag) =
     Resource.handler @@
     Resource.bindings (Flow.Pi.shutdown (module X)) @ [
+      H (Socket, (module X));
       H (Datagram_socket, (module X));
       H (Resource.Close, X.close)
     ]
@@ -215,7 +264,7 @@ module Pi = struct
   module type LISTENING_SOCKET = sig
     type t
     type tag
-
+    include SOCKET with type t := t
     val accept : t -> sw:Switch.t -> tag stream_socket_ty r * Sockaddr.stream
     val close : t -> unit
     val listening_addr : t -> Sockaddr.stream
@@ -227,6 +276,7 @@ module Pi = struct
   let listening_socket (type t tag) (module X : LISTENING_SOCKET with type t = t and type tag = tag) =
     Resource.handler [
       H (Resource.Close, X.close);
+      H (Socket, (module X));
       H (Listening_socket, (module X))
     ]
 
@@ -277,6 +327,20 @@ let accept_fork ~sw (t : [> 'a listening_socket_ty] r) ~on_error handle =
              on_error (Exn.add_context ex "handling connection from %a" Sockaddr.pp addr)
          )
     )
+
+let setsockopt (Resource.T (t, ops)) opt v =
+  let module X = (val (Resource.get ops Pi.Socket)) in
+  try X.setsockopt t opt v
+  with Exn.Io _ as ex ->
+    let bt = Printexc.get_raw_backtrace () in
+    Exn.reraise_with_context ex bt "setting socket option %a" Sockopt.pp_binding (opt, v)
+
+let getsockopt (Resource.T (t, ops)) opt =
+  let module X = (val (Resource.get ops Pi.Socket)) in
+  try X.getsockopt t opt
+  with Exn.Io _ as ex ->
+    let bt = Printexc.get_raw_backtrace () in
+    Exn.reraise_with_context ex bt "getting socket option %a" Sockopt.pp opt
 
 let listening_addr (type tag) (Resource.T (t, ops) : [> tag listening_socket_ty] r) =
   let module X = (val (Resource.get ops Pi.Listening_socket)) in

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -23,6 +23,7 @@ type error =
     (** This is a wrapper for epipe, econnreset and similar errors.
         It indicates that the flow has failed, and data may have been lost. *)
   | Connection_failure of connection_failure
+  | Invalid_option (** Option not supported by backend. *)
 
 type Exn.err += E of error
 
@@ -126,6 +127,47 @@ type 'tag ty = [`Network | `Platform of 'tag]
 
 type 'a t = 'a r
   constraint 'a = [> [> `Generic] ty]
+
+(** {2 Socket options} *)
+
+module Sockopt : sig
+  (** An extensible type for socket options. Portable options can be defined
+      here, while platform-specific options can be added by backends.
+
+      @since 1.4 *)
+
+  type _ t = ..
+
+  val pp : 'a t Fmt.t
+  val pp_binding : ('a t * 'a) Fmt.t
+
+  (** {2 Registering printers (for backend use only)} *)
+
+  type printer_fn = {
+    get : 'a. 'a t -> (string * 'a Fmt.t) option
+  } [@@unboxed]
+
+  val register_printer : printer_fn -> unit
+  (** [register_printer { get }] adds [get] to the list of printers.
+
+      If called with an option it recognises, it should return the option's name
+      and a printer for values of the appropriate type. If the option isn't known,
+      return [None]. *)
+end
+
+val setsockopt : [> `Socket] r -> 'a Sockopt.t -> 'a -> unit
+(** [setsockopt s opt v] sets socket option [opt] to value [v] on socket [s].
+
+    @raise Eio.Io if the operating system rejects the option for this socket.
+
+    @since 1.4 *)
+
+val getsockopt : [> `Socket] r -> 'a Sockopt.t -> 'a
+(** [getsockopt s opt] gets the value of socket option [opt] on socket [s].
+
+    @raise Eio.Io if the operating system rejects the option for this socket.
+
+    @since 1.4 *)
 
 (** {2 Out-bound Connections} *)
 
@@ -304,11 +346,18 @@ val close : [> `Close] r -> unit
 (** {2 Provider Interface} *)
 
 module Pi : sig
+  module type SOCKET = sig
+    type t
+    val setsockopt : t -> 'a Sockopt.t -> 'a -> unit
+    val getsockopt : t -> 'a Sockopt.t -> 'a
+  end
+
   module type STREAM_SOCKET = sig
     type tag
     include Flow.Pi.SHUTDOWN
     include Flow.Pi.SOURCE with type t := t
     include Flow.Pi.SINK with type t := t
+    include SOCKET with type t := t
     val close : t -> unit
   end
 
@@ -319,6 +368,7 @@ module Pi : sig
   module type DATAGRAM_SOCKET = sig
     type tag
     include Flow.Pi.SHUTDOWN
+    include SOCKET with type t := t
     val send : t -> ?dst:Sockaddr.datagram -> Cstruct.t list -> unit
     val recv : t -> Cstruct.t -> Sockaddr.datagram * int
     val close : t -> unit
@@ -331,7 +381,7 @@ module Pi : sig
   module type LISTENING_SOCKET = sig
     type t
     type tag
-
+    include SOCKET with type t := t
     val accept : t -> sw:Switch.t -> tag stream_socket_ty r * Sockaddr.stream
     val close : t -> unit
     val listening_addr : t -> Sockaddr.stream

--- a/lib_eio/unix/net.ml
+++ b/lib_eio/unix/net.ml
@@ -91,3 +91,55 @@ let socketpair_datagram ~sw ?(domain=Unix.PF_UNIX) ?(protocol=0) () =
 
 let fd socket =
   Option.get (Resource.fd_opt socket)
+
+type _ Eio.Net.Sockopt.t +=
+  | Sockopt_bool : Unix.socket_bool_option -> bool Eio.Net.Sockopt.t
+  | Sockopt_int : Unix.socket_int_option -> int Eio.Net.Sockopt.t
+  | Sockopt_optint : Unix.socket_optint_option -> int option Eio.Net.Sockopt.t
+  | Sockopt_float : Unix.socket_float_option -> float Eio.Net.Sockopt.t
+
+let () =
+  let get : type a. a Eio.Net.Sockopt.t -> (string * a Fmt.t) option = function
+    | Sockopt_bool SO_DEBUG -> Some ("Unix.SO_DEBUG", Fmt.bool)
+    | Sockopt_bool SO_BROADCAST -> Some ("Unix.SO_BROADCAST", Fmt.bool)
+    | Sockopt_bool SO_REUSEADDR -> Some ("Unix.SO_REUSEADDR", Fmt.bool)
+    | Sockopt_bool SO_KEEPALIVE -> Some ("Unix.SO_KEEPALIVE", Fmt.bool)
+    | Sockopt_bool SO_DONTROUTE -> Some ("Unix.SO_DONTROUTE", Fmt.bool)
+    | Sockopt_bool SO_OOBINLINE -> Some ("Unix.SO_OOBINLINE", Fmt.bool)
+    | Sockopt_bool SO_ACCEPTCONN -> Some ("Unix.SO_ACCEPTCONN", Fmt.bool)
+    | Sockopt_bool TCP_NODELAY -> Some ("Unix.TCP_NODELAY", Fmt.bool)
+    | Sockopt_bool IPV6_ONLY -> Some ("Unix.IPV6_ONLY", Fmt.bool)
+    | Sockopt_bool SO_REUSEPORT -> Some ("Unix.SO_REUSEPORT", Fmt.bool)
+    | Sockopt_int SO_SNDBUF -> Some ("Unix.SO_SNDBUF", Fmt.int)
+    | Sockopt_int SO_RCVBUF -> Some ("Unix.SO_RCVBUF", Fmt.int)
+    | Sockopt_int SO_ERROR -> Some ("Unix.SO_ERROR", Fmt.int)
+    | Sockopt_int SO_TYPE -> Some ("Unix.SO_TYPE", Fmt.int)
+    | Sockopt_int SO_RCVLOWAT -> Some ("Unix.SO_RCVLOWAT", Fmt.int)
+    | Sockopt_int SO_SNDLOWAT -> Some ("Unix.SO_SNDLOWAT", Fmt.int)
+    | Sockopt_optint SO_LINGER -> Some ("Unix.SO_LINGER", Fmt.(option ~none:(any "<none>") int))
+    | Sockopt_float SO_RCVTIMEO -> Some ("Unix.SO_RCVTIMEO", Fmt.float)
+    | Sockopt_float SO_SNDTIMEO -> Some ("Unix.SO_SNDTIMEO", Fmt.float)
+    | _ -> None
+  [@@alert "-deprecated"]
+  in
+  Eio.Net.Sockopt.register_printer { get }
+
+let setsockopt : type a. Fd.t -> a Eio.Net.Sockopt.t -> a -> unit = fun fd opt v ->
+  Fd.use_exn "setsockopt" fd @@ fun fd ->
+  match opt with
+  | Sockopt_bool bo -> Unix.setsockopt fd bo v
+  | Sockopt_int bo -> Unix.setsockopt_int fd bo v
+  | Sockopt_optint bo -> Unix.setsockopt_optint fd bo v
+  | Sockopt_float bo -> Unix.setsockopt_float fd bo v
+  | _ -> raise (Eio.Net.err Invalid_option)
+
+let getsockopt_descr : type a. Unix.file_descr -> a Eio.Net.Sockopt.t -> a = fun fd opt ->
+  match opt with
+  | Sockopt_bool bo -> Unix.getsockopt fd bo
+  | Sockopt_int bo -> Unix.getsockopt_int fd bo
+  | Sockopt_optint bo -> Unix.getsockopt_optint fd bo
+  | Sockopt_float bo -> Unix.getsockopt_float fd bo
+  | _ -> raise (Eio.Net.err Invalid_option)
+
+let getsockopt : type a. Fd.t -> a Eio.Net.Sockopt.t -> a = fun fd opt ->
+  Fd.use_exn "getsockopt" fd @@ fun fd -> getsockopt_descr fd opt

--- a/lib_eio/unix/net.mli
+++ b/lib_eio/unix/net.mli
@@ -99,6 +99,20 @@ val socketpair_datagram :
     This creates OS-level resources using [socketpair(2)].
     Note that, like all FDs created by Eio, they are both marked as close-on-exec by default. *)
 
+(** {2 Socket options} *)
+
+(** Generic wrappers for Unix socket options.
+    This extends {!Eio.Net.Sockopt} with support for any Unix socket option. *)
+type _ Eio.Net.Sockopt.t +=
+  | Sockopt_bool : Unix.socket_bool_option -> bool Eio.Net.Sockopt.t
+      (** Wrap any Unix boolean socket option *)
+  | Sockopt_int : Unix.socket_int_option -> int Eio.Net.Sockopt.t
+      (** Wrap any Unix integer socket option *)
+  | Sockopt_optint : Unix.socket_optint_option -> int option Eio.Net.Sockopt.t
+      (** Wrap any Unix optional integer socket option *)
+  | Sockopt_float : Unix.socket_float_option -> float Eio.Net.Sockopt.t
+      (** Wrap any Unix float socket option *)
+
 (** {2 Private API for backends} *)
 
 val getnameinfo : Eio.Net.Sockaddr.t -> (string * string)
@@ -116,3 +130,17 @@ type _ Effect.t +=
   | Socketpair_datagram : Eio.Switch.t * Unix.socket_domain * int ->
       ([`Unix_fd | datagram_socket_ty] r * [`Unix_fd | datagram_socket_ty] r) Effect.t  (** See {!socketpair_datagram} *)
 [@@alert "-unstable"]
+
+val setsockopt : Fd.t -> 'a Eio.Net.Sockopt.t -> 'a -> unit
+(** [setsockopt fd opt v] sets socket option [opt] to value [v] on file descriptor [fd].
+
+    Note: for an {!Eio.Net.socket}, use {!Eio.Net.setsockopt}.
+
+    @since 1.4 *)
+
+val getsockopt : Fd.t -> 'a Eio.Net.Sockopt.t -> 'a
+(** [getsockopt fd opt] gets the value of socket option [opt] on file descriptor [fd].
+
+    Note: for an {!Eio.Net.socket}, use {!Eio.Net.getsockopt}.
+
+    @since 1.4 *)

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -62,6 +62,9 @@ module Datagram_socket = struct
     | `Receive -> Unix.SHUTDOWN_RECEIVE
     | `Send -> Unix.SHUTDOWN_SEND
     | `All -> Unix.SHUTDOWN_ALL
+
+  let setsockopt = Low_level.setsockopt
+  let getsockopt = Low_level.getsockopt
 end
 
 let datagram_handler = Eio_unix.Pi.datagram_handler (module Datagram_socket)
@@ -91,6 +94,9 @@ module Listening_socket = struct
   let listening_addr fd =
     Eio_unix.Fd.use_exn "listening_addr" fd
       (fun fd -> Eio_unix.Net.sockaddr_of_unix_stream (Unix.getsockname fd))
+
+  let setsockopt = Low_level.setsockopt
+  let getsockopt = Low_level.getsockopt
 end
 
 let listening_handler = Eio_unix.Pi.listening_socket_handler (module Listening_socket)

--- a/lib_eio_linux/err.ml
+++ b/lib_eio_linux/err.ml
@@ -14,3 +14,8 @@ let wrap_fs code name arg =
   | Unix.ENOENT -> Eio.Fs.err (Not_found e)
   | Unix.EXDEV | EPERM | EACCES -> Eio.Fs.err (Permission_denied e)
   | _ -> wrap code name arg
+
+let run fn x =
+  try fn x
+  with Unix.Unix_error (code, name, arg) ->
+    raise (wrap code name arg)

--- a/lib_eio_linux/flow.ml
+++ b/lib_eio_linux/flow.ml
@@ -130,6 +130,9 @@ module Impl = struct
   let seek = Low_level.lseek
   let sync = Low_level.fsync
   let truncate = Low_level.ftruncate
+
+  let setsockopt = Low_level.setsockopt
+  let getsockopt = Low_level.getsockopt
 end
 
 let flow_handler = Eio_unix.Pi.flow_handler (module Impl)

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -327,6 +327,9 @@ let recv_msg_with_fds ~sw ~max_fds fd buf =
   let fds = Uring.Msghdr.get_fds msghdr |> Fd.of_unix_list ~sw in
   addr, res, fds
 
+let setsockopt t opt v = Err.run (Eio_unix.Net.setsockopt t opt) v
+let getsockopt t opt = Err.run (Eio_unix.Net.getsockopt t) opt
+
 let rec openat2 ~sw ?seekable ~access ~flags ~perm ~resolve ?dir path =
   let use dir_opt =
     let res = Sched.enter "openat2" (enqueue_openat2 (access, flags, perm, resolve, dir_opt, path)) in

--- a/lib_eio_linux/low_level.mli
+++ b/lib_eio_linux/low_level.mli
@@ -229,6 +229,12 @@ val recv_msg_with_fds : sw:Switch.t -> max_fds:int -> fd -> Cstruct.t list -> Ur
 (** [recv_msg_with_fds] is like [recv_msg] but also allows receiving up to [max_fds] file descriptors
     (sent using SCM_RIGHTS over a Unix domain socket). *)
 
+val setsockopt : fd -> 'a Eio.Net.Sockopt.t -> 'a -> unit
+(** [setsockopt fd opt v] sets socket option [opt] to value [v] on file descriptor [fd]. *)
+
+val getsockopt : fd -> 'a Eio.Net.Sockopt.t -> 'a
+(** [getsockopt fd opt] gets the value of socket option [opt] on file descriptor [fd]. *)
+
 (** {1 Randomness} *)
 
 val getrandom : Cstruct.t -> unit

--- a/lib_eio_posix/flow.ml
+++ b/lib_eio_posix/flow.ml
@@ -120,6 +120,9 @@ module Impl = struct
   let fd t = t
 
   let close = Eio_unix.Fd.close
+
+  let setsockopt t opt v = Err.run (Eio_unix.Net.setsockopt t opt) v
+  let getsockopt t opt = Err.run (Eio_unix.Net.getsockopt t) opt
 end
 
 let handler = Eio_unix.Pi.flow_handler (module Impl)

--- a/lib_eio_posix/net.ml
+++ b/lib_eio_posix/net.ml
@@ -40,6 +40,9 @@ module Listening_socket = struct
   let listening_addr { fd; _ } =
     Eio_unix.Fd.use_exn "listening_addr" fd
       (fun fd -> Eio_unix.Net.sockaddr_of_unix_stream (Unix.getsockname fd))
+
+  let setsockopt t opt v = Err.run (Eio_unix.Net.setsockopt t.fd opt) v
+  let getsockopt t opt = Err.run (Eio_unix.Net.getsockopt t.fd) opt
 end
 
 let listening_handler = Eio_unix.Pi.listening_socket_handler (module Listening_socket)
@@ -74,6 +77,9 @@ module Datagram_socket = struct
     with
     | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
     | Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+
+  let setsockopt t opt v = Err.run (Eio_unix.Net.setsockopt t opt) v
+  let getsockopt t opt = Err.run (Eio_unix.Net.getsockopt t) opt
 end
 
 let datagram_handler = Eio_unix.Pi.datagram_handler (module Datagram_socket)

--- a/lib_eio_windows/flow.ml
+++ b/lib_eio_windows/flow.ml
@@ -83,6 +83,9 @@ module Impl = struct
   let fd t = t
 
   let close = Eio_unix.Fd.close
+
+  let setsockopt t opt v = Err.run (Eio_unix.Net.setsockopt t opt) v
+  let getsockopt t opt = Err.run (Eio_unix.Net.getsockopt t) opt
 end
 
 let handler = Eio_unix.Pi.flow_handler (module Impl)

--- a/lib_eio_windows/net.ml
+++ b/lib_eio_windows/net.ml
@@ -40,6 +40,9 @@ module Listening_socket = struct
   let listening_addr { fd; _ } =
     Eio_unix.Fd.use_exn "listening_addr" fd
       (fun fd -> Eio_unix.Net.sockaddr_of_unix_stream (Unix.getsockname fd))
+
+  let setsockopt t opt v = Err.run (Eio_unix.Net.setsockopt t.fd opt) v
+  let getsockopt t opt = Err.run (Eio_unix.Net.getsockopt t.fd) opt
 end
 
 let listening_handler = Eio_unix.Pi.listening_socket_handler (module Listening_socket)
@@ -76,6 +79,9 @@ module Datagram_socket = struct
     with
     | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
     | Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+
+  let setsockopt t opt v = Err.run (Eio_unix.Net.setsockopt t opt) v
+  let getsockopt t opt = Err.run (Eio_unix.Net.getsockopt t) opt
 end
 
 let datagram_handler = Eio_unix.Pi.datagram_handler (module Datagram_socket)

--- a/tests/network.md
+++ b/tests/network.md
@@ -564,6 +564,42 @@ Exception: Eio.Io Fs Not_found _,
 - : unit = ()
 ```
 
+## Socket Options
+
+```ocaml
+let try_getsockopt sock opt =
+  match Eio.Net.getsockopt sock opt with
+  | v -> traceln "%a" Eio.Net.Sockopt.pp_binding (opt, v)
+  | exception ex -> traceln "%a -> %a" Eio.Net.Sockopt.pp opt Fmt.exn ex
+```
+
+Test Unix-specific socket option wrappers:
+
+```ocaml
+# Eio_main.run @@ fun _ ->
+  Switch.run @@ fun sw ->
+  let a, b = Eio_unix.Net.socketpair_stream ~sw () in
+  Eio.Net.setsockopt a (Eio_unix.Net.Sockopt_int SO_SNDBUF) 32768;
+  let sndbuf = Eio.Net.getsockopt a (Eio_unix.Net.Sockopt_int Unix.SO_SNDBUF) in
+  traceln "Unix SO_SNDBUF: %s" (if sndbuf > 0 then "positive" else "zero");
+  assert (sndbuf > 0);
+  Eio.Net.setsockopt a (Eio_unix.Net.Sockopt_optint SO_LINGER) (Some 5);
+  try_getsockopt a (Eio_unix.Net.Sockopt_optint SO_LINGER);;
++Unix SO_SNDBUF: positive
++Unix.SO_LINGER = 5
+- : unit = ()
+```
+
+Unknown options report `Invalid_option`:
+
+```ocaml
+# Eio_mock.Backend.run @@ fun () ->
+  let ls = Eio_mock.Net.listening_socket "socket" in
+  Eio.Net.getsockopt ls (Eio_unix.Net.Sockopt_optint SO_LINGER);;
+Exception: Eio.Io Net Invalid_option,
+  getting socket option Unix.SO_LINGER
+```
+
 ## Getaddrinfo
 
 ```ocaml


### PR DESCRIPTION
This adds a `Eio.Net.Sockopt.t` extensible variant for socket options.

This is based on @avsm's #575. To make review easier, I removed all the portable options. I'll rebase that PR on this one next. Other changes from #575:

- In `Eio.Net`, `Sockopt` is the type and the functions are outside as e.g. `getsockopt`, but elsewhere we had e.g. `Eio_unix.Net.Sockaddr.get`. I changed everything to use the `getsockopt` pattern.
- Before, you had to call the correct pretty-printer depending on the option. Here, I added a `register_printer` function so it works like OCaml's exception printers: `Eio.Net.Sockopt.pp` now works everywhere.
- `pp` now just prints the name. `pp_binding` shows the value too.
- Trying to set or get an option that isn't supported now raises `Io Net Invalid_option`. Before it raised `Invalid_argument` ("the given arguments do not make sense"), but it's not a programming bug to try to set an option that isn't supported.
- I added error context to getters and setters so you can see what it was trying to set on error.
- The documentation and examples implied that you should use `Eio.Net.setsockopt` for portable options and `Eio_unix.Net.Sockopt.set` for Unix-specific ones, but this is misleading. `Eio.Net.setsockopt` works for both; the `Eio_unix` function is just to handle common options for backends.