### PR TITLE
Add portable names for common network options

### DIFF
--- a/lib_eio/mock/sockopt.ml
+++ b/lib_eio/mock/sockopt.ml
@@ -1,4 +1,29 @@
 open Eio.Std
 
 let setsockopt label opt v = traceln "%s: setsockopt %a" label Eio.Net.Sockopt.pp_binding (opt, v)
-let getsockopt _label _opt = raise (Eio.Net.err Invalid_option)
+
+let default (type a) (opt : a Eio.Net.Sockopt.t) : a =
+  let open Eio.Net.Sockopt in
+  match opt with
+  | SO_DEBUG -> false
+  | SO_BROADCAST -> false
+  | SO_REUSEADDR -> false
+  | SO_KEEPALIVE -> false
+  | SO_DONTROUTE -> false
+  | SO_OOBINLINE -> false
+  | TCP_NODELAY -> false
+  | IPV6_ONLY -> false
+  | SO_REUSEPORT -> false
+  | SO_SNDBUF -> 0
+  | SO_RCVBUF -> 0
+  | SO_RCVLOWAT -> 0
+  | SO_SNDLOWAT -> 0
+  | SO_LINGER -> None
+  | SO_RCVTIMEO -> 0.0
+  | SO_SNDTIMEO -> 0.0
+  | _ -> raise (Eio.Net.err Invalid_option)
+
+let getsockopt : type a. string -> a Eio.Net.Sockopt.t -> a = fun label opt ->
+  let v = default opt in
+  traceln "%s: getsockopt %a" label Eio.Net.Sockopt.pp_binding (opt, v);
+  v

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -193,6 +193,46 @@ module Sockopt = struct
   let pp_binding f (opt, v) =
     let name, pp = find_printer opt in
     Fmt.pf f "%s = %a" name pp v
+
+  type _ t +=
+    | SO_DEBUG : bool t
+    | SO_BROADCAST : bool t
+    | SO_REUSEADDR : bool t
+    | SO_KEEPALIVE : bool t
+    | SO_DONTROUTE : bool t
+    | SO_OOBINLINE : bool t
+    | TCP_NODELAY : bool t
+    | IPV6_ONLY : bool t
+    | SO_REUSEPORT : bool t
+    | SO_SNDBUF : int t
+    | SO_RCVBUF : int t
+    | SO_RCVLOWAT : int t
+    | SO_SNDLOWAT : int t
+    | SO_LINGER : int option t
+    | SO_RCVTIMEO : float t
+    | SO_SNDTIMEO : float t
+
+  let () =
+    let get : type a. a t -> (string * a Fmt.t) option = function
+      | SO_DEBUG -> Some ("SO_DEBUG", Fmt.bool)
+      | SO_BROADCAST -> Some ("SO_BROADCAST", Fmt.bool)
+      | SO_REUSEADDR -> Some ("SO_REUSEADDR", Fmt.bool)
+      | SO_KEEPALIVE -> Some ("SO_KEEPALIVE", Fmt.bool)
+      | SO_DONTROUTE -> Some ("SO_DONTROUTE", Fmt.bool)
+      | SO_OOBINLINE -> Some ("SO_OOBINLINE", Fmt.bool)
+      | TCP_NODELAY -> Some ("TCP_NODELAY", Fmt.bool)
+      | IPV6_ONLY -> Some ("IPV6_ONLY", Fmt.bool)
+      | SO_REUSEPORT -> Some ("SO_REUSEPORT", Fmt.bool)
+      | SO_SNDBUF -> Some ("SO_SNDBUF", Fmt.int)
+      | SO_RCVBUF -> Some ("SO_RCVBUF", Fmt.int)
+      | SO_RCVLOWAT -> Some ("SO_RCVLOWAT", Fmt.int)
+      | SO_SNDLOWAT -> Some ("SO_SNDLOWAT", Fmt.int)
+      | SO_LINGER -> Some ("SO_LINGER", Fmt.(option ~none:(any "<none>") int))
+      | SO_RCVTIMEO -> Some ("SO_RCVTIMEO", Fmt.float)
+      | SO_SNDTIMEO -> Some ("SO_SNDTIMEO", Fmt.float)
+      | _ -> None
+    in
+    register_printer { get }
 end
 
 type socket_ty = [`Socket | `Close]

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -138,6 +138,24 @@ module Sockopt : sig
 
   type _ t = ..
 
