### PR TITLE
chmod: prevent sandbox escape using symlinks

### DIFF
--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -741,13 +741,24 @@ let read_link fd path =
     Eio_unix.run_in_systhread ~label:"read_link" (fun () -> Eio_unix.Private.read_link (Some parent) leaf)
   with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
 
-let chmod ~follow ~mode dir path =
-  let module X = Uring.Statx in
-  let flags = if follow then X.Flags.empty else X.Flags.symlink_nofollow in
-  let flags = (flags :> int) in
+let chmod ~follow ~mode dirfd path =
   try
-    with_parent_dir_fd dir path @@ fun parent leaf ->
-    Eio_unix.run_in_systhread ~label:"chmod" (fun () -> Eio_unix.Private.chmod parent leaf ~mode ~flags)
+    Switch.run @@ fun sw ->
+    let fd =
+      openat ~sw ~access:`R ~perm:0 dirfd path
+        ~flags:Uring.Open_flags.(cloexec + path + if follow then empty else nofollow)
+    in
+    Eio_unix.run_in_systhread ~label:"chmod" (fun () ->
+        try
+          Eio_unix.Private.chmod ~mode fd ""
+            ~flags:(Uring.Statx.Flags.empty_path :> int)
+        with
+        | Unix.Unix_error ((ENOSYS | EOPNOTSUPP | EINVAL), _, _) ->
+          (* For Linux before 6.6 *)
+          Eio_unix.Fd.use_exn "chmod" fd @@ fun fd ->
+          let fd : int = Obj.magic fd in
+          Unix.chmod (Printf.sprintf "/proc/self/fd/%d" fd) mode
+      )
   with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
 
 let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) dirfd path =

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -465,13 +465,6 @@ let symlink ~link_to new_dir new_path =
   let new_dir = Option.value new_dir ~default:at_fdcwd in
   eio_symlinkat link_to new_dir new_path
 
-let chmod ~follow ~mode dir path =
-  in_worker_thread "chmod" @@ fun () ->
-  let flags = if follow then 0 else Config.at_symlink_nofollow in
-  Resolve.with_parent "chmod" dir path @@ fun dir path ->
-  let new_dir = Option.value dir ~default:at_fdcwd in
-  Eio_unix.Private.chmod_unix new_dir path ~mode ~flags
-
 let read_link dirfd path =
   in_worker_thread "read_link" @@ fun () ->
   Resolve.with_parent "read_link" dirfd path @@ fun dirfd path ->
@@ -549,6 +542,28 @@ let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) dirfd path =
     Eio_unix.Private.chown_unix ~flags ~uid ~gid at_fdcwd path 
   | Cwd -> use_confined None
   | Fd dirfd -> Fd.use_exn "chown" dirfd @@ fun dirfd -> use_confined (Some dirfd)
+
+let chmod ~follow ~mode dirfd path =
+  Err.run (in_worker_thread "chmod") @@ fun () ->
+  let use_confined dirfd =
+    Resolve.with_parent_loop ?dirfd path @@ fun dirfd path ->
+    let dirfd = Option.value dirfd ~default:at_fdcwd in
+    if follow && is_symlink dirfd path then Error (`Symlink None)       (* For BSD systems *)
+    else (
+      (* Note: Same race as in [chown] here. Except on Linux, where we get
+         EOPNOTSUPP because it can't chmod symlinks! *)
+      match Eio_unix.Private.chmod_unix dirfd path ~mode ~flags:Config.at_symlink_nofollow with
+      | () -> Ok ()
+      | exception (Unix.Unix_error (EOPNOTSUPP, _, _) as e) when follow ->
+        Error (`Symlink (Some e))       (* Linux *)
+    )
+  in
+  match dirfd with
+  | Fs ->
+    let flags = if follow then 0 else Config.at_symlink_nofollow in
+    Eio_unix.Private.chmod_unix at_fdcwd path ~mode ~flags
+  | Cwd -> use_confined None
+  | Fd dirfd -> Fd.use_exn "chmod" dirfd @@ fun dirfd -> use_confined (Some dirfd)
 
 let lseek fd off cmd =
   Fd.use_exn "lseek" fd @@ fun fd ->

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -898,6 +898,64 @@ Chmod works.
 - : unit = ()
 ```
 
+`chmod ~follow:true` follows the leaf symlink within the sandbox.
+A leaf symlink pointing out of the sandbox must not be followed:
+
+```ocaml
+# run ~clear:["sandbox"; "outside.txt"] @@ fun env ->
+  let cwd = Eio.Stdenv.cwd env in
+  Switch.run @@ fun sw ->
+  Path.save ~create:(`Exclusive 0o644) (cwd / "outside.txt") "outside";
+  try_mkdir (cwd / "sandbox");
+  Path.save ~create:(`Exclusive 0o644) (cwd / "sandbox/inside.txt") "inside";
+  (* Set mode, to avoid effect of umask *)
+  try_chmod ~follow:true ~perm:0o644 (cwd / "outside.txt");
+  try_chmod ~follow:true ~perm:0o644 (cwd / "sandbox/inside.txt");
+  let sandbox = Path.open_subtree ~sw (cwd / "sandbox") in
+  Path.symlink ~link_to:"inside.txt" (sandbox / "ok");
+  Path.symlink ~link_to:"../outside.txt" (sandbox / "escape");
+  (* Following a symlink to a file inside the sandbox works: *)
+  try_chmod ~follow:false ~perm:0o600 (sandbox / "inside.txt");
+  try_stat ~info_type:`Perm (sandbox / "inside.txt");
+  try_chmod ~follow:true ~perm:0o400 (sandbox / "ok");
+  try_stat ~info_type:`Perm (sandbox / "inside.txt");
+  (* Following a symlink out of the sandbox is rejected, and the target is unchanged: *)
+  try_chmod ~follow:true ~perm:0o400 (sandbox / "escape");
+  try_stat ~info_type:`Perm (cwd / "outside.txt");
+  traceln "Try without sandboxing";
+  let unconfined = env#fs / "sandbox" in
+  try_chmod ~follow:true ~perm:0o400 (unconfined / "escape");
+  try_stat ~info_type:`Perm (cwd / "outside.txt");;
++mkdir <cwd:sandbox> -> ok
++chmod <cwd:outside.txt> to 644 -> ok
++chmod <cwd:sandbox/inside.txt> to 644 -> ok
++chmod <sandbox:inside.txt> to 600 -> ok
++<sandbox:inside.txt> -> 600
++chmod <sandbox:ok> to 400 -> ok
++<sandbox:inside.txt> -> 400
++Eio.Io Fs Permission_denied _, chmoding file <sandbox:escape>
++<cwd:outside.txt> -> 644
++Try without sandboxing
++chmod <fs:sandbox/escape> to 400 -> ok
++<cwd:outside.txt> -> 400
+- : unit = ()
+```
+
+Test chmod on a symlink, on platforms that allow it:
+
+```ocaml
+# run ~clear:["symlink"] @@ fun env ->
+  let path = env#cwd / "symlink" in
+  Eio.Path.symlink ~link_to:"/foo" path;
+  try
+    Eio.Path.chmod path ~follow:false ~perm:0o600;
+    assert ((Eio.Path.stat ~follow:false path).perm = 0o600);
+    Eio.Path.chmod path ~follow:false ~perm:0o660;
+    assert ((Eio.Path.stat ~follow:false path).perm = 0o660)
+  with Eio.Io (Eio.Exn.X Eio_unix.Unix_error (EOPNOTSUPP, _, _), _) ->
+    ()  (* Some systems don't support this, e.g. Linux *)
+- : unit = ()
+```
 
 # pread/pwrite
 


### PR DESCRIPTION
There appears to be a mess involving AT_SYMLINK_NOFOLLOW and chmod on Linux, see https://www.phoronix.com/news/fchmodat2-For-Linux-6.6 for background.

This testcase does fail but I haven't figured out a fix! This does increase the case for #845 and a modern glibc/kernel minimum I think.