### PR TITLE
eio_posix: fall back to select() for fds that poll() fails with POLLNVAL

### DIFF
--- a/lib_eio_posix/eio_posix_stubs.c
+++ b/lib_eio_posix/eio_posix_stubs.c
@@ -1,8 +1,14 @@
+#ifdef __APPLE__
+/* Must be defined before including any system headers */
+#define _DARWIN_UNLIMITED_SELECT
+#endif
+
 #include "primitives.h"
 
 #define _FILE_OFFSET_BITS 64
 
 #include <sys/types.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #ifdef __linux__
 #if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
@@ -21,6 +27,7 @@
 
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
+#include <caml/fail.h>
 #include <caml/alloc.h>
 #include <caml/unixsupport.h>
 #include <caml/bigarray.h>
@@ -43,6 +50,34 @@ static void caml_stat_free_preserving_errno(void *ptr) {
   int saved = errno;
   caml_stat_free(ptr);
   errno = saved;
+}
+
+/* Wait for a single FD to become readable or writable, with a timeout. */
+CAMLprim value caml_eio_posix_select_one(value v_fd, value v_write, value v_timeout) {
+#ifndef __APPLE__
+  caml_unix_error(EOPNOTSUPP, "This work-around is only for macOS", Nothing);
+#else
+  CAMLparam1(v_timeout);
+  int fd = Int_val(v_fd);
+  double timeout = Double_val(v_timeout);
+  struct timeval tv;
+  int ret;
+
+  fd_set *fds = caml_stat_calloc_noexc((size_t)fd / NFDBITS + 1, sizeof(fd_mask));
+  if (fds == NULL) caml_raise_out_of_memory();
+  FD_SET(fd, fds);
+  tv.tv_sec = (time_t)timeout;
+  tv.tv_usec = (suseconds_t)((timeout - (double)tv.tv_sec) * 1e6);
+  caml_enter_blocking_section();
+  ret = select(fd + 1,
+               Bool_val(v_write) ? NULL : fds,
+               Bool_val(v_write) ? fds : NULL,
+               NULL, &tv);
+  caml_leave_blocking_section();
+  caml_stat_free_preserving_errno(fds);
+  if (ret == -1) uerror("select", Nothing);
+  CAMLreturn(Val_bool(ret > 0));
+#endif
 }
 
 CAMLprim value caml_eio_posix_getrandom(value v_ba, value v_off, value v_len) {

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -22,25 +22,48 @@ type dir_fd =
 
 let in_worker_thread label = Eio_unix.run_in_systhread ~label
 
+(* macOS poll rejects some character devices like /dev/[tty,null]
+   with POLLNVAL. The scheduler reports these by raising [Sched.Unpollable].
+   select does support such devices, so we wait with short select()s in a
+   systhread instead. TODO avsm: is 0.1 too low here? *)
+let unpollable_select_timeout = 0.1
+
+let rec await_unpollable ty fd =
+  let ready =
+    in_worker_thread "select" @@ fun () ->
+    try
+      match (ty : ty) with
+      | Read ->
+        let readable, _, _ = Unix.select [fd] [] [] unpollable_select_timeout in
+        readable <> []
+      | Write ->
+        let _, writable, _ = Unix.select [] [fd] [] unpollable_select_timeout in
+        writable <> []
+    with Unix.Unix_error (EINTR, _, _) -> false     (* Retry, rechecking cancellation. *)
+  in
+  if not ready then await_unpollable ty fd
+
 let await_readable op fd =
   Fd.use_exn "await_readable" fd @@ fun fd ->
-  Sched.enter op @@ fun t k ->
-  Sched.await_readable t k fd
+  try Sched.enter op @@ fun t k -> Sched.await_readable t k fd
+  with Sched.Unpollable -> await_unpollable Read fd
 
 let await_writable op fd =
   Fd.use_exn "await_writable" fd @@ fun fd ->
-  Sched.enter op @@ fun t k ->
-  Sched.await_writable t k fd
+  try Sched.enter op @@ fun t k -> Sched.await_writable t k fd
+  with Sched.Unpollable -> await_unpollable Write fd
 
 let rec do_nonblocking ty op fn fd =
   try fn fd with
   | Unix.Unix_error (EINTR, _, _) -> do_nonblocking ty op fn fd    (* Just in case *)
   | Unix.Unix_error((EAGAIN | EWOULDBLOCK), _, _) ->
-    Sched.enter op (fun t k ->
-        match ty with
-        | Read -> Sched.await_readable t k fd
-        | Write -> Sched.await_writable t k fd
-      );
+    (try
+       Sched.enter op (fun t k ->
+           match ty with
+           | Read -> Sched.await_readable t k fd
+           | Write -> Sched.await_writable t k fd
+         )
+     with Sched.Unpollable -> await_unpollable ty fd);
     do_nonblocking ty op fn fd
 
 let do_nonblocking ty op fn fd =

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -23,22 +23,16 @@ type dir_fd =
 let in_worker_thread label = Eio_unix.run_in_systhread ~label
 
 (* macOS poll rejects some character devices like /dev/[tty,null]
-   with POLLNVAL. The scheduler reports these by raising [Sched.Unpollable].
-   select does support such devices, so we wait with short select()s in a
-   systhread instead. TODO avsm: is 0.1 too low here? *)
-let unpollable_select_timeout = 0.1
+   with POLLNVAL. The scheduler reports these by raising [Sched.Unpollable]
+   and falling back to select(2) with a short timeout. *)
+let unpollable_select_timeout = 0.2
+
+external eio_select_one : Unix.file_descr -> bool -> float -> bool = "caml_eio_posix_select_one"
 
 let rec await_unpollable ty fd =
   let ready =
     in_worker_thread "select" @@ fun () ->
