### PR TITLE
Add Eio_unix.Err module

### DIFF
--- a/lib_eio/unix/config.ml.windows
+++ b/lib_eio/unix/config.ml.windows
@@ -1,0 +1,1 @@
+let enotcapable = None

--- a/lib_eio/unix/dune
+++ b/lib_eio/unix/dune
@@ -27,3 +27,12 @@
  (alias runtest)
  (action
   (diff primitives.h primitives.h.new)))
+
+(rule
+ (targets config.ml)
+ (enabled_if (= %{os_type} "Unix"))
+ (action (run ./include/discover.exe)))
+
+(rule
+ (enabled_if (<> %{os_type} "Unix"))
+ (action (copy config.ml.windows config.ml)))

--- a/lib_eio/unix/eio_unix.ml
+++ b/lib_eio/unix/eio_unix.ml
@@ -3,6 +3,7 @@ open Eio.Std
 module Fd = Fd
 module Resource = Resource
 module Private = Private
+module Err = Err
 
 include Types
 
@@ -10,12 +11,7 @@ let await_readable = Private.await_readable
 let await_writable = Private.await_writable
 let pipe = Private.pipe
 
-type Eio.Exn.Backend.t += Unix_error of Unix.error * string * string
-let () =
-  Eio.Exn.Backend.register_pp (fun f -> function
-      | Unix_error (code, name, arg) -> Fmt.pf f "Unix_error (%s, %S, %S)" (Unix.error_message code) name arg; true
-      | _ -> false
-    )
+type Eio.Exn.Backend.t += Unix_error = Err.Unix_error
 
 let sleep d =
   Eio.Time.Mono.sleep (Effect.perform Private.Get_monotonic_clock) d

--- a/lib_eio/unix/eio_unix.mli
+++ b/lib_eio/unix/eio_unix.mli
@@ -9,6 +9,20 @@ open Eio.Std
 type Eio.Exn.Backend.t += Unix_error of Unix.error * string * string
 (** Wrapper for embedding {!Unix.Unix_error} errors. *)
 
+(** Wrap Unix errors as {!Eio.Io} ones. *)
+module Err : sig
+  val v : Unix.error -> string -> string -> exn
+  (** [v e fn arg] returns an {!Eio.Io} error corresponding to a [Unix.Unix_error (e, fn arg)] exception.
+
+      Example:
+      {[
+        try
+          Unix.rmdir "/tmp/foo"
+        with Unix.Unix_error (e, fn, arg) ->
+          raise (Eio_unix.Err.v e fn arg)
+      ]} *)
+end
+
 module Fd = Fd
 (** A safe wrapper for {!Unix.file_descr}. *)
 

--- a/lib_eio/unix/err.ml
+++ b/lib_eio/unix/err.ml
@@ -1,0 +1,22 @@
+type Eio.Exn.Backend.t += Unix_error of Unix.error * string * string
+
+let () =
+  Eio.Exn.Backend.register_pp (fun f -> function
+      | Unix_error (code, name, arg) -> Fmt.pf f "Unix_error (%s, %S, %S)" (Unix.error_message code) name arg; true
+      | _ -> false
+    )
+
+let unclassified e = Eio.Exn.create (Eio.Exn.X e)
+
+let v code name arg =
+  let e = Unix_error (code, name, arg) in
+  match code with
+  | EUNKNOWNERR x when Some x = Config.enotcapable -> Eio.Fs.err (Permission_denied e)
+  | ECONNREFUSED -> Eio.Net.err (Connection_failure (Refused e))
+  | ECONNRESET | EPIPE | ECONNABORTED -> Eio.Net.err (Connection_reset e)
+  | ENOPROTOOPT -> Eio.Net.err Invalid_option
+  | ENOSYS | EOPNOTSUPP -> Eio.Exn.create (Eio.Exn.Not_available e)
+  | EEXIST -> Eio.Fs.err (Already_exists e)
+  | ENOENT -> Eio.Fs.err (Not_found e)
+  | EXDEV | EACCES | EPERM -> Eio.Fs.err (Permission_denied e)
+  | _ -> unclassified e

