### PR TITLE
Report errors from getaddrinfo

### DIFF
--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -2,12 +2,65 @@ open Std
 
 type connection_failure =
   | Refused of Exn.Backend.t
-  | No_matching_addresses
   | Timeout
+
+module Getaddrinfo_error = struct
+  (* keep in sync with C stubs *)
+  type t =
+    | UNKNOWN
+    | ADDRFAMILY
+    | AGAIN
+    | BADFLAGS
+    | BADHINTS
+    | FAIL
+    | FAMILY
+    | MEMORY
+    | NODATA
+    | NONAME
+    | OVERFLOW
+    | PROTOCOL
+    | SERVICE
+    | SOCKTYPE
+
+  let to_tag = function
+    | UNKNOWN    -> "UNKNOWN"
+    | ADDRFAMILY -> "ADDRFAMILY"
+    | AGAIN      -> "AGAIN"
+    | BADFLAGS   -> "BADFLAGS"
+    | BADHINTS   -> "BADHINTS"
+    | FAIL       -> "FAIL"
+    | FAMILY     -> "FAMILY"
+    | MEMORY     -> "MEMORY"
+    | NODATA     -> "NODATA"
+    | NONAME     -> "NONAME"
+    | OVERFLOW   -> "OVERFLOW"
+    | PROTOCOL   -> "PROTOCOL"
+    | SERVICE    -> "SERVICE"
+    | SOCKTYPE   -> "SOCKTYPE"
+
+  let to_message = function
+    | ADDRFAMILY -> "address family for name not supported"
+    | AGAIN      -> "temporary failure in name resolution"
+    | BADFLAGS   -> "invalid value for ai_flags"
+    | BADHINTS   -> "invalid value for hints"
+    | FAIL       -> "non-recoverable failure in name resolution"
+    | FAMILY     -> "ai_family not supported"
+    | MEMORY     -> "memory allocation failure"
+    | NODATA     -> "no address associated with name"
+    | NONAME     -> "name or service is not known"
+    | OVERFLOW   -> "argument buffer overflow"
+    | PROTOCOL   -> "resolved protocol is unknown"
+    | SERVICE    -> "service not supported for ai_socktype"
+    | SOCKTYPE   -> "ai_socktype not supported"
+    | UNKNOWN    -> "unknown error"
+
+  let pp f t = Fmt.pf f "%s (%s)" (to_tag t) (to_message t)
+end
 
 type error =
   | Connection_reset of Exn.Backend.t
   | Connection_failure of connection_failure
+  | Address_lookup_failed of Getaddrinfo_error.t
   | Invalid_option
 
 type Exn.err += E of error
@@ -22,8 +75,8 @@ let () =
           | Connection_reset e -> Fmt.pf f "Connection_reset %a" Exn.Backend.pp e
           | Connection_failure Refused e -> Fmt.pf f "Connection_failure Refused %a" Exn.Backend.pp e
           | Connection_failure Timeout -> Fmt.pf f "Connection_failure Timeout"
-          | Connection_failure No_matching_addresses -> Fmt.pf f "Connection_failure No_matching_addresses"
           | Invalid_option -> Fmt.string f "Invalid_option"
+          | Address_lookup_failed e -> Fmt.pf f "Address_lookup_failed %a" Getaddrinfo_error.pp e
         end;
         true
       | _ -> false
