### PR TITLE
eio_linux: add Low_level.{socket,bind,listen} with uring support

### DIFF
--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -116,8 +116,7 @@ let socket_domain_of = function
 
 let connect ~sw connect_addr =
   let addr = Eio_unix.Net.sockaddr_to_unix connect_addr in
-  let sock_unix = Unix.socket ~cloexec:true (socket_domain_of connect_addr) Unix.SOCK_STREAM 0 in
-  let sock = Fd.of_unix ~sw ~seekable:false ~close_unix:true sock_unix in
+  let sock = Low_level.socket ~sw (socket_domain_of connect_addr) Unix.SOCK_STREAM 0 in
   Low_level.connect sock addr;
   (Flow.of_fd sock :> _ Eio_unix.Net.stream_socket)
 
@@ -137,8 +136,7 @@ module Impl = struct
         | exception Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
     );
     let addr = Eio_unix.Net.sockaddr_to_unix listen_addr in
-    let sock_unix = Unix.socket ~cloexec:true (socket_domain_of listen_addr) Unix.SOCK_STREAM 0 in
-    let sock = Fd.of_unix ~sw ~seekable:false ~close_unix:true sock_unix in
+    let sock = Low_level.socket ~sw (socket_domain_of listen_addr) Unix.SOCK_STREAM 0 in
     (* For Unix domain sockets, remove the path when done (except for abstract sockets). *)
     begin match listen_addr with
       | `Unix path ->
@@ -146,12 +144,13 @@ module Impl = struct
           Switch.on_release sw (fun () -> Unix.unlink path)
       | `Tcp _ -> ()
     end;
-    if reuse_addr then
-      Unix.setsockopt sock_unix Unix.SO_REUSEADDR true;
-    if reuse_port then
-      Unix.setsockopt sock_unix Unix.SO_REUSEPORT true;
-    Unix.bind sock_unix addr;
-    Unix.listen sock_unix backlog;
+    if reuse_addr || reuse_port then (
+      Fd.use_exn "setsockopt" sock (fun sock_unix ->
+          if reuse_addr then Unix.setsockopt sock_unix Unix.SO_REUSEADDR true;
+          if reuse_port then Unix.setsockopt sock_unix Unix.SO_REUSEPORT true);
+    );
+    Low_level.bind sock addr;
+    Low_level.listen sock backlog;
     (listening_socket sock :> _ Eio.Net.listening_socket_ty r)
 
   let connect () ~sw addr = (connect ~sw addr :> [`Generic | `Unix] Eio.Net.stream_socket_ty r)
@@ -167,16 +166,16 @@ module Impl = struct
         | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
         | exception Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
     );
-    let sock_unix = Unix.socket ~cloexec:true (socket_domain_of saddr) Unix.SOCK_DGRAM 0 in
-    let sock = Fd.of_unix ~sw ~seekable:false ~close_unix:true sock_unix in
+    let sock = Low_level.socket ~sw (socket_domain_of saddr) Unix.SOCK_DGRAM 0 in
     begin match saddr with
     | `Udp _ | `Unix _ as saddr ->
       let addr = Eio_unix.Net.sockaddr_to_unix saddr in
-      if reuse_addr then
-        Unix.setsockopt sock_unix Unix.SO_REUSEADDR true;
-      if reuse_port then
-        Unix.setsockopt sock_unix Unix.SO_REUSEPORT true;
-      Unix.bind sock_unix addr
+      if reuse_addr || reuse_port then (
+        Fd.use_exn "setsockopt" sock (fun sock_unix ->
+            if reuse_addr then Unix.setsockopt sock_unix Unix.SO_REUSEADDR true;
+            if reuse_port then Unix.setsockopt sock_unix Unix.SO_REUSEPORT true);
+      );
+      Low_level.bind sock addr
     | `UdpV4 | `UdpV6 -> ()
     end;
     (datagram_socket sock :> [`Generic | `Unix] Eio.Net.datagram_socket_ty r)

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -700,30 +700,87 @@ let symlink ~link_to dir path =
     eio_symlinkat link_to parent leaf
   with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
 