--- a/lib_eio/unix/include/discover.ml
+++ b/lib_eio/unix/include/discover.ml
@@ -1,16 +1,16 @@
 module C = Configurator.V1
 
 let optional_flags = [
-  "O_DSYNC";
-  "O_RESOLVE_BENEATH";
-  "O_PATH";
-  "MSG_CMSG_CLOEXEC";
+  "ENOTCAPABLE";
+]
+
+let always_present_flags = [
 ]
 
 let () =
   C.main ~name:"discover" (fun c ->
-      let c_flags = ["-D_LARGEFILE64_SOURCE"; "-D_XOPEN_SOURCE=700"; "-D_DARWIN_C_SOURCE"; "-D_GNU_SOURCE"; "-D_BSD_SOURCE"; "-D__BSD_VISIBLE"] in
-      let includes = ["errno.h"; "sys/types.h"; "sys/stat.h"; "fcntl.h"; "limits.h"; "sys/socket.h"] in
+      let c_flags = [] in
+      let includes = ["errno.h"] in
       let extra_flags, missing_defs =
         C.C_define.import c ~c_flags ~includes
           C.C_define.Type.(List.map (fun name -> name, Switch) optional_flags)
@@ -22,28 +22,7 @@ let () =
           )
       in
       let present_defs =
-        C.C_define.import c ~c_flags ~includes
-          C.C_define.Type.(extra_flags @ [
-            "O_RDONLY", Int;
-            "O_RDWR", Int;
-            "O_WRONLY", Int;
-
-            "O_APPEND", Int;
-            "O_CLOEXEC", Int;
-            "O_CREAT", Int;
-            "O_DIRECTORY", Int;
-            "O_EXCL", Int;
-            "O_NOCTTY", Int;
-            "O_NOFOLLOW", Int;
-            "O_NONBLOCK", Int;
-            "O_SYNC", Int;
-            "O_TRUNC", Int;
-
-            "AT_FDCWD", Int;
-            "AT_SYMLINK_NOFOLLOW", Int;
-
-            "IOV_MAX", Int;
-          ])
+        C.C_define.import c ~c_flags ~includes (extra_flags @ always_present_flags)
         |> List.map (function
             | name, C.C_define.Value.Int v when List.mem name optional_flags ->
               Printf.sprintf "let %s = Some 0x%x" (String.lowercase_ascii name) v

--- a/lib_eio/unix/include/dune
+++ b/lib_eio/unix/include/dune
@@ -1,0 +1,4 @@
+(executable
+ (name discover)
+ (modules discover)
+ (libraries dune-configurator))

--- a/lib_eio_linux/eio_linux.ml
+++ b/lib_eio_linux/eio_linux.ml
@@ -124,7 +124,7 @@ let run_event_loop (type a) ?fallback config (main : _ -> a) arg : a =
           with
           | r -> continue k r
           | exception Unix.Unix_error (code, name, arg) ->
-              discontinue k (Err.wrap code name arg)
+              discontinue k (Err.v code name arg)
         )
       | Eio_unix.Net.Socketpair_datagram (sw, domain, protocol) -> Some (fun k ->
           match
@@ -135,7 +135,7 @@ let run_event_loop (type a) ?fallback config (main : _ -> a) arg : a =
           with
           | r -> continue k r
           | exception Unix.Unix_error (code, name, arg) ->
-              discontinue k (Err.wrap code name arg)
+              discontinue k (Err.v code name arg)
         )
       | Eio_unix.Private.Pipe sw -> Some (fun k ->
           match
@@ -146,7 +146,7 @@ let run_event_loop (type a) ?fallback config (main : _ -> a) arg : a =
           with
           | r -> continue k r
           | exception Unix.Unix_error (code, name, arg) ->
-            discontinue k (Err.wrap code name arg)
+            discontinue k (Err.v code name arg)
         )
       | _ -> None
   } in

--- a/lib_eio_linux/err.ml
+++ b/lib_eio_linux/err.ml
@@ -1,23 +1,8 @@
+include Eio_unix.Err
+
 let unclassified e = Eio.Exn.create (Eio.Exn.X e)
-
-let wrap code name arg =
-  let ex = Eio_unix.Unix_error (code, name, arg) in
-  match code with
-  | ECONNREFUSED -> Eio.Net.err (Connection_failure (Refused ex))
-  | ECONNRESET | EPIPE -> Eio.Net.err (Connection_reset ex)
-  | ENOPROTOOPT -> Eio.Net.err Invalid_option
-  | ENOSYS | EOPNOTSUPP -> Eio.Exn.create (Eio.Exn.Not_available ex)
-  | _ -> unclassified ex
-
-let wrap_fs code name arg =
-  let e = Eio_unix.Unix_error (code, name, arg) in
-  match code with
-  | Unix.EEXIST -> Eio.Fs.err (Already_exists e)
-  | Unix.ENOENT -> Eio.Fs.err (Not_found e)
-  | Unix.EXDEV | EPERM | EACCES -> Eio.Fs.err (Permission_denied e)
-  | _ -> wrap code name arg
 
 let run fn x =
   try fn x
   with Unix.Unix_error (code, name, arg) ->