@@ -461,24 +514,33 @@ let datagram_socket (type tag) ?(reuse_addr=false) ?(reuse_port=false) ~sw (t:[>
   let addr = (addr :> [Sockaddr.datagram | `UdpV4 | `UdpV6]) in 
   X.datagram_socket t ~reuse_addr ~reuse_port ~sw addr
 
-let getaddrinfo (type tag) ?(service="") (t:[> tag ty] r) hostname =
+let getaddrinfo_full (type tag) ~filter ?(service="") (t:[> tag ty] r) hostname =
   let (Resource.T (t, ops)) = t in
   let module X = (val (Resource.get ops Pi.Network)) in
-  X.getaddrinfo t ~service hostname
+  match
+    X.getaddrinfo t ~service hostname
+    |> List.filter_map filter
+  with
+  | [] -> raise @@ err (Address_lookup_failed NONAME)
+  | xs -> xs
+
+let getaddrinfo ?service t hostname =
+  getaddrinfo_full ?service t hostname
+    ~filter:Option.some 
 
 let getaddrinfo_stream ?service t hostname =
-  getaddrinfo ?service t hostname
-  |> List.filter_map (function
-      | #Sockaddr.stream as x -> Some x
-      | _ -> None
-    )
+  getaddrinfo_full ?service t hostname
+    ~filter:(function
+        | #Sockaddr.stream as x -> Some x
+        | _ -> None
+      )
 
 let getaddrinfo_datagram ?service t hostname =
-  getaddrinfo ?service t hostname
-  |> List.filter_map (function
-      | #Sockaddr.datagram as x -> Some x
-      | _ -> None
-    )
+  getaddrinfo_full ?service t hostname
+    ~filter:(function
+        | #Sockaddr.datagram as x -> Some x
+        | _ -> None
+      )
 
 let getnameinfo (type tag) (t:[> tag ty] r) sockaddr =
   let (Resource.T (t, ops)) = t in
@@ -491,7 +553,7 @@ let with_tcp_connect ?(timeout=Time.Timeout.none) ~host ~service t f =
   Switch.run ~name:"with_tcp_connect" @@ fun sw ->
   match
     let rec aux = function
-      | [] -> raise @@ err (Connection_failure No_matching_addresses)
+      | [] -> assert false      (* getaddrinfo_full never returns an empty list *)
       | addr :: addrs ->
         try Time.Timeout.run_exn timeout (fun () -> connect ~sw t addr) with
         | Time.Timeout | Exn.Io _ when addrs <> [] ->
@@ -499,11 +561,11 @@ let with_tcp_connect ?(timeout=Time.Timeout.none) ~host ~service t f =
         | Time.Timeout ->
           raise @@ err (Connection_failure Timeout)
     in
-    getaddrinfo_stream ~service t host
-    |> List.filter_map (function
-        | `Tcp _ as x -> Some x
-        | `Unix _ -> None
-      )
+    getaddrinfo_full ~service t host
+      ~filter:(function
+          | `Tcp _ as x -> Some x
+          | `Udp _ | `Unix _ -> None
+        )
     |> aux
   with
   | conn -> f conn

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -15,14 +15,40 @@ open Std
 
 type connection_failure =
   | Refused of Exn.Backend.t
-  | No_matching_addresses
   | Timeout
+
+module Getaddrinfo_error : sig
+  (** Error codes returned by getaddrinfo(3) *)
+
+  type t =
+    | UNKNOWN
+    | ADDRFAMILY
+    | AGAIN
+    | BADFLAGS
+    | BADHINTS
+    | FAIL
+    | FAMILY
+    | MEMORY
+    | NODATA
+    | NONAME
+    | OVERFLOW
+    | PROTOCOL
+    | SERVICE
+    | SOCKTYPE
+
+  val to_tag : t -> string
+  (** [to_tag t] is the constructor name. e.g. [to_tag NONAME = "NONAME"]. *)
+
+  val to_message : t -> string
+  (** [to_message t] returns a string representation of [t], like gai_strerror(3). *)
+end
 
 type error =
   | Connection_reset of Exn.Backend.t
     (** This is a wrapper for epipe, econnreset and similar errors.
         It indicates that the flow has failed, and data may have been lost. *)
   | Connection_failure of connection_failure
+  | Address_lookup_failed of Getaddrinfo_error.t
   | Invalid_option (** Socket option not supported. *)
 
 type Exn.err += E of error
@@ -405,7 +431,11 @@ val recv : _ datagram_socket -> Cstruct.t -> Sockaddr.datagram * int
     returned along with the sender address and port. If the [buf] is too small then excess bytes may be discarded
     depending on the type of the socket the message is received from. *)
 
-(** {2 DNS queries} *)
+(** {2 DNS/getaddrinfo queries}
+
+    Note that unlike {!Unix.getaddrinfo}, Eio's [getaddrinfo] family
+    of functions raise an exception (see {!Address_lookup_failed}) with an error
+    code instead of returning an empty list. *)
 
 val getaddrinfo: ?service:string -> _ t -> string -> Sockaddr.t list
 (** [getaddrinfo ?service t node] returns a list of IP addresses for [node]. [node] is either a domain name or
@@ -414,13 +444,19 @@ val getaddrinfo: ?service:string -> _ t -> string -> Sockaddr.t list
     @param service is a human friendly textual name for internet services assigned by IANA., eg.
     'http', 'https', 'ftp', etc.
 
-    For a more thorough treatment, see {{:https://man7.org/linux/man-pages/man3/getaddrinfo.3.html} getaddrinfo}. *)
+    For a more thorough treatment, see {{:https://man7.org/linux/man-pages/man3/getaddrinfo.3.html} getaddrinfo}.
+
+    Never returns an empty list; it will raise [Eio.Io (Eio.Net.E Address_lookup_failed _, _)] instead. *)
 
 val getaddrinfo_stream: ?service:string -> _ t -> string -> Sockaddr.stream list
-(** [getaddrinfo_stream] is like {!getaddrinfo}, but filters out non-stream protocols. *)
+(** [getaddrinfo_stream] is like {!getaddrinfo}, but filters out non-stream protocols.
+
+    Never returns an empty list; it will raise [Eio.Io (Eio.Net.E Address_lookup_failed _, _)] instead. *)
 
 val getaddrinfo_datagram: ?service:string -> _ t -> string -> Sockaddr.datagram list
-(** [getaddrinfo_datagram] is like {!getaddrinfo}, but filters out non-datagram protocols. *)
+(** [getaddrinfo_datagram] is like {!getaddrinfo}, but filters out non-datagram protocols.
+
+    Never returns an empty list; it will raise [Eio.Io (Eio.Net.E Address_lookup_failed _, _)] instead. *)
 
 val getnameinfo : _ t -> Sockaddr.t -> (string * string)
 (** [getnameinfo t sockaddr] is [(hostname, service)] corresponding to [sockaddr]. [hostname] is the

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -135,6 +135,8 @@ module Private : sig
   val chmod_unix : Unix.file_descr -> string -> flags:int -> mode:int -> unit
   val chown : flags:int -> uid:int64 -> gid:int64 -> Fd.t -> string -> unit
   val chown_unix : flags:int -> uid:int64 -> gid:int64 -> Unix.file_descr -> string -> unit
+
+  val getaddrinfo : service:string -> string -> Eio.Net.Sockaddr.t list
 end
 
 module Pi = Pi

--- a/lib_eio/unix/eio_unix_stubs.c
+++ b/lib_eio/unix/eio_unix_stubs.c
@@ -5,12 +5,18 @@
 #include <errno.h>
 #include <dirent.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#ifndef _WIN32
+# include <sys/socket.h>
+# include <netdb.h>
+#endif
 
 #include <caml/mlvalues.h>
 #include <caml/unixsupport.h>
 #include <caml/memory.h>
 #include <caml/bigarray.h>
 #include <caml/alloc.h>
+#include <caml/socketaddr.h>
 
 static void caml_stat_free_preserving_errno(void *ptr) {
   int saved = errno;
@@ -111,5 +117,133 @@ CAMLprim value eio_unix_fchownat(value v_fd, value v_path, value v_uid, value v_
   if (ret == -1)
     caml_uerror("fchownat", v_path);
   CAMLreturn(Val_unit);
+#endif
+}
+
+static int caml_eai_of_unix(int eai) {
+  switch (eai) {
+    // These numbers must match the order of constructors in Eio.Net.Getaddrinfo_error.t
+#ifdef EAI_ADDRFAMILY
+    case EAI_ADDRFAMILY: return 1;
+#endif
+    case EAI_AGAIN: return 2;
+    case EAI_BADFLAGS: return 3;
+#ifdef EAI_BADHINTS
+    case EAI_BADHINTS: return 4;
+#endif
+    case EAI_FAIL: return 5;
+    case EAI_FAMILY: return 6;
+    case EAI_MEMORY: return 7;
+#ifdef EAI_NODATA
+    case EAI_NODATA: return 8;
+#endif
+    case EAI_NONAME: return 9;
+#ifdef EAI_OVERFLOW
+    case EAI_OVERFLOW: return 10;
+#endif
+#ifdef EAI_PROTOCOL
+    case EAI_PROTOCOL: return 11;
+#endif
+    case EAI_SERVICE: return 12;
+    case EAI_SOCKTYPE: return 13;
+    default: return 0;
+  }
+}
+
+CAMLprim value eio_unix_getaddrinfo(value v_node, value v_service) {
+#ifdef _WIN32
+  caml_unix_error(EOPNOTSUPP, "getaddrinfo not supported on Windows", Nothing);
+#else
+  CAMLparam2(v_node, v_service);
+  CAMLlocal3(v_result, v_list, v_cons);
+  CAMLlocal3(v_host, v_addr, v_item);
+  struct addrinfo *res = NULL;
+  int r;
+  int have_node = caml_string_length(v_node) > 0;
+  int have_service = caml_string_length(v_service) > 0;
+  int saved_errno = 0;
+
+  {
+    struct addrinfo hints = {
+      .ai_family = AF_UNSPEC,
+      .ai_socktype = 0,
+      .ai_protocol = 0,
+      .ai_flags = AI_ADDRCONFIG,
+    };
+    char *node = have_node ? caml_stat_strdup(String_val(v_node)) : NULL;
+    char *service = have_service ? caml_stat_strdup(String_val(v_service)) : NULL;
+
+    caml_enter_blocking_section();
+    r = getaddrinfo(node, service, &hints, &res);
+    saved_errno = errno;
+    caml_leave_blocking_section();
+
+    if (node) caml_stat_free(node);
+    if (service) caml_stat_free(service);
+  }
+
+  if (r == 0) {
+    struct addrinfo *item;
+
+    for (item = res; item; item = item->ai_next) {
+      if (item->ai_socktype == SOCK_STREAM || item->ai_socktype == SOCK_DGRAM) {
+        int tag, port;
+
+        switch (item->ai_protocol) {
+          case IPPROTO_TCP:
+            tag = caml_hash_variant("Tcp");
+            break;
+          case IPPROTO_UDP:
+            tag = caml_hash_variant("Udp");
+            break;
+          default:
+            continue;
+        }
+
+        switch (item->ai_family) {
+          case AF_INET:
+            struct sockaddr_in *ip = (struct sockaddr_in *) item->ai_addr;
+            v_host = caml_unix_alloc_inet_addr(&ip->sin_addr);
+            port = ip->sin_port;
+            break;
+          case AF_INET6:
+            struct sockaddr_in6 *ip6 = (struct sockaddr_in6 *) item->ai_addr;
+            v_host = caml_unix_alloc_inet6_addr(&ip6->sin6_addr);
+            port = ip6->sin6_port;
+            break;
+          default:
+            continue;
+        }
+
+        if (!have_service) { port = 0; }
+
+        v_addr = caml_alloc(2, 0);
+        Store_field(v_addr, 0, v_host);
+        Store_field(v_addr, 1, Val_int(ntohs(port)));
+
+        v_item = caml_alloc(2, 0);
+        Store_field(v_item, 0, tag);
+        Store_field(v_item, 1, v_addr);
+
+        v_cons = caml_alloc(2, Tag_cons);
+        Store_field(v_cons, 0, v_item);
+        Store_field(v_cons, 1, v_list);
+        v_list = v_cons;
+      }
+    }
+
+    freeaddrinfo(res);
+
+    v_result = caml_alloc(1, 0);        // Ok res
+    Store_field(v_result, 0, v_list);
+    CAMLreturn(v_result);
+  } else if (r == EAI_SYSTEM) {
+    errno = saved_errno;
+    uerror("getaddrinfo", v_node);
+  } else {
+    v_result = caml_alloc(1, 1);        // Error r
+    Store_field(v_result, 0, Val_int(caml_eai_of_unix(r)));
+    CAMLreturn(v_result);
+  }
 #endif
 }

--- a/lib_eio/unix/primitives.h
+++ b/lib_eio/unix/primitives.h
@@ -20,4 +20,5 @@ CAMLprim value eio_unix_cap_enter(value);
 CAMLprim value eio_unix_readlinkat(value, value, value);
 CAMLprim value eio_unix_fchmodat(value, value, value, value);
 CAMLprim value eio_unix_fchownat(value, value, value, value, value);
+CAMLprim value eio_unix_getaddrinfo(value, value);
 CAMLprim value eio_unix_is_blocking(value);

--- a/lib_eio/unix/private.ml
+++ b/lib_eio/unix/private.ml
@@ -52,3 +52,14 @@ let chown_unix ~flags ~uid ~gid fd path =
 
 let chown ~flags ~uid ~gid fd path =
   Fd.use_exn "chown" fd (fun fd -> chown_unix ~uid ~gid ~flags fd path)
+
+type sockaddr = [ `Tcp of Eio.Net.Ipaddr.v4v6 * int
+                | `Udp of Eio.Net.Ipaddr.v4v6 * int ]
+
+external eio_getaddrinfo : string -> string -> (sockaddr list, Eio.Net.Getaddrinfo_error.t) result
+  = "eio_unix_getaddrinfo"
+
+let getaddrinfo ~service node =
+  match eio_getaddrinfo node service with
+  | Ok x -> List.rev (x :> Eio.Net.Sockaddr.t list)
+  | Error e -> raise @@ Eio.Net.err @@ Eio.Net.Address_lookup_failed e

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -750,22 +750,9 @@ let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) fd path =
     Eio_unix.run_in_systhread ~label:"chown" (fun () -> Eio_unix.Private.chown ~flags ~uid ~gid parent leaf)
   with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
 
-(* https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml *)
 let getaddrinfo ~service node =
-  let to_eio_sockaddr_t {Unix.ai_family; ai_addr; ai_socktype; ai_protocol; _ } =
-    match ai_family, ai_socktype, ai_addr with
-    | (Unix.PF_INET | PF_INET6),
-      (Unix.SOCK_STREAM | SOCK_DGRAM),
-      Unix.ADDR_INET (inet_addr,port) -> (
-        match ai_protocol with
-        | 6 -> Some (`Tcp (Eio_unix.Net.Ipaddr.of_unix inet_addr, port))
-        | 17 -> Some (`Udp (Eio_unix.Net.Ipaddr.of_unix inet_addr, port))
-        | _ -> None)
-    | _ -> None
-  in
   Eio_unix.run_in_systhread ~label:"getaddrinfo" @@ fun () ->
-  Unix.getaddrinfo node service []
-  |> List.filter_map to_eio_sockaddr_t
+  Err.run (Eio_unix.Private.getaddrinfo ~service) node
 
 let pipe ~sw =
   let unix_r, unix_w = Unix.pipe ~cloexec:true () in

--- a/lib_eio_posix/net.ml
+++ b/lib_eio_posix/net.ml
@@ -87,27 +87,9 @@ let datagram_handler = Eio_unix.Pi.datagram_handler (module Datagram_socket)
 let datagram_socket fd =
   Eio.Resource.T (fd, datagram_handler)
 
-(* https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml *)
 let getaddrinfo ~service node =
-  let to_eio_sockaddr_t {Unix.ai_family; ai_addr; ai_socktype; ai_protocol; _ } =
-    match ai_family, ai_socktype, ai_addr with
-    | (Unix.PF_INET | PF_INET6),
-      (Unix.SOCK_STREAM | SOCK_DGRAM),
-      Unix.ADDR_INET (inet_addr,port) -> (
-        match ai_protocol with
-        | 6 -> Some (`Tcp (Eio_unix.Net.Ipaddr.of_unix inet_addr, port))
-        | 17 -> Some (`Udp (Eio_unix.Net.Ipaddr.of_unix inet_addr, port))
-        | _ -> None)
-    | _ -> None
-  in
-  Err.run (Eio_unix.run_in_systhread ~label:"getaddrinfo") @@ fun () ->
-  let rec aux () =
-    try
-      Unix.getaddrinfo node service []
-      |> List.filter_map to_eio_sockaddr_t
-    with Unix.Unix_error (EINTR, _, _) -> aux ()
-  in
-  aux ()
+  Eio_unix.run_in_systhread ~label:"getaddrinfo" @@ fun () ->
+  Err.run (Eio_unix.Private.getaddrinfo ~service) node
 
 let listen ~reuse_addr ~reuse_port ~backlog ~sw (listen_addr : Eio.Net.Sockaddr.stream) =
   let socket_type, addr =

--- a/tests/network.md
+++ b/tests/network.md
@@ -673,6 +673,9 @@ Exception: Eio.Io Net Invalid_option,
 - : Eio.Net.Sockaddr.datagram list = [`Udp (127.0.0.1, 80)]
 ```
 
+Note: these are "non-deterministic" because on macos, http and ftp
+also return UDP results.
+
 <!-- $MDX non-deterministic=output -->
 ```ocaml
 # Eio_main.run @@ fun env ->
@@ -690,9 +693,23 @@ Exception: Eio.Io Net Invalid_option,
 <!-- $MDX non-deterministic=output -->
 ```ocaml
 # Eio_main.run @@ fun env ->
-  Eio.Net.getaddrinfo ~service:"https" env#net "ocaml.org";;
+  try
+    Eio.Net.getaddrinfo ~service:"https" env#net "ocaml.org"
+  with Eio.Io _ as ex ->
+    traceln "%a" Fmt.exn ex; [];; (* Ignore errors *)
 - : Eio.Net.Sockaddr.t list =
 [`Tcp (51.159.83.169, 443); `Udp (51.159.83.169, 443)]
+```
+
+`getaddrinfo` raises instead of returning an empty list (the exact error may vary;
+CI shows `AGAIN` rather than `NONAME`):
+
+```ocaml
+# Eio_main.run @@ fun env ->
+  try
+    Eio.Net.getaddrinfo env#net "name.invalid."
+  with Eio.Io (Eio.Net.E Address_lookup_failed _, _) -> failwith "Address_lookup_failed";;
+Exception: Failure "Address_lookup_failed".
 ```
 
 ## getnameinfo
@@ -723,7 +740,7 @@ No usable addresses:
   Eio.Net.with_tcp_connect ~host:"www.example.com" ~service:"http" net (fun _ -> assert false);;
 +mock-net: getaddrinfo ~service:http www.example.com
 Exception:
-Eio.Io Net Connection_failure No_matching_addresses,
+Eio.Io Net Address_lookup_failed NONAME (name or service is not known),
   connecting to "www.example.com":http
 ```
 


### PR DESCRIPTION
Before, `Net.getaddrinfo` returned `[]` on error, but this isn't very useful:

- Callers must remember to check for this and generate an error.
- The actual error is lost, so the reported error isn't very accurate.

Fixes #776 ("Eio.Net.getaddrinfo_stream fails to resolve host after 1019 successful calls on linux"), where the process has too many files open and starts returning an empty list of addresses rather than giving a useful error.

Notes:

- The error `Connection_failure No_matching_addresses` has been replaced by `Address_lookup_failed _` (it wasn't the connect that was failing anyway).

- We now pass `AI_ADDRCONFIG` on eio_linux and eio_posix, which means that we only return IPv4 or IPv6 addresses if the local system is configured to use them. This is the default behaviour for `getaddrinfo` on Linux.

This is based on Christiano's #352. However, there the C stubs were based on the ones in OCaml and the OCaml developers did not want to relicense them so I've written my own C stub instead.