### PR TITLE
Pre-connect socket options (follow up to #713)

### DIFF
--- a/lib_eio/mock/net.ml
+++ b/lib_eio/mock/net.ml
@@ -36,8 +36,16 @@ module Impl = struct
     Switch.on_release sw (fun () -> Eio.Resource.close socket);
     socket
 
-  let connect t ~sw addr =
+  let connect t ~bind_to ~options ~sw addr =
     traceln "%s: connect to %a" t.label Eio.Net.Sockaddr.pp addr;
+    let rec trace_options : Eio.Net.Sockopt.settings -> unit = function
+      | [] -> ()
+      | (o, v) :: tl ->
+        traceln "%s: setsockopt %a" t.label Eio.Net.Sockopt.pp_binding (o, v);
+        trace_options tl
+    in
+    trace_options options;
+    Option.iter (fun a -> traceln "%s: bind %a" t.label Eio.Net.Sockaddr.pp a) bind_to;
     let socket = Handler.run t.on_connect in
     Switch.on_release sw (fun () -> Eio.Flow.close socket);
     socket

--- a/lib_eio/mock/net.ml
+++ b/lib_eio/mock/net.ml
@@ -38,10 +38,17 @@ module Impl = struct
     Switch.on_release sw (fun () -> Eio.Resource.close socket);
     socket
 
-  let connect t ~sw addr =
-    traceln "%s: connect to %a" t.label Eio.Net.Sockaddr.pp addr;
+  let connect t ~bind_to ~options ~sw addr =
+    let pp_bind_to f bind_to = Fmt.pf f " (bind to %a)" Eio.Net.Sockaddr.pp bind_to in
+    traceln "%s: connect to %a%a" t.label Eio.Net.Sockaddr.pp addr
+      (Fmt.option pp_bind_to) bind_to;
     let socket = Handler.run t.on_connect in
     Switch.on_release sw (fun () -> Eio.Flow.close socket);
+    let rec trace_options : Eio.Net.Sockopt.settings -> unit = function
+      | [] -> ()
+      | (o, v) :: tl -> Eio.Net.setsockopt socket o v; trace_options tl
+    in
+    trace_options options;
     socket
 
   let datagram_socket t ~reuse_addr:_ ~reuse_port:_ ~sw addr =

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -247,6 +247,10 @@ module Sockopt = struct
     let name, pp = find_printer opt in
     Fmt.pf f "%s = %a" name pp v
 
+  type settings =
+    | [] : settings
+    | (::) : ('a t * 'a) * settings -> settings
+
   type _ t +=
     | SO_DEBUG : bool t
     | SO_BROADCAST : bool t
@@ -426,7 +430,9 @@ module Pi = struct
     type tag
 
     val listen : t -> reuse_addr:bool -> reuse_port:bool -> backlog:int -> sw:Switch.t -> Sockaddr.stream -> tag listening_socket_ty r
-    val connect : t -> sw:Switch.t -> Sockaddr.stream -> tag stream_socket_ty r
+    val connect :
+      t -> bind_to:Sockaddr.stream option -> options:Sockopt.settings ->
+      sw:Switch.t -> Sockaddr.stream -> tag stream_socket_ty r
     val datagram_socket :
       t
       -> reuse_addr:bool
@@ -500,10 +506,10 @@ let listen (type tag) ?(reuse_addr=false) ?(reuse_port=false) ~backlog ~sw (t:[>
   let module X = (val (Resource.get ops Pi.Network)) in
   X.listen t ~reuse_addr ~reuse_port ~backlog ~sw
 
-let connect (type tag) ~sw (t:[> tag ty] r) addr =
+let connect (type tag) ?bind_to ?(options=Sockopt.[]) ~sw (t:[> tag ty] r) addr =
   let (Resource.T (t, ops)) = t in
   let module X = (val (Resource.get ops Pi.Network)) in
-  try X.connect t ~sw addr
+  try X.connect t ~bind_to ~options ~sw addr
   with Exn.Io _ as ex ->
     let bt = Printexc.get_raw_backtrace () in
     Exn.reraise_with_context ex bt "connecting to %a" Sockaddr.pp addr

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -167,6 +167,14 @@ module Sockopt : sig
   val pp : 'a t Fmt.t
   val pp_binding : ('a t * 'a) Fmt.t
 
+  type settings =
+    | [] : settings
+    | (::) : ('a t * 'a) * settings -> settings
+  (** A heterogeneous list of socket options, each paired with the value to
+      set it to. For example:
+
+      {[ Eio.Net.Sockopt.[ (SO_REUSEADDR, true); (SO_SNDBUF, 4096) ] ]} *)
+
   (** {2 Common options} *)
 
   type _ t +=
@@ -286,10 +294,32 @@ val getsockopt : [> `Socket] r -> 'a Sockopt.t -> 'a
 
 (** {2 Out-bound Connections} *)
 
-val connect : sw:Switch.t -> [> 'tag ty] t -> Sockaddr.stream -> 'tag stream_socket_ty r
+val connect :
+  ?bind_to:Sockaddr.stream ->
+  ?options:Sockopt.settings ->
+  sw:Switch.t -> [> 'tag ty] t -> Sockaddr.stream -> 'tag stream_socket_ty r
 (** [connect ~sw t addr] is a new socket connected to remote address [addr].
 
-    The new socket will be closed when [sw] finishes, unless closed manually first. *)
+    The new socket will be closed when [sw] finishes, unless closed manually first.
+
+    Before connecting, each option in [options] is applied in list order and
+    then the socket is bound to [bind_to] (if given).
+
+    For example, to make an outbound connection from a fixed local address:
+
+    {[
+      Eio.Net.connect ~sw net addr
+        ~bind_to:(`Tcp (local_ip, 0))
+        ~options:Eio.Net.Sockopt.[
+            (SO_REUSEADDR, true);
+            (SO_KEEPALIVE, true);
+          ]
+    ]}
+
+    @param options Socket options to set before binding and connecting.
+    @param bind_to Local address to bind to before connecting. This is how
+      a multi-homed host chooses the local address that an outbound
+      connection uses. *)
 
 val with_tcp_connect :
   ?timeout:Time.Timeout.t ->
