### PR TITLE
Remove unused show_backend_exceptions flag

### DIFF
--- a/lib_eio/core/exn.ml
+++ b/lib_eio/core/exn.ml
@@ -1,5 +1,3 @@
-let show_backend_exceptions = ref true
-
 type with_bt = exn * Printexc.raw_backtrace
 
 type err = ..


### PR DESCRIPTION
`Backend.show` is the one that's actually used (and exposed in the public API).