+let rec enqueue_shutdown fd command st action =
+  let retry = Sched.with_cancel_hook ~action st (fun () ->
+      Uring.shutdown st.uring fd command (Job action)
+    )
+  in
+  if retry then (* wait until an sqe is available *)
+    Queue.push (fun st -> enqueue_shutdown fd command st action) st.io_q
+
 let shutdown socket command =
-  try
-    Fd.use_exn "shutdown" socket @@ fun fd ->
-    Unix.shutdown fd command
-  with
-  | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
-  | Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+  Fd.use_exn "shutdown" socket @@ fun fd ->
+  let res = Sched.enter "shutdown" (enqueue_shutdown fd command) in
+  match Res.unit_result res with
+  | Ok () -> ()
+  | Error Unix.ENOTCONN -> ()
+  | Error e -> raise @@ Err.wrap e "shutdown" ""
+
+let rec enqueue_socket domain ty protocol st action =
+  let retry = Sched.with_cancel_hook ~action st (fun () ->
+      (* The default [flags] sets close-on-exec on the new socket. *)
+      Uring.socket st.uring domain ty protocol (Job action)
+    )
+  in
+  if retry then (* wait until an sqe is available *)
+    Queue.push (fun st -> enqueue_socket domain ty protocol st action) st.io_q
 
 let socket ~sw domain ty protocol =
   let fd =
-    try Unix.socket ~cloexec:true domain ty protocol
-    with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+    if !Sched.socket_works then (
+      let res = Sched.enter "socket" (enqueue_socket domain ty protocol) in
+      match Uring.Res.fd_result res with
+      | Ok fd -> fd
+      | Error e -> raise @@ Err.wrap e "socket" ""
+    ) else (
+      (* IORING_OP_SOCKET requires Linux >= 5.19; fall back to a blocking call. *)
+      try Unix.socket ~cloexec:true domain ty protocol
+      with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+    )
   in
   Fd.of_unix ~sw ~seekable:false ~close_unix:true fd
 
+let rec enqueue_bind fd addr st action =
+  let retry = Sched.with_cancel_hook ~action st (fun () ->
+      Uring.bind st.uring fd addr (Job action)
+    )
+  in
+  if retry then (* wait until an sqe is available *)
+    Queue.push (fun st -> enqueue_bind fd addr st action) st.io_q
+
 let bind fd addr =
   Fd.use_exn "bind" fd @@ fun fd ->
-  try Unix.bind fd addr
-  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+  if !Sched.bind_works then (
+    let res = Sched.enter "bind" (enqueue_bind fd addr) in
+    match Res.unit_result res with
+    | Ok () -> ()
+    | Error e -> raise @@ Err.wrap e "bind" ""
+  ) else (
+    (* IORING_OP_BIND requires Linux >= 6.11; fall back to a blocking call. *)
+    try Unix.bind fd addr
+    with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+  )
+
+let rec enqueue_listen fd backlog st action =
+  let retry = Sched.with_cancel_hook ~action st (fun () ->
+      Uring.listen st.uring fd backlog (Job action)
+    )
+  in
+  if retry then (* wait until an sqe is available *)
+    Queue.push (fun st -> enqueue_listen fd backlog st action) st.io_q
 
 let listen fd backlog =
   Fd.use_exn "listen" fd @@ fun fd ->
-  try Unix.listen fd backlog
-  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+  if !Sched.listen_works then (
+    let res = Sched.enter "listen" (enqueue_listen fd backlog) in
+    match Res.unit_result res with
+    | Ok () -> ()
+    | Error e -> raise @@ Err.wrap e "listen" ""
+  ) else (
+    (* IORING_OP_LISTEN requires Linux >= 6.11; fall back to a blocking call. *)
+    try Unix.listen fd backlog
+    with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+  )
 
 let accept ~sw fd =
   Fd.use_exn "accept" fd @@ fun fd ->

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -727,7 +727,7 @@ let rec enqueue_socket domain ty protocol st action =
 
 let socket ~sw domain ty protocol =
   let fd =