-    raise (wrap code name arg)
+    raise (v code name arg)

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -193,7 +193,7 @@ let read_upto ?file_offset:off fd buf amount =
   match Uring.Res.int_result res with
   | Ok 0 -> raise End_of_file
   | Ok n -> n
-  | Error e -> raise @@ Err.wrap e "read" ""
+  | Error e -> raise @@ Err.v e "read" ""
 
 let rec read_exactly ?file_offset fd buf len =
   let got = read_upto ?file_offset fd buf len in
@@ -221,7 +221,7 @@ let readv ?file_offset fd bufs =
   match Uring.Res.int_result res with
   | Ok 0 -> raise End_of_file
   | Ok n -> n
-  | Error e -> raise @@ Err.wrap e "readv" ""
+  | Error e -> raise @@ Err.v e "readv" ""
 
 let writev_single ?file_offset fd bufs =
   let file_offset =
@@ -233,7 +233,7 @@ let writev_single ?file_offset fd bufs =
   let res = Sched.enter "writev" (enqueue_writev (file_offset, fd, bufs)) in
   match Uring.Res.int_result res with
   | Ok x -> x
-  | Error e -> raise @@ Err.wrap e "writev" ""
+  | Error e -> raise @@ Err.v e "writev" ""
 
 let rec writev ?file_offset fd bufs =
   let bytes_written = writev_single ?file_offset fd bufs in
@@ -271,7 +271,7 @@ let write_single ?file_offset:off fd buf len =
     ) in
   match Uring.Res.int_result res with
   | Ok x -> x
-  | Error e -> raise @@ Err.wrap e "write" ""
+  | Error e -> raise @@ Err.v e "write" ""
 
 let rec write ?file_offset fd buf len =
   let wrote = write_single ?file_offset fd buf len in
@@ -287,20 +287,14 @@ let splice src ~dst ~len =
   match Uring.Res.int_result res with
   | Ok 0 -> raise End_of_file
   | Ok n -> n
-  | Error e -> raise @@ Err.wrap e "splice" ""
+  | Error e -> raise @@ Err.v e "splice" ""
 
 let connect fd addr =
   Fd.use_exn "connect" fd @@ fun fd ->
   let res = Sched.enter "connect" (enqueue_connect fd addr) in
   match Res.unit_result res with
   | Ok () -> ()
-  | Error e ->
-    let ex =
-      match addr with
-      | ADDR_UNIX _ -> Err.wrap_fs e "connect" ""
-      | ADDR_INET _ -> Err.wrap e "connect" ""
-    in
-    raise ex
+  | Error e -> raise (Err.v e "connect" "")
 
 let send_msg fd ?(fds=[]) ?dst buf =
   Fd.use_exn "send_msg" fd @@ fun fd ->
@@ -308,7 +302,7 @@ let send_msg fd ?(fds=[]) ?dst buf =
   let res = Sched.enter "send_msg" (enqueue_send_msg fd ~fds ~dst buf) in
   match Uring.Res.int_result res with
   | Ok x -> x
-  | Error e -> raise @@ Err.wrap e "send_msg" ""
+  | Error e -> raise @@ Err.v e "send_msg" ""
 
 let recv_msg fd buf =
   Fd.use_exn "recv_msg" fd @@ fun fd ->
@@ -316,7 +310,7 @@ let recv_msg fd buf =
   let msghdr = Uring.Msghdr.create ~addr buf in
   let res = Sched.enter "recv_msg" (enqueue_recv_msg fd msghdr) in
   match Uring.Res.int_result res with
-  | Error e -> raise @@ Err.wrap e "recv_msg" ""
+  | Error e -> raise @@ Err.v e "recv_msg" ""
   | Ok res -> addr, res
 
 let recv_msg_with_fds ~sw ~max_fds fd buf =
@@ -325,7 +319,7 @@ let recv_msg_with_fds ~sw ~max_fds fd buf =
   let msghdr = Uring.Msghdr.create ~n_fds:max_fds ~addr buf in
   let res = Sched.enter "recv_msg_with_fds" (enqueue_recv_msg fd msghdr) in
   match Uring.Res.int_result res with