@@ -524,7 +554,9 @@ module Pi : sig
       t -> reuse_addr:bool -> reuse_port:bool -> backlog:int -> sw:Switch.t ->
       Sockaddr.stream -> tag listening_socket_ty r
 
-    val connect : t -> sw:Switch.t -> Sockaddr.stream -> tag stream_socket_ty r
+    val connect :
+      t -> bind_to:Sockaddr.stream option -> options:Sockopt.settings ->
+      sw:Switch.t -> Sockaddr.stream -> tag stream_socket_ty r
 
     val datagram_socket :
       t

--- a/lib_eio/net.mli
+++ b/lib_eio/net.mli
@@ -167,6 +167,14 @@ module Sockopt : sig
   val pp : 'a t Fmt.t
   val pp_binding : ('a t * 'a) Fmt.t
 
+  type settings =
+    | [] : settings
+    | (::) : ('a t * 'a) * settings -> settings
+  (** A heterogeneous list of socket options, each paired with the value to
+      set it to. For example:
+
+      {[ Eio.Net.Sockopt.[ (SO_REUSEADDR, true); (SO_SNDBUF, 4096) ] ]} *)
+
   (** {2 Common options} *)
 
   type _ t +=
@@ -294,10 +302,32 @@ val getsockopt : [> `Socket] r -> 'a Sockopt.t -> 'a
 
 (** {2 Out-bound Connections} *)
 
-val connect : sw:Switch.t -> [> 'tag ty] t -> Sockaddr.stream -> 'tag stream_socket_ty r
+val connect :
+  ?bind_to:Sockaddr.stream ->
+  ?options:Sockopt.settings ->
+  sw:Switch.t -> [> 'tag ty] t -> Sockaddr.stream -> 'tag stream_socket_ty r
 (** [connect ~sw t addr] is a new socket connected to remote address [addr].
 
-    The new socket will be closed when [sw] finishes, unless closed manually first. *)
+    The new socket will be closed when [sw] finishes, unless closed manually first.
+
+    Before connecting, each option in [options] is applied in list order and
+    then the socket is bound to [bind_to] (if given).
+
+    For example, to make an outbound connection from a fixed local address:
+
+    {[
+      Eio.Net.connect ~sw net addr
+        ~bind_to:(`Tcp (local_ip, 0))
+        ~options:Eio.Net.Sockopt.[
+            (SO_REUSEADDR, true);
+            (SO_KEEPALIVE, true);
+          ]
+    ]}
+
+    @param options Socket options to set before binding and connecting.
+    @param bind_to Local address to bind to before connecting. This is how
+      a multi-homed host chooses the local address that an outbound
+      connection uses. *)
 
 val with_tcp_connect :
   ?timeout:Time.Timeout.t ->