+  type _ t +=
+    | SO_DEBUG : bool t         (** Enable socket debugging *)
+    | SO_BROADCAST : bool t     (** Permit sending of broadcast messages *)
+    | SO_REUSEADDR : bool t     (** Allow reuse of local addresses *)
+    | SO_KEEPALIVE : bool t     (** Keep TCP connection alive *)
+    | SO_DONTROUTE : bool t     (** Bypass routing tables *)
+    | SO_OOBINLINE : bool t     (** Leave out-of-band data in line *)
+    | TCP_NODELAY : bool t      (** Disable Nagle's algorithm *)
+    | IPV6_ONLY : bool t        (** Restrict to IPv6 only *)
+    | SO_REUSEPORT : bool t     (** Allow reuse of local port *)
+    | SO_SNDBUF : int t         (** Send buffer size *)
+    | SO_RCVBUF : int t         (** Receive buffer size *)
+    | SO_RCVLOWAT : int t       (** Receive low water mark *)
+    | SO_SNDLOWAT : int t       (** Send low water mark *)
+    | SO_LINGER : int option t  (** Linger on close if data present *)
+    | SO_RCVTIMEO : float t     (** Receive timeout *)
+    | SO_SNDTIMEO : float t     (** Send timeout *)
+
   val pp : 'a t Fmt.t
   val pp_binding : ('a t * 'a) Fmt.t
 

--- a/lib_eio/unix/net.ml
+++ b/lib_eio/unix/net.ml
@@ -127,6 +127,22 @@ let () =
 let setsockopt : type a. Fd.t -> a Eio.Net.Sockopt.t -> a -> unit = fun fd opt v ->
   Fd.use_exn "setsockopt" fd @@ fun fd ->
   match opt with
+  | Eio.Net.Sockopt.SO_DEBUG -> Unix.setsockopt fd Unix.SO_DEBUG v
+  | Eio.Net.Sockopt.SO_BROADCAST -> Unix.setsockopt fd Unix.SO_BROADCAST v
+  | Eio.Net.Sockopt.SO_REUSEADDR -> Unix.setsockopt fd Unix.SO_REUSEADDR v
+  | Eio.Net.Sockopt.SO_KEEPALIVE -> Unix.setsockopt fd Unix.SO_KEEPALIVE v
+  | Eio.Net.Sockopt.SO_DONTROUTE -> Unix.setsockopt fd Unix.SO_DONTROUTE v
+  | Eio.Net.Sockopt.SO_OOBINLINE -> Unix.setsockopt fd Unix.SO_OOBINLINE v
+  | Eio.Net.Sockopt.TCP_NODELAY -> Unix.setsockopt fd Unix.TCP_NODELAY v
+  | Eio.Net.Sockopt.IPV6_ONLY -> Unix.setsockopt fd Unix.IPV6_ONLY v
+  | Eio.Net.Sockopt.SO_REUSEPORT -> Unix.setsockopt fd Unix.SO_REUSEPORT v
+  | Eio.Net.Sockopt.SO_SNDBUF -> Unix.setsockopt_int fd Unix.SO_SNDBUF v
+  | Eio.Net.Sockopt.SO_RCVBUF -> Unix.setsockopt_int fd Unix.SO_RCVBUF v
+  | Eio.Net.Sockopt.SO_RCVLOWAT -> Unix.setsockopt_int fd Unix.SO_RCVLOWAT v
+  | Eio.Net.Sockopt.SO_SNDLOWAT -> Unix.setsockopt_int fd Unix.SO_SNDLOWAT v
+  | Eio.Net.Sockopt.SO_LINGER -> Unix.setsockopt_optint fd Unix.SO_LINGER v
+  | Eio.Net.Sockopt.SO_RCVTIMEO -> Unix.setsockopt_float fd Unix.SO_RCVTIMEO v
+  | Eio.Net.Sockopt.SO_SNDTIMEO -> Unix.setsockopt_float fd Unix.SO_SNDTIMEO v
   | Sockopt_bool bo -> Unix.setsockopt fd bo v
   | Sockopt_int bo -> Unix.setsockopt_int fd bo v
   | Sockopt_optint bo -> Unix.setsockopt_optint fd bo v
@@ -135,6 +151,22 @@ let setsockopt : type a. Fd.t -> a Eio.Net.Sockopt.t -> a -> unit = fun fd opt v
 
 let getsockopt_descr : type a. Unix.file_descr -> a Eio.Net.Sockopt.t -> a = fun fd opt ->
   match opt with
+  | Eio.Net.Sockopt.SO_DEBUG -> Unix.getsockopt fd Unix.SO_DEBUG
+  | Eio.Net.Sockopt.SO_BROADCAST -> Unix.getsockopt fd Unix.SO_BROADCAST
+  | Eio.Net.Sockopt.SO_REUSEADDR -> Unix.getsockopt fd Unix.SO_REUSEADDR
+  | Eio.Net.Sockopt.SO_KEEPALIVE -> Unix.getsockopt fd Unix.SO_KEEPALIVE
+  | Eio.Net.Sockopt.SO_DONTROUTE -> Unix.getsockopt fd Unix.SO_DONTROUTE
+  | Eio.Net.Sockopt.SO_OOBINLINE -> Unix.getsockopt fd Unix.SO_OOBINLINE
+  | Eio.Net.Sockopt.TCP_NODELAY -> Unix.getsockopt fd Unix.TCP_NODELAY
+  | Eio.Net.Sockopt.IPV6_ONLY -> Unix.getsockopt fd Unix.IPV6_ONLY
+  | Eio.Net.Sockopt.SO_REUSEPORT -> Unix.getsockopt fd Unix.SO_REUSEPORT
+  | Eio.Net.Sockopt.SO_SNDBUF -> Unix.getsockopt_int fd Unix.SO_SNDBUF
+  | Eio.Net.Sockopt.SO_RCVBUF -> Unix.getsockopt_int fd Unix.SO_RCVBUF
+  | Eio.Net.Sockopt.SO_RCVLOWAT -> Unix.getsockopt_int fd Unix.SO_RCVLOWAT
+  | Eio.Net.Sockopt.SO_SNDLOWAT -> Unix.getsockopt_int fd Unix.SO_SNDLOWAT
+  | Eio.Net.Sockopt.SO_LINGER -> Unix.getsockopt_optint fd Unix.SO_LINGER
+  | Eio.Net.Sockopt.SO_RCVTIMEO -> Unix.getsockopt_float fd Unix.SO_RCVTIMEO
+  | Eio.Net.Sockopt.SO_SNDTIMEO -> Unix.getsockopt_float fd Unix.SO_SNDTIMEO
   | Sockopt_bool bo -> Unix.getsockopt fd bo
   | Sockopt_int bo -> Unix.getsockopt_int fd bo
   | Sockopt_optint bo -> Unix.getsockopt_optint fd bo

--- a/tests/network.md
+++ b/tests/network.md
@@ -573,6 +573,53 @@ let try_getsockopt sock opt =
   | exception ex -> traceln "%a -> %a" Eio.Net.Sockopt.pp opt Fmt.exn ex
 ```
 
+Test portable socket options on a TCP socket:
+
+```ocaml
+# run @@ fun ~net sw ->
+  let server = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:5 addr in
+  let client = Eio.Net.connect ~sw net (Eio.Net.listening_addr server) in
+  Eio.Net.setsockopt client Eio.Net.Sockopt.TCP_NODELAY true;
+  assert (Eio.Net.getsockopt client Eio.Net.Sockopt.TCP_NODELAY);
+  Eio.Net.setsockopt client Eio.Net.Sockopt.SO_KEEPALIVE true;
+  assert (Eio.Net.getsockopt client Eio.Net.Sockopt.SO_KEEPALIVE);
+  Eio.Net.setsockopt client Eio.Net.Sockopt.SO_SNDBUF 32768;
+  let sndbuf = Eio.Net.getsockopt client Eio.Net.Sockopt.SO_SNDBUF in
+  traceln "SO_SNDBUF: %s" (if sndbuf > 0 then "positive" else "error");
+  assert (sndbuf > 0);
+  Eio.Net.setsockopt client Eio.Net.Sockopt.SO_LINGER (Some 10);
+  try_getsockopt client Eio.Net.Sockopt.SO_LINGER;
+  Eio.Net.setsockopt client Eio.Net.Sockopt.SO_RCVTIMEO 5.0;
+  let timeout = Eio.Net.getsockopt client Eio.Net.Sockopt.SO_RCVTIMEO in
+  traceln "SO_RCVTIMEO: %.1f seconds" timeout;;
++SO_SNDBUF: positive
++SO_LINGER = 10
++SO_RCVTIMEO: 5.0 seconds
+- : unit = ()
+```
+
+Test socket options on listening socket:
+
+```ocaml
+# run @@ fun ~net sw ->
+  let server = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:5 addr in
+  Eio.Net.setsockopt server Eio.Net.Sockopt.SO_REUSEADDR true;
+  try_getsockopt server Eio.Net.Sockopt.SO_REUSEADDR;;
++SO_REUSEADDR = true
+- : unit = ()
+```
+
+Test socket options on datagram socket:
+
+```ocaml
+# run @@ fun ~net sw ->
+  let udp = Eio.Net.datagram_socket net ~sw `UdpV4 in
+  Eio.Net.setsockopt udp Eio.Net.Sockopt.SO_BROADCAST true;
+  try_getsockopt udp Eio.Net.Sockopt.SO_BROADCAST;;
++SO_BROADCAST = true
+- : unit = ()
+```
+
 Test Unix-specific socket option wrappers:
 
 ```ocaml


### PR DESCRIPTION
This is the next part of @avsm's https://github.com/ocaml-multicore/eio/pull/575 PR.

It adds `Eio.Net.Sockopt.TCP_NODELAY` etc, since these options are also useful outside of Unix processes (e.g. in unikernels or mocks). This is also a nicer API (`Unix`'s API predates GADTs).

Closes #376 and #322.