-    try
-      match (ty : ty) with
-      | Read ->
-        let readable, _, _ = Unix.select [fd] [] [] unpollable_select_timeout in
-        readable <> []
-      | Write ->
-        let _, writable, _ = Unix.select [] [fd] [] unpollable_select_timeout in
-        writable <> []
+    try eio_select_one fd (ty = Write) unpollable_select_timeout
     with Unix.Unix_error (EINTR, _, _) -> false     (* Retry, rechecking cancellation. *)
   in
   if not ready then await_unpollable ty fd

--- a/lib_eio_posix/primitives.h
+++ b/lib_eio_posix/primitives.h
@@ -2,6 +2,7 @@
 #define CAML_NAME_SPACE
 #define _GNU_SOURCE
 #include <caml/mlvalues.h>
+CAMLprim value caml_eio_posix_select_one(value, value, value);
 CAMLprim value caml_eio_posix_send_msg(value, value, value, value, value);
 CAMLprim value caml_eio_posix_recv_msg(value, value, value, value);
 CAMLprim value caml_eio_posix_getrandom(value, value, value);

--- a/lib_eio_posix/sched.ml
+++ b/lib_eio_posix/sched.ml
@@ -30,6 +30,8 @@ type runnable =
   | Thread : 'a Suspended.t * 'a -> runnable            (* Resume a fiber with a result value *)
   | Failed_thread : 'a Suspended.t * exn -> runnable    (* Resume a fiber with an exception *)
 