-  | Error e -> raise @@ Err.wrap e "recv_msg" ""
+  | Error e -> raise @@ Err.v e "recv_msg" ""
   | Ok res ->
     let fds = Uring.Msghdr.get_fds msghdr |> Fd.of_unix_list ~sw in
     addr, res, fds
@@ -516,7 +510,7 @@ let rec openat2 ~sw ?seekable ~access ~flags ~perm ~resolve ?dir path =
         (* Linux can return this due to a concurrent update.
            It also seems to happen sometimes with no concurrent updates. *)
         openat2 ~sw ?seekable ~access ~flags ~perm ~resolve ?dir path
-      | e -> raise @@ Err.wrap_fs e "openat2" ""
+      | e -> raise @@ Err.v e "openat2" ""
   in
   match dir with
   | None -> use None
@@ -590,7 +584,7 @@ let fsync fd =
   let res = Sched.enter "fsync" (enqueue_fsync fd) in
   match Res.unit_result res with
   | Ok () -> ()
-  | Error e -> raise @@ Err.wrap e "fsync" ""
+  | Error e -> raise @@ Err.v e "fsync" ""
 
 let rec enqueue_fdatasync fd st action =
   let retry = Sched.with_cancel_hook ~action st (fun () ->
@@ -605,7 +599,7 @@ let fdatasync fd =
   let res = Sched.enter "fdatasync" (enqueue_fdatasync fd) in
   match Res.unit_result res with
   | Ok () -> ()
-  | Error e -> raise @@ Err.wrap e "fdatasync" ""
+  | Error e -> raise @@ Err.v e "fdatasync" ""
 
 let rec enqueue_ftruncate fd len st action =
   let retry = Sched.with_cancel_hook ~action st (fun () ->
@@ -623,13 +617,13 @@ let ftruncate fd len =
     let res = Sched.enter "ftruncate" (enqueue_ftruncate fd len) in
     (match Res.unit_result res with
      | Ok () -> ()
-     | Error e -> raise @@ Err.wrap e "ftruncate" "")
+     | Error e -> raise @@ Err.v e "ftruncate" "")
   | false -> begin
     try
       Eio_unix.run_in_systhread ~label:"ftruncate" @@ fun () ->
       Fd.use_exn "ftruncate" fd @@ fun fd ->
       Unix.LargeFile.ftruncate fd len
-    with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+    with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
   end
 
 let rec enqueue_fallocate fd ~mode ~off ~len st action =
@@ -647,7 +641,7 @@ let fallocate ?(mode=Uring.Fallocate_flags.empty) fd ~off ~len =
   let res = Sched.enter "fallocate" (enqueue_fallocate fd ~mode ~off ~len) in
   match Res.unit_result res with
   | Ok () -> ()
-  | Error e -> raise @@ Err.wrap e "fallocate" ""
+  | Error e -> raise @@ Err.v e "fallocate" ""
 
 let getrandom { Cstruct.buffer; off; len } =
   let rec loop n =
@@ -704,7 +698,7 @@ let statx_raw ?fd ~mask path buf flags =
       Sched.enter "statx" (enqueue_statx (Some fd, path, buf, flags, mask))
   in
   match Res.unit_result res with
-  | Error e -> raise @@ Err.wrap_fs e "statx" path
+  | Error e -> raise @@ Err.v e "statx" path
   | Ok () -> ()
 
 let statx ~mask ~follow fd path buf =
@@ -735,14 +729,14 @@ let mkdir ~perm dir path =
   (* [mkdir] is really an operation on [path]'s parent. Get a reference to that first: *)
   with_parent_dir "mkdir" dir path @@ fun parent leaf ->
   try eio_mkdirat parent leaf perm
-  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
+  with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
 
 let unlink ~rmdir dir path =
   (* [unlink] is really an operation on [path]'s parent. Get a reference to that first: *)
   with_parent_dir "unlink" dir path @@ fun parent leaf ->
   let res = Sched.enter "unlink" (enqueue_unlink (rmdir, parent, leaf)) in
   match Res.unit_result res with
-  | Error e -> raise @@ Err.wrap_fs e "unlinkat" ""
+  | Error e -> raise @@ Err.v e "unlinkat" ""
   | Ok () -> ()
 
 let rename old_dir old_path new_dir new_path =
@@ -752,13 +746,13 @@ let rename old_dir old_path new_dir new_path =
     eio_renameat
       old_parent old_leaf
       new_parent new_leaf
-  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
+  with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
 
 let symlink ~link_to dir path =
   with_parent_dir "symlinkat-new" dir path @@ fun parent leaf ->
   try
     eio_symlinkat link_to parent leaf
-  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
+  with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
 
 let rec enqueue_shutdown fd command st action =
   let retry = Sched.with_cancel_hook ~action st (fun () ->
@@ -774,7 +768,7 @@ let shutdown socket command =
   match Res.unit_result res with
   | Ok () -> ()
   | Error Unix.ENOTCONN -> ()
-  | Error e -> raise @@ Err.wrap e "shutdown" ""
+  | Error e -> raise @@ Err.v e "shutdown" ""
 
 let rec enqueue_socket domain ty protocol st action =
   let retry = Sched.with_cancel_hook ~action st (fun () ->
@@ -791,11 +785,11 @@ let socket ~sw domain ty protocol =
       let res = Sched.enter "socket" (enqueue_socket domain ty protocol) in
       match Uring.Res.fd_result res with
       | Ok fd -> fd
-      | Error e -> raise @@ Err.wrap e "socket" ""
+      | Error e -> raise @@ Err.v e "socket" ""
     ) else (
       (* IORING_OP_SOCKET requires Linux >= 5.19; fall back to a blocking call. *)
       try Unix.socket ~cloexec:true domain ty protocol
-      with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+      with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
     )
   in
   Fd.of_unix ~sw ~seekable:false ~close_unix:true fd
@@ -814,11 +808,11 @@ let bind fd addr =
     let res = Sched.enter "bind" (enqueue_bind fd addr) in
     match Res.unit_result res with
     | Ok () -> ()
-    | Error e -> raise @@ Err.wrap e "bind" ""
+    | Error e -> raise @@ Err.v e "bind" ""
   ) else (
     (* IORING_OP_BIND requires Linux >= 6.11; fall back to a blocking call. *)
     try Unix.bind fd addr
-    with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+    with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
   )
 
 let rec enqueue_listen fd backlog st action =
@@ -835,11 +829,11 @@ let listen fd backlog =
     let res = Sched.enter "listen" (enqueue_listen fd backlog) in
     match Res.unit_result res with
     | Ok () -> ()
-    | Error e -> raise @@ Err.wrap e "listen" ""
+    | Error e -> raise @@ Err.v e "listen" ""
   ) else (
     (* IORING_OP_LISTEN requires Linux >= 6.11; fall back to a blocking call. *)
     try Unix.listen fd backlog
-    with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+    with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
   )
 
 let accept ~sw fd =
@@ -847,7 +841,7 @@ let accept ~sw fd =
   let client_addr = Uring.Sockaddr.create () in
   let res = Sched.enter "accept" (enqueue_accept fd client_addr) in
   match Uring.Res.fd_result res with
-  | Error e -> raise @@ Err.wrap e "accept" ""
+  | Error e -> raise @@ Err.v e "accept" ""
   | Ok unix ->
     let client = Fd.of_unix ~sw ~seekable:false ~close_unix:true unix in
     let client_addr = Uring.Sockaddr.get client_addr in
@@ -873,7 +867,7 @@ let read_link fd path =
   try
     with_parent_dir_fd fd path @@ fun parent leaf ->
     Eio_unix.run_in_systhread ~label:"read_link" (fun () -> Eio_unix.Private.read_link (Some parent) leaf)
-  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
+  with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
 
 let chmod ~follow ~mode dirfd path =
   try
@@ -893,7 +887,7 @@ let chmod ~follow ~mode dirfd path =
           let fd : int = Obj.magic fd in
           Unix.chmod (Printf.sprintf "/proc/self/fd/%d" fd) mode
       )
-  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
+  with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
 
 let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) dirfd path =
   try