-    if !Sched.socket_works then (
+    if Sched.op_supported Uring.Op.socket then (
       let res = Sched.enter "socket" (enqueue_socket domain ty protocol) in
       match Uring.Res.fd_result res with
       | Ok fd -> fd
@@ -750,7 +750,7 @@ let rec enqueue_bind fd addr st action =
 
 let bind fd addr =
   Fd.use_exn "bind" fd @@ fun fd ->
-  if !Sched.bind_works then (
+  if Sched.op_supported Uring.Op.bind then (
     let res = Sched.enter "bind" (enqueue_bind fd addr) in
     match Res.unit_result res with
     | Ok () -> ()
@@ -771,7 +771,7 @@ let rec enqueue_listen fd backlog st action =
 
 let listen fd backlog =
   Fd.use_exn "listen" fd @@ fun fd ->
-  if !Sched.listen_works then (
+  if Sched.op_supported Uring.Op.listen then (
     let res = Sched.enter "listen" (enqueue_listen fd backlog) in
     match Res.unit_result res with
     | Ok () -> ()

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -708,6 +708,23 @@ let shutdown socket command =
   | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
   | Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
 
+let socket ~sw domain ty protocol =
+  let fd =
+    try Unix.socket ~cloexec:true domain ty protocol
+    with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+  in
+  Fd.of_unix ~sw ~seekable:false ~close_unix:true fd
+
+let bind fd addr =
+  Fd.use_exn "bind" fd @@ fun fd ->
+  try Unix.bind fd addr
+  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+
+let listen fd backlog =
+  Fd.use_exn "listen" fd @@ fun fd ->
+  try Unix.listen fd backlog
+  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+
 let accept ~sw fd =
   Fd.use_exn "accept" fd @@ fun fd ->
   let client_addr = Uring.Sockaddr.create () in

--- a/lib_eio_linux/low_level.mli
+++ b/lib_eio_linux/low_level.mli
@@ -220,6 +220,18 @@ val ftruncate : fd -> Optint.Int63.t -> unit
 
 (** {1 Sockets} *)
 
+val socket : sw:Switch.t -> Unix.socket_domain -> Unix.socket_type -> int -> fd
+(** [socket ~sw domain ty protocol] creates a new socket, like {!Unix.socket}.
+
+    The new socket has the close-on-exec flag set and is attached to [sw]. *)
+
+val bind : fd -> Unix.sockaddr -> unit
+(** [bind fd addr] binds socket [fd] to [addr], like {!Unix.bind}. *)
+
+val listen : fd -> int -> unit
+(** [listen fd backlog] marks socket [fd] as accepting connections, like
+    {!Unix.listen}. *)
+
 val accept : sw:Switch.t -> fd -> (fd * Unix.sockaddr)
 (** [accept ~sw t] blocks until a new connection is received on listening socket [t].
 

--- a/lib_eio_linux/low_level.mli
+++ b/lib_eio_linux/low_level.mli
@@ -223,14 +223,22 @@ val ftruncate : fd -> Optint.Int63.t -> unit
 val socket : sw:Switch.t -> Unix.socket_domain -> Unix.socket_type -> int -> fd
 (** [socket ~sw domain ty protocol] creates a new socket, like {!Unix.socket}.
 
-    The new socket has the close-on-exec flag set and is attached to [sw]. *)
+    The new socket has the close-on-exec flag set and is attached to [sw].
+    On Linux >= 5.19 this uses io_uring and on older kernels it falls back
+    to a [socket(2)] call. *)
 
 val bind : fd -> Unix.sockaddr -> unit
-(** [bind fd addr] binds socket [fd] to [addr], like {!Unix.bind}. *)
+(** [bind fd addr] binds socket [fd] to [addr], like {!Unix.bind}.
+
+    On Linux >= 6.11 this uses io_uring and on older kernels falls back to a
+    [bind(2)] call. *)
 
 val listen : fd -> int -> unit
 (** [listen fd backlog] marks socket [fd] as accepting connections, like
-    {!Unix.listen}. *)
+    {!Unix.listen}.
+
+    On Linux >= 6.11 this uses io_uring and on older kernels falls back to a
+    [listen(2)] call. *)
 
 val accept : sw:Switch.t -> fd -> (fd * Unix.sockaddr)
 (** [accept ~sw t] blocks until a new connection is received on listening socket [t].

--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -9,9 +9,10 @@ module Suspended = Eio_utils.Suspended
 module Zzz = Eio_utils.Zzz
 module Lf_queue = Eio_utils.Lf_queue
 
-let socket_works = ref false    (* IORING_OP_SOCKET requires Linux >= 5.19 *)
-let bind_works = ref false      (* IORING_OP_BIND requires Linux >= 6.11 *)
-let listen_works = ref false    (* IORING_OP_LISTEN requires Linux >= 6.11 *)
+let probe = ref None
+
+let op_supported op =
+  Uring.op_supported (Option.get !probe) op
 
 type exit = [`Exit_scheduler]
 
@@ -454,19 +455,18 @@ let with_sched ?(fallback=no_fallback) config fn =
   | exception Unix.Unix_error(EPERM, _, _) -> fallback (`Msg "io_uring is not available (permission denied)")
   | exception Unix.Unix_error(ENOMEM, _, _) -> fallback (`Msg "io_uring is not available (ENOMEM)")
   | uring ->
-    let probe = Uring.get_probe uring in
+    let probe =
+      match !probe with
+      | Some p -> p
+      | None ->
+        let p = Uring.get_probe uring in
+        probe := Some p;
+        p
+    in
     if not (Uring.op_supported probe Uring.Op.msg_ring) then (
       Uring.exit uring;
       fallback (`Msg "Linux >= 5.18 is required for io_uring support")
     ) else (
-      (* The reason for an if here is to make sure we only set it once, when
-         the first domain is starting. This is just to avoid a tsan warning. *)
-      if not !socket_works && Uring.op_supported probe Uring.Op.socket then
-        socket_works := true;
-      if not !bind_works && Uring.op_supported probe Uring.Op.bind then
-        bind_works := true;
-      if not !listen_works && Uring.op_supported probe Uring.Op.listen then
-        listen_works := true;
       match
         let mem =
           let fixed_buf_len = block_size * n_blocks in

--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -9,6 +9,10 @@ module Suspended = Eio_utils.Suspended
 module Zzz = Eio_utils.Zzz
 module Lf_queue = Eio_utils.Lf_queue
 
+let socket_works = ref false    (* IORING_OP_SOCKET requires Linux >= 5.19 *)
+let bind_works = ref false      (* IORING_OP_BIND requires Linux >= 6.11 *)
+let listen_works = ref false    (* IORING_OP_LISTEN requires Linux >= 6.11 *)
+
 type exit = [`Exit_scheduler]
 
 (* Type of user-data attached to jobs. *)
@@ -455,6 +459,14 @@ let with_sched ?(fallback=no_fallback) config fn =
       Uring.exit uring;
       fallback (`Msg "Linux >= 5.18 is required for io_uring support")
     ) else (
+      (* The reason for an if here is to make sure we only set it once, when
+         the first domain is starting. This is just to avoid a tsan warning. *)
+      if not !socket_works && Uring.op_supported probe Uring.Op.socket then
+        socket_works := true;
+      if not !bind_works && Uring.op_supported probe Uring.Op.bind then
+        bind_works := true;
+      if not !listen_works && Uring.op_supported probe Uring.Op.listen then
+        listen_works := true;
       match
         let mem =
           let fixed_buf_len = block_size * n_blocks in


### PR DESCRIPTION
This is the networking part of @avsm's #850, split out to help me review it.

The first commit adds `Low_level.{socket,bind,listen}` helpers to clean up the code and the second gets them to use uring, if available. `shutdown` now also uses uring, and errors are wrapped in more cases.

I made a couple of minor changes:

- Instead of recording a bool for each feature, I added a commit to store the `probe` itself. `opcode_supported` is `noalloc`, so I wouldn't expect this to be a performance problem. Avoids having to modify `sched.ml` every time we need to query a new feature.
- I removed `test_tcp_loopback`. It didn't seem to be testing anything Linux-specific, and we already have loopback tests in the main `tests` directory.