### PR TITLE
Fix follow/nofollow confusion in chown

### DIFF
--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -133,8 +133,8 @@ module Private : sig
   val read_link_unix : Unix.file_descr option -> string -> string
   val chmod : Fd.t -> string -> flags:int -> mode:int -> unit
   val chmod_unix : Unix.file_descr -> string -> flags:int -> mode:int -> unit
-  val chown : flags:int -> uid:int64 -> gid:int64 -> Fd.t -> string -> unit
-  val chown_unix : flags:int -> uid:int64 -> gid:int64 -> Unix.file_descr -> string -> unit
+  val chown : follow:bool -> uid:int64 -> gid:int64 -> Fd.t -> string -> unit
+  val chown_unix : follow:bool -> uid:int64 -> gid:int64 -> Unix.file_descr -> string -> unit
 end
 
 module Pi = Pi

--- a/lib_eio/unix/eio_unix_stubs.c
+++ b/lib_eio/unix/eio_unix_stubs.c
@@ -92,20 +92,21 @@ CAMLprim value eio_unix_fchmodat(value v_fd, value v_path, value v_mode, value v
   #endif
 }
 
-CAMLprim value eio_unix_fchownat(value v_fd, value v_path, value v_uid, value v_gid, value v_flags) {
+CAMLprim value eio_unix_fchownat(value v_fd, value v_path, value v_uid, value v_gid, value v_follow) {
 #ifdef _WIN32
   caml_unix_error(EOPNOTSUPP, "fchownat not supported on Windows", v_path);
 #else
   CAMLparam3(v_path, v_uid, v_gid);
   char *path;
   int fd = Int_val(v_fd);
+  int flags = Bool_val(v_follow) ? 0 : AT_SYMLINK_NOFOLLOW;
   uid_t uid = Int64_val(v_uid);
   gid_t gid = Int64_val(v_gid);
   int ret;
   caml_unix_check_path(v_path, "fchownat");
   path = caml_stat_strdup(String_val(v_path));
   caml_enter_blocking_section();
-  ret = fchownat(fd, path, uid, gid, Int_val(v_flags));
+  ret = fchownat(fd, path, uid, gid, flags);
   caml_leave_blocking_section();
   caml_stat_free_preserving_errno(path);
   if (ret == -1)

--- a/lib_eio/unix/private.ml
+++ b/lib_eio/unix/private.ml
@@ -45,10 +45,10 @@ let chmod_unix fd path ~flags ~mode = eio_fchmodat fd path mode flags
 let chmod fd path ~flags ~mode =
   Fd.use_exn "chmod" fd (fun fd -> chmod_unix ~flags ~mode fd path)
 
-external eio_fchownat : Unix.file_descr -> string -> int64 -> int64 -> int -> unit = "eio_unix_fchownat"
+external eio_fchownat : Unix.file_descr -> string -> int64 -> int64 -> bool -> unit = "eio_unix_fchownat"
 
-let chown_unix ~flags ~uid ~gid fd path =
-  eio_fchownat fd path uid gid flags
+let chown_unix ~follow ~uid ~gid fd path =
+  eio_fchownat fd path uid gid follow
 
-let chown ~flags ~uid ~gid fd path =
-  Fd.use_exn "chown" fd (fun fd -> chown_unix ~uid ~gid ~flags fd path)
+let chown ~follow ~uid ~gid fd path =
+  Fd.use_exn "chown" fd (fun fd -> chown_unix ~uid ~gid ~follow fd path)

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -742,12 +742,9 @@ let chmod ~follow ~mode dir path =
   with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
 
 let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) fd path =
-  let module At = Uring.Linkat_flags in
-  let follow = if follow then At.(empty_path + symlink_follow) else At.empty_path in
-  let flags = (follow :> int) in
   try
     with_parent_dir_fd fd path @@ fun parent leaf ->
-    Eio_unix.run_in_systhread ~label:"chown" (fun () -> Eio_unix.Private.chown ~flags ~uid ~gid parent leaf)
+    Eio_unix.run_in_systhread ~label:"chown" (fun () -> Eio_unix.Private.chown ~follow ~uid ~gid parent leaf)
   with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
 
 (* https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml *)

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -478,11 +478,10 @@ let read_link dirfd path =
   Eio_unix.Private.read_link_unix dirfd path
 
 let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) dirfd path =
-  let flags = if follow then 0 else Config.at_symlink_nofollow in
   in_worker_thread "chown" @@ fun () ->
   Resolve.with_parent "chown" dirfd path @@ fun dirfd path ->
   let dirfd = Option.value dirfd ~default:at_fdcwd in
-  Eio_unix.Private.chown_unix ~flags ~uid ~gid dirfd path
+  Eio_unix.Private.chown_unix ~follow ~uid ~gid dirfd path
 
 type stat
 external create_stat : unit -> stat = "caml_eio_posix_make_stat"

--- a/lib_eio_windows/low_level.ml
+++ b/lib_eio_windows/low_level.ml
@@ -146,11 +146,8 @@ let read_link ?dirfd path =
   in_worker_thread @@ fun () ->
   Eio_unix.Private.read_link dirfd path
 