@@ -904,7 +898,7 @@ let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) dirfd path =
         let flags = (Uring.Statx.Flags.empty_path :> int) in
         Eio_unix.Private.chown ~flags ~uid ~gid fd ""
       )
-  with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap_fs code name arg
+  with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
 
 let getaddrinfo ~service node =
   Eio_unix.run_in_systhread ~label:"getaddrinfo" @@ fun () ->

--- a/lib_eio_linux/net.ml
+++ b/lib_eio_linux/net.ml
@@ -112,7 +112,7 @@ module Impl = struct
         | Unix.{ st_kind = S_SOCK; _ } -> Unix.unlink path
         | _ -> ()
         | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
-        | exception Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+        | exception Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
     );
     let addr = Eio_unix.Net.sockaddr_to_unix listen_addr in
     let sock = Low_level.socket ~sw (socket_domain_of listen_addr) Unix.SOCK_STREAM 0 in
@@ -143,7 +143,7 @@ module Impl = struct
         | Unix.{ st_kind = S_SOCK; _ } -> Unix.unlink path
         | _ -> ()
         | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
-        | exception Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+        | exception Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
     );
     let sock = Low_level.socket ~sw (socket_domain_of saddr) Unix.SOCK_DGRAM 0 in
     begin match saddr with

--- a/lib_eio_posix/domain_mgr.ml
+++ b/lib_eio_posix/domain_mgr.ml
@@ -31,7 +31,7 @@ let socketpair k ~sw ~domain ~ty ~protocol wrap_a wrap_b =
   with
   | r -> continue k r
   | exception Unix.Unix_error (code, name, arg) ->
