### PR TITLE
eio_posix, eio_windows: map ENOPROTOOPT to Invalid_option

### DIFF
--- a/lib_eio_posix/err.ml
+++ b/lib_eio_posix/err.ml
@@ -22,6 +22,7 @@ let wrap code name arg =
   | EUNKNOWNERR x when Some x = Config.enotcapable -> Eio.Fs.err (Permission_denied e)
   | ECONNREFUSED -> Eio.Net.err (Connection_failure (Refused e))
   | ECONNRESET | EPIPE -> Eio.Net.err (Connection_reset e)
+  | ENOPROTOOPT -> Eio.Net.err Invalid_option
   | _ -> unclassified_error e
 
 let run fn x =

--- a/lib_eio_windows/err.ml
+++ b/lib_eio_windows/err.ml
@@ -21,6 +21,7 @@ let wrap code name arg =
   | EXDEV | EACCES | EPERM -> Eio.Fs.err (Permission_denied e)
   | ECONNREFUSED -> Eio.Net.err (Connection_failure (Refused e))
   | ECONNRESET | EPIPE | ECONNABORTED -> Eio.Net.err (Connection_reset e)
+  | ENOPROTOOPT -> Eio.Net.err Invalid_option
   | _ -> unclassified_error e
 
 let run fn x =


### PR DESCRIPTION
This is just a minor cleanup for consistency across backends. Match the eio_linx backend so that an unsupported socket option is an `Eio.Net.Invalid_option` instead of an unclassified error.