### PR TITLE
eio_windows: fix removing of FDs from read/write sets

### DIFF
--- a/lib_eio_windows/sched.ml
+++ b/lib_eio_windows/sched.ml
@@ -132,8 +132,12 @@ let update t waiters fd =
       t.poll.to_write <- FdSet.remove fd t.poll.to_write;
       Hashtbl.remove t.fd_map fd
     )
-  | `R -> t.poll.to_read <- FdSet.add fd t.poll.to_read
-  | `W -> t.poll.to_write <- FdSet.add fd t.poll.to_write
+  | `R ->
+    t.poll.to_read <- FdSet.add fd t.poll.to_read;
+    t.poll.to_write <- FdSet.remove fd t.poll.to_write
+  | `W ->
+    t.poll.to_read <- FdSet.remove fd t.poll.to_read;
+    t.poll.to_write <- FdSet.add fd t.poll.to_write
   | `RW ->
     t.poll.to_read <- FdSet.add fd t.poll.to_read;
     t.poll.to_write <- FdSet.add fd t.poll.to_write


### PR DESCRIPTION
When an FD was being waited on for both reading and writing and is now only being used for one them, we need to remove it from the other set.

Fixes #837, which is where I took this fix from. I haven't tested it, but it looks correct.

(This function could be cleaned up a bit if someone with a Windows machine wants to have a go - combining the read and write flags into a single value and then having a 4-way match is silly)

/cc @z-rui