-    discontinue k (Err.wrap code name arg)
+    discontinue k (Err.v code name arg)
 
 (* Run an event loop in the current domain, using [fn x] as the root fiber. *)
 let run_event_loop fn x =
@@ -73,7 +73,7 @@ let run_event_loop fn x =
           with
           | r -> continue k r
           | exception Unix.Unix_error (code, name, arg) ->
-            discontinue k (Err.wrap code name arg)
+            discontinue k (Err.v code name arg)
         )
       | _ -> None
   }

--- a/lib_eio_posix/err.ml
+++ b/lib_eio_posix/err.ml
@@ -1,9 +1,9 @@
+include Eio_unix.Err
+
 type Eio.Exn.Backend.t +=
   | Outside_sandbox of string
   | Absolute_path
   | Invalid_leaf of string
-
-let unclassified_error e = Eio.Exn.create (Eio.Exn.X e)
 
 let () =
   Eio.Exn.Backend.register_pp (fun f -> function
@@ -13,20 +13,7 @@ let () =
       | _ -> false
     )
 
-let wrap code name arg =
-  let e = Eio_unix.Unix_error (code, name, arg) in
-  match code with
-  | EEXIST -> Eio.Fs.err (Already_exists e)
-  | ENOENT -> Eio.Fs.err (Not_found e)
-  | EXDEV | EACCES | EPERM -> Eio.Fs.err (Permission_denied e)
-  | EUNKNOWNERR x when Some x = Config.enotcapable -> Eio.Fs.err (Permission_denied e)
-  | ECONNREFUSED -> Eio.Net.err (Connection_failure (Refused e))
-  | ECONNRESET | EPIPE -> Eio.Net.err (Connection_reset e)
-  | ENOPROTOOPT -> Eio.Net.err Invalid_option
-  | ENOSYS | EOPNOTSUPP -> Eio.Exn.create (Eio.Exn.Not_available e)
-  | _ -> unclassified_error e
-
 let run fn x =
   try fn x
   with Unix.Unix_error (code, name, arg) ->
-    raise (wrap code name arg)
+    raise (v code name arg)

--- a/lib_eio_posix/flow.ml
+++ b/lib_eio_posix/flow.ml
@@ -58,13 +58,13 @@ module Impl = struct
       let x = Low_level.create_stat () in
       Low_level.fstat ~buf:x t;
       eio_of_stat x
-    with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+    with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
 
   let single_write t bufs =
     try
       Low_level.writev t (truncate_to_iomax bufs)
     with Unix.Unix_error (code, name, arg) ->
-      raise (Err.wrap code name arg)
+      raise (Err.v code name arg)
 
   (* Copy using the [Read_source_buffer] optimisation.
      Avoids a copy if the source already has the data. *)
@@ -87,7 +87,7 @@ module Impl = struct
     match Low_level.readv t [| buf |] with
     | 0 -> raise End_of_file
     | got -> got
-    | exception (Unix.Unix_error (code, name, arg)) -> raise (Err.wrap code name arg)
+    | exception (Unix.Unix_error (code, name, arg)) -> raise (Err.v code name arg)
 
   let shutdown t cmd =
     try