+exception Unpollable
+
 (* For each FD we track which fibers are waiting for it to become readable/writeable. *)
 type fd_event_waiters = {
   read : unit Suspended.t Lwt_dllist.t;
@@ -150,12 +152,24 @@ let resume t node =
   Fiber_context.clear_cancel_fn k.fiber;
   enqueue_thread t k ()
 
+let resume_failed t ex node =
+  t.active_ops <- t.active_ops - 1;
+  let k : unit Suspended.t = Lwt_dllist.get node in
+  Fiber_context.clear_cancel_fn k.fiber;
+  enqueue_failed_thread t k ex
+
 (* Called when poll indicates that an event we requested for [fd] is ready. *)
 let ready t _index fd revents =
-  assert (not Poll.Flags.(mem revents pollnval));
   if fd == t.eventfd_r then (
     clear_event_fd t
     (* The scheduler will now look at the run queue again and notice any new items. *)
+  ) else if Poll.Flags.(mem revents pollnval) then (
+    let waiters = Hashtbl.find t.fd_map fd in
+    let pending = Lwt_dllist.create () in
+    Lwt_dllist.transfer_l waiters.write pending;
+    Lwt_dllist.transfer_l waiters.read pending;
+    update t waiters fd;
+    Lwt_dllist.iter_node_r (resume_failed t Unpollable) pending
   ) else (
     let waiters = Hashtbl.find t.fd_map fd in
     let pending = Lwt_dllist.create () in

--- a/lib_eio_posix/sched.mli
+++ b/lib_eio_posix/sched.mli
@@ -10,6 +10,12 @@ type exit
     and so does not return until the whole event loop is finished. Such functions should normally
     be called in tail position. *)
 
+exception Unpollable
+(** Raised from an {!await_readable} or {!await_writable} wait if poll(2)
+    reports [POLLNVAL] for the FD, as it does for some macOS character
+    devices such as [/dev/tty] and [/dev/null]. The caller should wait
+    using select(2) instead. *)
+
 val with_sched : (t -> 'a) -> 'a
 (** [with_sched fn] sets up a scheduler and calls [fn t].
     Typically [fn] will call {!run}.

--- a/lib_eio_posix/test/dune
+++ b/lib_eio_posix/test/dune
@@ -4,7 +4,7 @@
   (deps (package eio_posix)))
 
 (tests
-  (names open_beneath test_await)
+  (names open_beneath test_await test_devices)
   (package eio_posix)
   (build_if (= %{os_type} "Unix"))
   (libraries eio_posix))

--- a/lib_eio_posix/test/test_devices.ml
+++ b/lib_eio_posix/test/test_devices.ml
@@ -1,0 +1,39 @@
+(* Regression test for https://github.com/ocaml-multicore/eio/issues/757.
+   macOS poll rejects /dev/null/tty with POLLNVAL. *)
+
+open Eio.Std
+
+let with_blocking_fd path flags fn =
+  Switch.run @@ fun sw ->
+  let fd = Unix.openfile path flags 0 in
+  fn (Eio_unix.Fd.of_unix ~sw ~blocking:true ~close_unix:true fd)
+
+let () =
+  Eio_posix.run @@ fun _env ->
+  with_blocking_fd "/dev/null" [Unix.O_WRONLY] (fun dev_null ->
+    let msg = Bytes.of_string "regression test for #757\n" in
+    let wrote = Eio_posix.Low_level.write dev_null msg 0 (Bytes.length msg) in
+    assert (wrote = Bytes.length msg));
+  with_blocking_fd "/dev/zero" [Unix.O_RDONLY] (fun dev_zero ->
+    let buf = Bytes.make 4 'x' in
+    let got = Eio_posix.Low_level.read dev_zero buf 0 4 in
+    assert (got = 4 && Bytes.to_string buf = "\x00\x00\x00\x00"));
+  begin match Unix.openfile "/dev/tty" [Unix.O_RDWR] 0 with
+   | exception Unix.Unix_error (code, _, _) ->
+     traceln "Skipping /dev/tty test (%s)" (Unix.error_message code)
+   | fd ->
+     Switch.run @@ fun sw ->
+     let tty = Eio_unix.Fd.of_unix ~sw ~blocking:true ~close_unix:true fd in
+     Eio_posix.Low_level.await_writable "test" tty;
+     (* Check the read can be cancelled *)
+     let cancelled =
+       Fiber.first
+         (fun () ->
+            let buf = Bytes.create 1 in
+            ignore (Eio_posix.Low_level.read tty buf 0 1 : int);
+            false)
+         (fun () -> Eio_unix.sleep 0.2; true)
+     in
+     assert cancelled
+  end;
+  traceln "test_devices: ok"


### PR DESCRIPTION
macOS poll() returns POLLNVAL for some device FDs such as /dev/tty or /dev/null. Following the discussions in #757, this is the simplest fix I could find that doesn't affect other platforms like Linux.

We now resume the waiters that fail with POLLNVAL with an [Unpollable] exception, which then uses select() calls via a systhread for these fds only. I'm just not sure if the select is too aggressive at 0.1s timeouts...

Without this fix the new regression test fails with "Fatal error: Assertion failed, sched.ml line 155"