### PR TITLE
fork_action: retry on eintr when writing to pipe

### DIFF
--- a/lib_eio/unix/fork_action.c
+++ b/lib_eio/unix/fork_action.c
@@ -45,6 +45,9 @@ static void try_write_all(int fd, char *buf) {
   while (len > 0) {
     int wrote = write(fd, buf, len);
 
+    if (wrote == -1 && errno == EINTR)
+     continue;
+
     if (wrote <= 0)
       return;
 


### PR DESCRIPTION
No harm doing this I think, in case the child is interrupted