-let chown ?dirfd ~follow:_ ?(uid=(-1L)) ?(gid=(-1L)) path =
-  in_worker_thread @@ fun () ->
-  match dirfd with
-  | None -> failwith "Chown is unsupported on Windows"
-  | Some dirfd -> Eio_unix.Private.chown ~flags:0 ~uid ~gid dirfd path
+let chown ?dirfd:_ ~follow:_ ?uid:_ ?gid:_ _path =
+  failwith "Chown is unsupported on Windows"
 
 external eio_readv : Unix.file_descr -> Cstruct.t array -> int = "caml_eio_windows_readv"
 

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -946,47 +946,54 @@ Reading at the end of a file:
 ```ocaml
 # run @@ fun env ->
   let cwd = Eio.Stdenv.cwd env in
-  let everyone = try Some (Unix.getgrnam "everyone") with Not_found -> None in
+  let path = cwd / "owner.txt" in
+  let link = cwd / "link.txt" in
+  let symlink = cwd / "symlink.txt" in
+
   let stat_uid_gid path =
     let stat = Eio.Path.stat ~follow:false path in
     stat.uid, stat.gid
   in
-  match everyone with
-    | None -> ()
-    | Some entry ->
-      let everybody = Int64.of_int entry.gr_gid in
+  Path.with_open_out path ~create:(`Or_truncate 0o644) ignore;
+  let uid_before, gid_before = stat_uid_gid path in
+  let othergroup =
+    let othergroups =
+      Unix.getgroups ()
+      |> Array.to_list
+      |> List.map Int64.of_int
+      |> List.filter ((<>) gid_before)
+    in
+    match othergroups with
+    | [] -> gid_before
+    | x :: _ -> x
+  in
 
-      let path = cwd / "owner.txt" in
-      let link = cwd / "link.txt" in
-      let symlink = cwd / "symlink.txt" in
+  (* Normal chown to othergroup *)
+  Eio.Path.chown ~follow:false ~uid:uid_before ~gid:othergroup path;
+  let uid_after, gid_after = stat_uid_gid path in
+  assert (uid_before = uid_after);
+  assert (gid_after = othergroup);
 
-      (* Normal chown to everyone group *)
-      Path.with_open_out path ~create:(`Or_truncate 0o644) ignore;
-      let uid_before, _gid_before = stat_uid_gid path in
-      Eio.Path.chown ~follow:false ~uid:uid_before ~gid:everybody path;
-      let uid_after, gid_after = stat_uid_gid path in
-      assert (uid_before = uid_after);
-      assert (everybody = gid_after);
+  (* Chowning through a symlink *)
+  Path.with_open_out link ~create:(`Or_truncate 0o644) ignore;
+  Eio.Path.symlink ~link_to:"link.txt" symlink;
+  let luid1, lgid1 = stat_uid_gid link in
+  let suid1, sgid1 = stat_uid_gid symlink in
 
-      (* Chowning through a symlink *)
-      Path.with_open_out link ~create:(`Or_truncate 0o644) ignore;
-      Eio.Path.symlink ~link_to:"link.txt" symlink;
-      let luid1, lgid1 = stat_uid_gid link in
-      let suid1, sgid1 = stat_uid_gid symlink in
+  (* Only chown the symlink, not the target *)
+  Eio.Path.chown ~follow:false ~gid:othergroup symlink;
+  let luid2, lgid2 = stat_uid_gid link in
+  let suid2, sgid2 = stat_uid_gid symlink in
+  assert (luid1 = luid2 && lgid1 = lgid2);
+  assert (suid1 = suid2 && sgid2 = othergroup);
 
-      (* Only chown the symlink, not the target *)
-      Eio.Path.chown ~follow:false ~gid:everybody symlink;
-      let luid2, lgid2 = stat_uid_gid link in
-      let suid2, sgid2 = stat_uid_gid symlink in
-      assert (luid1 = luid2 && lgid1 = lgid2 && suid1 = suid2 && Int64.to_int sgid2 = entry.gr_gid);
-
-      (* Now chown the target too *)
-      Eio.Path.chown ~follow:true ~gid:everybody symlink;
-      let luid3, lgid3 = stat_uid_gid link in
-      let suid3, sgid3 = stat_uid_gid symlink in
-      assert (suid3 = luid3);
-      assert (Int64.to_int lgid3 = entry.gr_gid);
-      assert (Int64.to_int sgid3 = entry.gr_gid);;
+  (* Now chown the target too *)
+  Eio.Path.chown ~follow:true ~gid:othergroup symlink;
+  let luid3, lgid3 = stat_uid_gid link in
+  let suid3, sgid3 = stat_uid_gid symlink in
+  assert (suid3 = luid3);
+  assert (lgid3 = othergroup);
+  assert (sgid3 = othergroup);;
 - : unit = ()
 ```
 


### PR DESCRIPTION
- `AT_SYMLINK_FOLLOW` only works with `linkat`
- `AT_SYMLINK_NOFOLLOW` is the flag for `fchownat`

This also updates the tests so they would detect this problem.

Spotted by @avsm in https://github.com/ocaml-multicore/eio/pull/781

/cc @patricoferris

Note: I removed the `AT_EMPTY_PATH` as it doesn't seem to be needed for anything and was only used on Linux anyway. Could be added back later (with a test) if required.