@@ -97,7 +97,7 @@ module Impl = struct
       | `All -> Unix.SHUTDOWN_ALL
     with
     | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
-    | Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+    | Unix.Unix_error (code, name, arg) -> raise (Err.v code name arg)
 
   let read_methods = []
 

--- a/lib_eio_posix/fs.ml
+++ b/lib_eio_posix/fs.ml
@@ -88,7 +88,7 @@ end = struct
     match Low_level.openat ~sw ~mode t.fd path flags with
     | fd -> (Flow.of_fd fd :> Eio.File.rw_ty r)
     | exception Unix.Unix_error (code, name, arg) ->
-      raise (Err.wrap code name arg)
+      raise (Err.v code name arg)
 
   let mkdir t ~perm path =
     Err.run (Low_level.mkdir ~mode:perm t.fd) path

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -75,7 +75,7 @@ let connect fd addr =
     await_writable "connect" fd;
     match Fd.use_exn "connect" fd Unix.getsockopt_error with
     | None -> ()
-    | Some code -> raise (Err.wrap code "connect-in-progress" "")
+    | Some code -> raise (Err.v code "connect-in-progress" "")
 
 let accept ~sw sock =
   Fd.use_exn "accept" sock @@ fun sock ->

--- a/lib_eio_posix/net.ml
+++ b/lib_eio_posix/net.ml
@@ -76,7 +76,7 @@ module Datagram_socket = struct
       | `All -> Unix.SHUTDOWN_ALL
     with
     | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
-    | Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+    | Unix.Unix_error (code, name, arg) -> raise (Err.v code name arg)
 
   let setsockopt t opt v = Err.run (Eio_unix.Net.setsockopt t opt) v
   let getsockopt t opt = Err.run (Eio_unix.Net.getsockopt t) opt
@@ -100,7 +100,7 @@ let listen ~reuse_addr ~reuse_port ~backlog ~sw (listen_addr : Eio.Net.Sockaddr.
         match Low_level.fstatat ~buf ~follow:false Fs path with
         | () -> if Low_level.kind buf = `Socket then Unix.unlink path
         | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
-        | exception Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+        | exception Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
       );
       Unix.SOCK_STREAM, Unix.ADDR_UNIX path
     | `Tcp (host, port)  ->
@@ -138,7 +138,7 @@ let connect ~sw connect_addr =
   try
     Low_level.connect sock addr;
     (Flow.of_fd sock :> _ Eio_unix.Net.stream_socket)
-  with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+  with Unix.Unix_error (code, name, arg) -> raise (Err.v code name arg)
 
 let create_datagram_socket ~reuse_addr ~reuse_port ~sw saddr =
   let sock = Low_level.socket ~sw (socket_domain_of saddr) Unix.SOCK_DGRAM 0 in

--- a/lib_eio_windows/domain_mgr.ml
+++ b/lib_eio_windows/domain_mgr.ml
@@ -30,7 +30,7 @@ let socketpair k ~sw ~domain ~ty ~protocol wrap_a wrap_b =
   with
   | r -> continue k r
   | exception Unix.Unix_error (code, name, arg) ->
-    discontinue k (Err.wrap code name arg)
+    discontinue k (Err.v code name arg)
 
 (* Run an event loop in the current domain, using [fn x] as the root fiber. *)
 let run_event_loop fn x =
@@ -73,7 +73,7 @@ let run_event_loop fn x =
           with
           | r -> continue k r
           | exception Unix.Unix_error (code, name, arg) ->
-            discontinue k (Err.wrap code name arg)
+            discontinue k (Err.v code name arg)
         )
       | _ -> None
   }

--- a/lib_eio_windows/err.ml
+++ b/lib_eio_windows/err.ml
@@ -1,3 +1,5 @@
+include Eio_unix.Err
+
 type Eio.Exn.Backend.t +=
   | Outside_sandbox of string * string
   | Absolute_path
@@ -13,19 +15,7 @@ let () =
       | _ -> false
     )
 
-let wrap code name arg =
-  let e = Eio_unix.Unix_error (code, name, arg) in
-  match code with
-  | EEXIST -> Eio.Fs.err (Already_exists e)
-  | ENOENT -> Eio.Fs.err (Not_found e)
-  | EXDEV | EACCES | EPERM -> Eio.Fs.err (Permission_denied e)
-  | ECONNREFUSED -> Eio.Net.err (Connection_failure (Refused e))
-  | ECONNRESET | EPIPE | ECONNABORTED -> Eio.Net.err (Connection_reset e)
-  | ENOPROTOOPT -> Eio.Net.err Invalid_option
-  | ENOSYS | EOPNOTSUPP -> Eio.Exn.create (Eio.Exn.Not_available e)
-  | _ -> unclassified_error e
-
 let run fn x =
   try fn x
   with Unix.Unix_error (code, name, arg) ->
-    raise (wrap code name arg)
+    raise (v code name arg)

