### PR TITLE
chown: prevent sandbox escape using symlinks

### DIFF
--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -750,13 +750,15 @@ let chmod ~follow ~mode dir path =
     Eio_unix.run_in_systhread ~label:"chmod" (fun () -> Eio_unix.Private.chmod parent leaf ~mode ~flags)
   with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
 
-let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) fd path =
-  let module X = Uring.Statx in
-  let flags = if follow then X.Flags.empty_path else X.Flags.(empty_path + symlink_nofollow) in
-  let flags = (flags :> int) in
+let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) dirfd path =
   try
-    with_parent_dir_fd fd path @@ fun parent leaf ->
-    Eio_unix.run_in_systhread ~label:"chown" (fun () -> Eio_unix.Private.chown ~flags ~uid ~gid parent leaf)
+    Switch.run @@ fun sw ->
+    let flags = Uring.Open_flags.(cloexec + path + if follow then empty else nofollow) in
+    let fd = openat ~sw ~flags ~access:`R ~perm:0 dirfd path in
+    Eio_unix.run_in_systhread ~label:"chown" (fun () ->
+        let flags = (Uring.Statx.Flags.empty_path :> int) in
+        Eio_unix.Private.chown ~flags ~uid ~gid fd ""
+      )
   with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
 
 let getaddrinfo ~service node =

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -477,13 +477,6 @@ let read_link dirfd path =
   Resolve.with_parent "read_link" dirfd path @@ fun dirfd path ->
   Eio_unix.Private.read_link_unix dirfd path
 
-let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) dirfd path =
-  let flags = if follow then 0 else Config.at_symlink_nofollow in
-  in_worker_thread "chown" @@ fun () ->
-  Resolve.with_parent "chown" dirfd path @@ fun dirfd path ->
-  let dirfd = Option.value dirfd ~default:at_fdcwd in
-  Eio_unix.Private.chown_unix ~flags ~uid ~gid dirfd path
-
 type stat
 external create_stat : unit -> stat = "caml_eio_posix_make_stat"
 external eio_fstatat : stat -> Unix.file_descr -> string -> int -> unit = "caml_eio_posix_fstatat"
@@ -530,6 +523,32 @@ let fstatat ~buf ~follow dirfd path =
   | Fd dirfd ->
     Fd.use_exn "fstat" dirfd @@ fun dirfd ->
     fstatat_confined ~buf ~follow (Some dirfd) path
+
+let is_symlink dirfd path =
+  let buf = create_stat () in
+  eio_fstatat buf dirfd path Config.at_symlink_nofollow;
+  kind buf = `Symbolic_link
+
+let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) dirfd path =
+  Err.run (in_worker_thread "chown") @@ fun () ->
+  let use_confined dirfd =
+    Resolve.with_parent_loop ?dirfd path @@ fun dirfd path ->
+    let dirfd = Option.value dirfd ~default:at_fdcwd in
+    if follow && is_symlink dirfd path then Error (`Symlink None)
+    else (
+      (* Note: if [follow=true] and [path] wasn't a symlink when we checked
+         above but is now, we'll chown the new symlink instead of its target.
+         However, this doesn't allow escaping the sandbox. *)
+      Eio_unix.Private.chown_unix ~flags:Config.at_symlink_nofollow ~uid ~gid dirfd path;
+      Ok ()
+    )
+  in
+  match dirfd with
+  | Fs ->
+    let flags = if follow then 0 else Config.at_symlink_nofollow in
+    Eio_unix.Private.chown_unix ~flags ~uid ~gid at_fdcwd path 
+  | Cwd -> use_confined None
+  | Fd dirfd -> Fd.use_exn "chown" dirfd @@ fun dirfd -> use_confined (Some dirfd)
 
 let lseek fd off cmd =
   Fd.use_exn "lseek" fd @@ fun fd ->

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -995,6 +995,58 @@ useful, so run it occasionally either as root or as a user with multiple groups.
 - : unit = ()
 ```
 
+Check that chown sandboxing works:
+
+```ocaml
+# run ~clear:["sandbox"; "outside.txt"] @@ fun env ->
+  let cwd = Eio.Stdenv.cwd env in
+  Switch.run @@ fun sw ->
+  Path.save ~create:(`Exclusive 0o644) (cwd / "outside.txt") "outside";
+  try_mkdir (cwd / "sandbox");
+  Path.save ~create:(`Exclusive 0o644) (cwd / "sandbox/inside.txt") "inside";
+  let sandbox = Path.open_subtree ~sw (cwd / "sandbox") in
+  Path.symlink ~link_to:"inside.txt" (sandbox / "ok");
+  Path.symlink ~link_to:"../outside.txt" (sandbox / "escape");
+  let gid0 = (Eio.Path.stat ~follow:false sandbox).gid in
+  let other_gid =
+    (* Find another group we have access to.
+       If there isn't one, just use the file's initial group. *)
+    Unix.getegid () :: Array.to_list (Unix.getgroups ())
+    |> List.map Int64.of_int
+    |> List.find_opt (fun gid -> gid <> gid0)
+    |> Option.value ~default:gid0
+  in
+  let try_chown ~follow path =
+    match Eio.Path.chown ~gid:other_gid ~follow path with
+    | exception ex -> traceln "chown %a (follow=%b) -> @[<h>%a@]" Path.pp path follow Eio.Exn.pp ex
+    | () ->
+      traceln "chown %a (follow=%b) -> ok" Path.pp path follow;
+      if (Eio.Path.stat ~follow path).gid = other_gid then (
+        Eio.Path.chown ~follow ~gid:gid0 path;
+      ) else (
+        failwith "chown didn't set correct group!"
+      )
+  in
+  (* Following a symlink out of the sandbox is rejected, and the target is unchanged: *)
+  try_chown ~follow:true (sandbox / "ok");
+  try_chown ~follow:true (sandbox / "escape");
+  try_chown ~follow:false (sandbox / "ok");
+  try_chown ~follow:false (sandbox / "escape");
+  traceln "Try without sandboxing";
+  let unconfined = env#fs / "sandbox" in
+  try_chown ~follow:false (unconfined / "escape");
+  try_chown ~follow:true (unconfined / "escape");;
++mkdir <cwd:sandbox> -> ok
++chown <sandbox:ok> (follow=true) -> ok
++chown <sandbox:escape> (follow=true) -> Eio.Io Fs Permission_denied _, changing ownership of <sandbox:escape>
++chown <sandbox:ok> (follow=false) -> ok
++chown <sandbox:escape> (follow=false) -> ok
++Try without sandboxing
++chown <fs:sandbox/escape> (follow=false) -> ok
++chown <fs:sandbox/escape> (follow=true) -> ok
+- : unit = ()
+```
+
 # Cancelling while readable
 
 Ensure reads can be cancelled promptly, even if there is no need to wait:


### PR DESCRIPTION
Before, we opened the parent directory and then did `chown`, following symlinks if called with `~follow:true`. This is not safe, since the symlink may point outside of the sandbox.

The new code works as follows:

On eio_linux:
- Instead of opening the parent directory, just open the target itself with `O_PATH` and use `AT_EMPTY_PATH` to set it.

On eio_posix with follow=false:
- Open the parent directory and do `chown ~follow:false` on the child.

On eio_posix with follow=true:
- Open the parent directory.
- If the child is a symlink, follow it.
- Otherwise, `chown ~follow:false` on it.

For this last case (eio_posix+follow), there is a small race:
- If a symlink changes into a non-symlink while we're chowning it, we'll raise an error from `readlink`.
- If a non-symlink changes into a symlink, we'll change the ownership of the symlink even though we're supposed to be following links.

We don't escape the sandbox in either case.

(this addresses just the `chown` part of @avsm's #872)

/cc @patricoferris 

(note: chown support hasn't yet appeared in a release)