### PR TITLE
win32: declare unixsupport functions as CAMLextern

### DIFF
--- a/lib_eio/unix/eio_unix_stubs.c
+++ b/lib_eio/unix/eio_unix_stubs.c
@@ -12,11 +12,21 @@
 #endif
 
 #include <caml/mlvalues.h>
-#include <caml/unixsupport.h>
 #include <caml/memory.h>
 #include <caml/bigarray.h>
 #include <caml/alloc.h>
-#include <caml/socketaddr.h>
+
+#ifndef _WIN32
+# include <caml/socketaddr.h>
+#endif
+
+#ifdef _WIN32
+CAMLnoret CAMLextern
+void caml_unix_error (int errcode, const char * cmdname, value arg);
+#define Nothing ((value) 0)
+#else
+#include <caml/unixsupport.h>
+#endif
 
 static void caml_stat_free_preserving_errno(void *ptr) {
   int saved = errno;
@@ -120,6 +130,7 @@ CAMLprim value eio_unix_fchownat(value v_fd, value v_path, value v_uid, value v_
 #endif
 }
 
+#ifndef _WIN32
 static int caml_eai_of_unix(int eai) {
   switch (eai) {
     // These numbers must match the order of constructors in Eio.Net.Getaddrinfo_error.t
@@ -149,6 +160,7 @@ static int caml_eai_of_unix(int eai) {
     default: return 0;
   }
 }
+#endif /* !_WIN32 */
 
 CAMLprim value eio_unix_getaddrinfo(value v_node, value v_service) {
 #ifdef _WIN32

--- a/lib_eio/unix/fork_action.c
+++ b/lib_eio/unix/fork_action.c
@@ -26,6 +26,10 @@
 
 #include "fork_action.h"
 
+#ifdef _WIN32
+CAMLextern value caml_unix_error_of_code(int errcode);
+#endif
+
 #ifndef _WIN32
 void eio_unix_run_fork_actions(int errors, value v_actions) {
   int old_flags = fcntl(errors, F_GETFL, 0);

--- a/lib_eio/unix/pty.c
+++ b/lib_eio/unix/pty.c
@@ -19,6 +19,11 @@
 #include <caml/fail.h>
 #include <caml/unixsupport.h>
 
+#ifdef _WIN32
+CAMLnoret CAMLextern
+void caml_unix_error (int errcode, const char * cmdname, value arg);
+#endif
+
 /* Returns [pty_fd], opened close-on-exec. */
 CAMLprim value eio_unix_open_pty(value v_unit) {
 #ifdef _WIN32


### PR DESCRIPTION
This is necessary under Windows to prevent flexdll errors when dynamically loading "caml_unix_error RELOC_REL32, target is too far" and with the fix allows mdx tests to get further

Solution pointed out by @dra27