--- a/lib_eio_windows/flow.ml
+++ b/lib_eio_windows/flow.ml
@@ -36,11 +36,11 @@ module Impl = struct
         mtime   = ust.st_mtime;
         ctime   = ust.st_ctime;
       }
-    with Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+    with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
 
   let write_all t bufs =
     try Low_level.writev t bufs
-    with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+    with Unix.Unix_error (code, name, arg) -> raise (Err.v code name arg)
 
   (* todo: provide a way to do a single write *)
   let single_write t bufs =
@@ -53,7 +53,7 @@ module Impl = struct
     match Low_level.read_cstruct t buf with
     | 0 -> raise End_of_file
     | got -> got
-    | exception (Unix.Unix_error (code, name, arg)) -> raise (Err.wrap code name arg)
+    | exception (Unix.Unix_error (code, name, arg)) -> raise (Err.v code name arg)
 
   let shutdown t cmd =
     try
@@ -63,7 +63,7 @@ module Impl = struct
       | `All -> Unix.SHUTDOWN_ALL
     with
     | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
-    | Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+    | Unix.Unix_error (code, name, arg) -> raise (Err.v code name arg)
 
   let read_methods = []
 

--- a/lib_eio_windows/fs.ml
+++ b/lib_eio_windows/fs.ml
@@ -131,7 +131,7 @@ end = struct
       in
       open_out t ~sw ~append ~create full_target
     | exception Unix.Unix_error (code, name, arg) ->
-      raise (Err.wrap code name arg)
+      raise (Err.v code name arg)
 
   let mkdir t ~perm path =
     with_parent_dir t path @@ fun dirfd path ->

--- a/lib_eio_windows/low_level.ml
+++ b/lib_eio_windows/low_level.ml
@@ -76,7 +76,7 @@ let connect fd addr =
     await_writable fd;
     match Fd.use_exn "connect" fd Unix.getsockopt_error with
     | None -> ()
-    | Some code -> raise (Err.wrap code "connect-in-progress" "")
+    | Some code -> raise (Err.v code "connect-in-progress" "")
 
 let accept ~sw sock =
   Fd.use_exn "accept" sock @@ fun sock ->

--- a/lib_eio_windows/net.ml
+++ b/lib_eio_windows/net.ml
@@ -78,7 +78,7 @@ module Datagram_socket = struct
       | `All -> Unix.SHUTDOWN_ALL
     with
     | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ()
-    | Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+    | Unix.Unix_error (code, name, arg) -> raise (Err.v code name arg)
 
   let setsockopt t opt v = Err.run (Eio_unix.Net.setsockopt t opt) v
   let getsockopt t opt = Err.run (Eio_unix.Net.getsockopt t) opt
@@ -119,7 +119,7 @@ let listen ~reuse_addr ~reuse_port ~backlog ~sw (listen_addr : Eio.Net.Sockaddr.
         | Unix.{ st_kind = S_SOCK; _ } -> Unix.unlink path
         | _ -> ()
         | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
-        | exception Unix.Unix_error (code, name, arg) -> raise @@ Err.wrap code name arg
+        | exception Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
       );
       Unix.SOCK_STREAM, Unix.ADDR_UNIX path, true
     | `Tcp (host, port)  ->
@@ -159,7 +159,7 @@ let connect ~sw connect_addr =
   try
     Low_level.connect sock addr;
     (Flow.of_fd sock :> _ Eio_unix.Net.stream_socket)
-  with Unix.Unix_error (code, name, arg) -> raise (Err.wrap code name arg)
+  with Unix.Unix_error (code, name, arg) -> raise (Err.v code name arg)
 
 let create_datagram_socket ~reuse_addr ~reuse_port ~sw saddr =
   let sock = Low_level.socket ~sw (socket_domain_of saddr) Unix.SOCK_DGRAM 0 in


### PR DESCRIPTION
This is convenient whenever wrapping a function that raises `Unix_error`, so it makes sense for it to be public. Also, it avoids duplicating the logic across eio_linux, eio_posix and eio_windows, with possible inconsistencies.

I renamed `Err.wrap` to `Err.v`, which seems more sensible. I didn't include `Err.run` in the public API as I don't really like it (it's too easy to partially apply it). This also removes the distinction between `wrap` and `wrap_fs` in eio_linux. eio_posix didn't do this, so it probably wasn't necessary.

This will also be useful if we want to make other functions in `Eio_unix` raise `Eio.Io` exceptions in future.

The new `discover.ml` is nearly empty, but I except it will be a useful place for more shared logic in future.