### PR TITLE
Remove all use of `[@@@alert "-unstable"]`

### DIFF
--- a/lib_eio/core/fiber.ml
+++ b/lib_eio/core/fiber.ml
@@ -1,5 +1,3 @@
-[@@@alert "-unstable"]
-
 type _ Effect.t += Fork : Cancel.fiber_context * (unit -> unit) -> unit Effect.t
 
 let yield () =

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -1,5 +1,3 @@
-[@@@alert "-unstable"]
-
 open Eio.Std
 
 module Fd = Fd

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -4,8 +4,6 @@
     For example, it is possible to leak file descriptors this way, or to use them after they've been closed,
     allowing one module to corrupt a file belonging to an unrelated module. *)
 
-[@@@alert "-unstable"]
-
 open Eio.Std
 
 type Eio.Exn.Backend.t += Unix_error of Unix.error * string * string

--- a/lib_eio/unix/net.ml
+++ b/lib_eio/unix/net.ml
@@ -57,8 +57,6 @@ let getnameinfo (sockaddr : Eio.Net.Sockaddr.t) =
 
 type t = [`Generic | `Unix] Eio.Net.ty r
 
-[@@@alert "-unstable"]
-
 type _ Effect.t +=
   | Import_socket_stream : Switch.t * bool * Unix.file_descr -> [`Unix_fd | stream_socket_ty] r Effect.t
   | Import_socket_listening : Switch.t * bool * Unix.file_descr -> [`Unix_fd | listening_socket_ty] r Effect.t

--- a/lib_eio/unix/net.mli
+++ b/lib_eio/unix/net.mli
@@ -129,7 +129,6 @@ type _ Effect.t +=
       ([`Unix_fd | stream_socket_ty] r * [`Unix_fd | stream_socket_ty] r) Effect.t      (** See {!socketpair_stream} *)
   | Socketpair_datagram : Eio.Switch.t * Unix.socket_domain * int ->
       ([`Unix_fd | datagram_socket_ty] r * [`Unix_fd | datagram_socket_ty] r) Effect.t  (** See {!socketpair_datagram} *)
-[@@alert "-unstable"]
 
 val setsockopt : Fd.t -> 'a Eio.Net.Sockopt.t -> 'a -> unit
 (** [setsockopt fd opt v] sets socket option [opt] to value [v] on file descriptor [fd].

--- a/lib_eio/unix/private.ml
+++ b/lib_eio/unix/private.ml
@@ -1,5 +1,3 @@
-[@@@alert "-unstable"]
-
 open Eio.Std
 open Types
 

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -15,8 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-[@@@alert "-unstable"]
-
 open Eio.Std
 
 module Fiber_context = Eio.Private.Fiber_context

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -1,5 +1,3 @@
-[@@@alert "-unstable"]
-
 open Eio.Std
 
 module Trace = Eio.Private.Trace

--- a/lib_eio_linux/sched.ml
+++ b/lib_eio_linux/sched.ml
@@ -1,5 +1,3 @@
-[@@@alert "-unstable"]
-
 open Eio.Std
 
 module Fiber_context = Eio.Private.Fiber_context

--- a/lib_eio_posix/domain_mgr.ml
+++ b/lib_eio_posix/domain_mgr.ml
@@ -16,8 +16,6 @@
 
 open Eio.Std
 
-[@@@alert "-unstable"]
-
 module Fd = Eio_unix.Fd
 module Trace = Eio.Private.Trace
 

--- a/lib_eio_posix/sched.ml
+++ b/lib_eio_posix/sched.ml
@@ -323,8 +323,6 @@ let with_op t fn x =
     t.active_ops <- t.active_ops - 1;
     raise ex
 
-[@@@alert "-unstable"]
-
 type _ Effect.t += Enter : (t -> 'a Eio_utils.Suspended.t -> [`Exit_scheduler]) -> 'a Effect.t
 
 let enter op fn =

--- a/lib_eio_posix/sched.mli
+++ b/lib_eio_posix/sched.mli
@@ -17,7 +17,7 @@ val with_sched : (t -> 'a) -> 'a
 
 val run :
   extra_effects:exit Effect.Deep.effect_handler ->
-  t -> ('a -> 'b) -> 'a -> 'b [@@alert "-unstable"]
+  t -> ('a -> 'b) -> 'a -> 'b
 (** [run ~extra_effects t f x] starts an event loop using [t] and runs [f x] as the root fiber within it.
 
     Unknown effects are passed to [extra_effects]. *)

--- a/lib_eio_windows/domain_mgr.ml
+++ b/lib_eio_windows/domain_mgr.ml
@@ -16,8 +16,6 @@
 
 open Eio.Std
 
-[@@@alert "-unstable"]
-
 module Fd = Eio_unix.Fd
 
 let socketpair k ~sw ~domain ~ty ~protocol wrap_a wrap_b =

--- a/lib_eio_windows/sched.ml
+++ b/lib_eio_windows/sched.ml
@@ -325,8 +325,6 @@ let with_op t fn x =
     t.active_ops <- t.active_ops - 1;
     raise ex
 
-[@@@alert "-unstable"]
-
 type _ Effect.t += Enter : (t -> 'a Eio_utils.Suspended.t -> [`Exit_scheduler]) -> 'a Effect.t
 let enter fn = Effect.perform (Enter fn)
 

--- a/lib_eio_windows/sched.mli
+++ b/lib_eio_windows/sched.mli
@@ -17,7 +17,7 @@ val with_sched : (t -> 'a) -> 'a
 
 val run :
   extra_effects:exit Effect.Deep.effect_handler ->
-  t -> ('a -> 'b) -> 'a -> 'b [@@alert "-unstable"]
+  t -> ('a -> 'b) -> 'a -> 'b
 (** [run ~extra_effects t f x] starts an event loop using [t] and runs [f x] as the root fiber within it.
 
     Unknown effects are passed to [extra_effects]. *)


### PR DESCRIPTION
We must have needed these at some point, but I can't work out when. The `unstable` tag was added to `stdlib/effect.mli` when it was first added in OCaml 5.0.0, but OCaml 5.0.0 already had that alert disabled by default.

I also tried building Eio 0.12 with dune 3.10 and OCaml 5.0.0, and that didn't show the alerts either, so I suspect that disabling them isn't needed now.