@@ -532,7 +562,9 @@ module Pi : sig
       t -> reuse_addr:bool -> reuse_port:bool -> backlog:int -> sw:Switch.t ->
       Sockaddr.stream -> tag listening_socket_ty r
 
-    val connect : t -> sw:Switch.t -> Sockaddr.stream -> tag stream_socket_ty r
+    val connect :
+      t -> bind_to:Sockaddr.stream option -> options:Sockopt.settings ->
+      sw:Switch.t -> Sockaddr.stream -> tag stream_socket_ty r
 
     val datagram_socket :
       t

--- a/lib_eio_linux/net.ml
+++ b/lib_eio_linux/net.ml
@@ -93,10 +93,17 @@ let socket_domain_of = function
       ~v4:(fun _ -> Unix.PF_INET)
       ~v6:(fun _ -> Unix.PF_INET6)
 
-let connect ~sw connect_addr =
+let connect ~bind_to ~options ~sw connect_addr =
   let addr = Eio_unix.Net.sockaddr_to_unix connect_addr in
   let sock = Low_level.socket ~sw (socket_domain_of connect_addr) Unix.SOCK_STREAM 0 in
-  Low_level.connect sock addr;
+  let rec set_options : Eio.Net.Sockopt.settings -> unit = function
+    | [] -> ()
+    | (o, v) :: tl -> Low_level.setsockopt sock o v; set_options tl
+  in
+  Err.run (fun () ->
+    set_options options;
+    Option.iter (fun a -> Low_level.bind sock (Eio_unix.Net.sockaddr_to_unix a)) bind_to;
+    Low_level.connect sock addr) ();
   (Flow.of_fd sock :> _ Eio_unix.Net.stream_socket)
 
 module Impl = struct
@@ -132,7 +139,8 @@ module Impl = struct
     Low_level.listen sock backlog;
     (listening_socket sock :> _ Eio.Net.listening_socket_ty r)
 
