### PR TITLE
Use a sensible minimum buffer size for Path.load

### DIFF
--- a/lib_eio/path.ml
+++ b/lib_eio/path.ml
@@ -164,7 +164,7 @@ let load t =
       raise @@ Fs.err File_too_large;
     let buf =
       Buf_read.of_flow flow
-        ~initial_size:(Optint.Int63.to_int size + 1)
+        ~initial_size:(max 4096 (Optint.Int63.to_int size + 1))
         ~max_size:(Sys.max_string_length + 1)
     in
     Buf_read.take_all buf


### PR DESCRIPTION
Files in `/proc` report a size of 0, which caused us to start with an initial buffer size of 1. This is inefficient. Also, `/proc` doesn't always produce correct results with very small buffers.

e.g. reading "/proc/sys/fs/file-nr" with a 1-byte buffer returns EOF after the first byte!

Fixes #835.