-  let connect () ~sw addr = (connect ~sw addr :> [`Generic | `Unix] Eio.Net.stream_socket_ty r)
+  let connect () ~bind_to ~options ~sw addr =
+    (connect ~bind_to ~options ~sw addr :> [`Generic | `Unix] Eio.Net.stream_socket_ty r)
 
   let datagram_socket () ~reuse_addr ~reuse_port ~sw saddr =
     if reuse_addr then (

--- a/lib_eio_linux/net.ml
+++ b/lib_eio_linux/net.ml
@@ -93,9 +93,15 @@ let socket_domain_of = function
       ~v4:(fun _ -> Unix.PF_INET)
       ~v6:(fun _ -> Unix.PF_INET6)
 
-let connect ~sw connect_addr =
+let connect ~bind_to ~options ~sw connect_addr =
   let addr = Eio_unix.Net.sockaddr_to_unix connect_addr in
   let sock = Low_level.socket ~sw (socket_domain_of connect_addr) Unix.SOCK_STREAM 0 in
+  let rec set_options : Eio.Net.Sockopt.settings -> unit = function
+    | [] -> ()
+    | (o, v) :: tl -> Low_level.setsockopt sock o v; set_options tl
+  in
+  set_options options;
+  Option.iter (fun a -> Low_level.bind sock (Eio_unix.Net.sockaddr_to_unix a)) bind_to;
   Low_level.connect sock addr;
   (Flow.of_fd sock :> _ Eio_unix.Net.stream_socket)
 
@@ -132,7 +138,8 @@ module Impl = struct
     Low_level.listen sock backlog;
     (listening_socket sock :> _ Eio.Net.listening_socket_ty r)
 
-  let connect () ~sw addr = (connect ~sw addr :> [`Generic | `Unix] Eio.Net.stream_socket_ty r)
+  let connect () ~bind_to ~options ~sw addr =
+    (connect ~bind_to ~options ~sw addr :> [`Generic | `Unix] Eio.Net.stream_socket_ty r)
 
   let datagram_socket () ~reuse_addr ~reuse_port ~sw saddr =
     if reuse_addr then (

--- a/lib_eio_posix/net.ml
+++ b/lib_eio_posix/net.ml
@@ -126,7 +126,7 @@ let listen ~reuse_addr ~reuse_port ~backlog ~sw (listen_addr : Eio.Net.Sockaddr.
     );
   (listening_socket ~hook sock :> _ Eio.Net.listening_socket_ty r)
 
-let connect ~sw connect_addr =
+let connect ~bind_to ~options ~sw connect_addr =
   let socket_type, addr =
     match connect_addr with
     | `Unix path         -> Unix.SOCK_STREAM, Unix.ADDR_UNIX path
@@ -135,10 +135,16 @@ let connect ~sw connect_addr =
       Unix.SOCK_STREAM, Unix.ADDR_INET (host, port)
   in
   let sock = Low_level.socket ~sw (socket_domain_of connect_addr) socket_type 0 in
-  try
-    Low_level.connect sock addr;
-    (Flow.of_fd sock :> _ Eio_unix.Net.stream_socket)
-  with Unix.Unix_error (code, name, arg) -> raise (Err.v code name arg)
+  let rec set_options : Eio.Net.Sockopt.settings -> unit = function
+    | [] -> ()
+    | (o, v) :: tl -> Eio_unix.Private.setsockopt sock o v; set_options tl
+  in
+  Err.run (fun () ->
+    set_options options;
+    Option.iter (fun a -> Fd.use_exn "bind" sock (fun fd -> Unix.bind fd (Eio_unix.Net.sockaddr_to_unix a))) bind_to;
+    Low_level.connect sock addr
+  ) ();
+  (Flow.of_fd sock :> _ Eio_unix.Net.stream_socket)
 
 let create_datagram_socket ~reuse_addr ~reuse_port ~sw saddr =
   let sock = Low_level.socket ~sw (socket_domain_of saddr) Unix.SOCK_DGRAM 0 in
@@ -162,8 +168,8 @@ module Impl = struct
 
   let listen () = listen
 
-  let connect () ~sw addr =
-    let socket = connect ~sw addr in
+  let connect () ~bind_to ~options ~sw addr =
+    let socket = connect ~bind_to ~options ~sw addr in
     (socket :> [`Generic | `Unix] Eio.Net.stream_socket_ty r)
 
   let datagram_socket () ~reuse_addr ~reuse_port ~sw saddr =

--- a/lib_eio_windows/net.ml
+++ b/lib_eio_windows/net.ml
@@ -147,7 +147,7 @@ let listen ~reuse_addr ~reuse_port ~backlog ~sw (listen_addr : Eio.Net.Sockaddr.
     );
   (listening_socket ~hook sock :> _ Eio.Net.listening_socket_ty r)
 
-let connect ~sw connect_addr =
+let connect ~bind_to ~options ~sw connect_addr =
   let socket_type, addr =
     match connect_addr with
     | `Unix path         -> Unix.SOCK_STREAM, Unix.ADDR_UNIX path
@@ -156,10 +156,16 @@ let connect ~sw connect_addr =
       Unix.SOCK_STREAM, Unix.ADDR_INET (host, port)
   in
   let sock = Low_level.socket ~sw (socket_domain_of connect_addr) socket_type 0 in
-  try
-    Low_level.connect sock addr;
-    (Flow.of_fd sock :> _ Eio_unix.Net.stream_socket)
-  with Unix.Unix_error (code, name, arg) -> raise (Err.v code name arg)
+  let rec set_options : Eio.Net.Sockopt.settings -> unit = function
+    | [] -> ()
+    | (o, v) :: tl -> Eio_unix.Private.setsockopt sock o v; set_options tl
+  in
+  Err.run (fun () ->
+     set_options options;
+     Option.iter (fun a -> Fd.use_exn "bind" sock (fun fd -> Unix.bind fd (Eio_unix.Net.sockaddr_to_unix a))) bind_to;
+     Low_level.connect sock addr;
+  ) ();
+  (Flow.of_fd sock :> _ Eio_unix.Net.stream_socket)
 
 let create_datagram_socket ~reuse_addr ~reuse_port ~sw saddr =
   let sock = Low_level.socket ~sw (socket_domain_of saddr) Unix.SOCK_DGRAM 0 in
@@ -183,8 +189,8 @@ module Impl = struct
 
   let listen () = listen
 
-  let connect () ~sw addr =
-    let socket = connect ~sw addr in
+  let connect () ~bind_to ~options ~sw addr =
+    let socket = connect ~bind_to ~options ~sw addr in
     (socket :> [`Generic | `Unix] Eio.Net.stream_socket_ty r)
 
   let datagram_socket () ~reuse_addr ~reuse_port ~sw saddr =

--- a/tests/network.md
+++ b/tests/network.md
@@ -647,6 +647,64 @@ Exception: Eio.Io Net Invalid_option,
   getting socket option Unix.SO_LINGER
 ```
 
+## Bind before connect
+
+Binding a source address and setting options before connecting.
+
+```ocaml
+# run @@ fun ~net sw ->
+  let server = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:5 addr in
+  let client =
+    Eio.Net.connect ~sw net (Eio.Net.listening_addr server)
+      ~bind_to:(`Tcp (Eio.Net.Ipaddr.V4.loopback, 0))
+      ~options:Eio.Net.Sockopt.[
+          (SO_REUSEADDR, true);
+          (SO_KEEPALIVE, true);
+        ]
+  in
+  let _ = Eio.Net.accept ~sw server in
+  traceln "keepalive=%b" (Eio.Net.getsockopt client Eio.Net.Sockopt.SO_KEEPALIVE);;
++keepalive=true
+- : unit = ()
+```
+
+The mock backend also traces the options in the order they are applied:
+
+```ocaml
+# Eio_mock.Backend.run @@ fun () ->
+  Switch.run @@ fun sw ->
+  let net = Eio_mock.Net.make "mock-net" in
+  Eio_mock.Net.on_connect net [`Return (Eio_mock.Flow.make "flow")];
+  let _ =
+    Eio.Net.connect ~sw net addr
+      ~bind_to:(`Tcp (Eio.Net.Ipaddr.V4.loopback, 0))
+      ~options:Eio.Net.Sockopt.[
+          (SO_REUSEADDR, true);
+          (SO_KEEPALIVE, true);
+        ]
+  in ();;
++mock-net: connect to tcp:127.0.0.1:8081
++mock-net: setsockopt SO_REUSEADDR = true
++mock-net: setsockopt SO_KEEPALIVE = true
++mock-net: bind tcp:127.0.0.1:0
++flow: closed
+- : unit = ()
+```
+
+A failing bind (here, a non-local source address) should be reported as `Eio.Io`.
+
+```ocaml
+# run @@ fun ~net sw ->
+  match
+    Eio.Net.connect ~sw net addr
+      ~bind_to:(`Tcp (Eio.Net.Ipaddr.of_raw "\001\002\003\004", 0))
+  with
+  | (_ : _ Eio.Net.stream_socket) -> traceln "unexpectedly connected"
+  | exception (Eio.Io _) -> traceln "got Eio.Io";;
++got Eio.Io
+- : unit = ()
+```
+
 ## Getaddrinfo
 
 ```ocaml

--- a/tests/network.md
+++ b/tests/network.md
@@ -647,6 +647,63 @@ Exception: Eio.Io Net Invalid_option,
   getting socket option Unix.SO_LINGER
 ```
 
+## Bind before connect
+
+Binding a source address and setting options before connecting.
+
+```ocaml
+# run @@ fun ~net sw ->
+  let server = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:5 addr in
+  let client =
+    Eio.Net.connect ~sw net (Eio.Net.listening_addr server)
+      ~bind_to:(`Tcp (Eio.Net.Ipaddr.V4.loopback, 0))
+      ~options:Eio.Net.Sockopt.[
+          (SO_REUSEADDR, true);
+          (SO_KEEPALIVE, true);
+        ]
+  in
+  let _ = Eio.Net.accept ~sw server in
+  traceln "keepalive=%b" (Eio.Net.getsockopt client Eio.Net.Sockopt.SO_KEEPALIVE);;
++keepalive=true
+- : unit = ()
+```
+
+The mock backend also traces the options in the order they are applied:
+
+```ocaml
+# Eio_mock.Backend.run @@ fun () ->
+  Switch.run @@ fun sw ->
+  let net = Eio_mock.Net.make "mock-net" in
+  Eio_mock.Net.on_connect net [`Return (Eio_mock.Flow.make "flow")];
+  let _ =
+    Eio.Net.connect ~sw net addr
+      ~bind_to:(`Tcp (Eio.Net.Ipaddr.V4.loopback, 0))
+      ~options:Eio.Net.Sockopt.[
+          (SO_REUSEADDR, true);
+          (SO_KEEPALIVE, true);
+        ]
+  in ();;
++mock-net: connect to tcp:127.0.0.1:8081 (bind to tcp:127.0.0.1:0)
++flow: setsockopt SO_REUSEADDR = true
++flow: setsockopt SO_KEEPALIVE = true
++flow: closed
+- : unit = ()
+```
+
+A failing bind (here, a non-local source address) should be reported as `Eio.Io`.
+
+```ocaml
+# run @@ fun ~net sw ->
+  match
+    Eio.Net.connect ~sw net addr
+      ~bind_to:(`Tcp (Eio.Net.Ipaddr.of_raw "\001\002\003\004", 0))
+  with
+  | (_ : _ Eio.Net.stream_socket) -> traceln "unexpectedly connected"
+  | exception (Eio.Io _) -> traceln "got Eio.Io";;
++got Eio.Io
+- : unit = ()
+```
+
 ## Getaddrinfo
 
 ```ocaml


### PR DESCRIPTION
Only 92d2924b1824b723610fa69ce54d6b1d03a3b31b is relevant here; it is layered over #850 

This is based on work by @art-w in #713 and revised based on review comments in that PR.  It exposes a single `options` GADT that can specify either bindings or setting options. Could be simplified more (to remove the convenience functions like `reuse_addr` if deemed too verbose) but I wanted to check on the basic interface first.