### PR TITLE
add null sink that consumes/discards all data written to it until eof

### DIFF
--- a/lib_eio/flow.ml
+++ b/lib_eio/flow.ml
@@ -180,16 +180,27 @@ let buffer_sink =
   let ops = Pi.sink (module Buffer_sink) in
   fun b -> Resource.T (b, ops)
 
-module Null_sink = struct
+module Null = struct
   type t = unit
+
+  let read_methods = []
+
+  let single_read () _dst = raise End_of_file
 
   let single_write () bufs = Cstruct.lenv bufs
 
   let copy t ~src = Pi.simple_copy ~single_write t ~src
 end
 
-let null_sink : sink_ty r =
-  Resource.T ((), Pi.sink (module Null_sink))
+let null_handler = 
+  Resource.handler [
+    H (Source, (module Null));
+    H (Sink, (module Null));
+  ]
+
+let null =
+  let x = Resource.T ((), null_handler) in
+  (x : [sink_ty | source_ty] r :> [< sink_ty | source_ty] r)
 
 type two_way_ty = [source_ty | sink_ty | shutdown_ty]
 type 'a two_way = ([> two_way_ty] as 'a) r

--- a/lib_eio/flow.ml
+++ b/lib_eio/flow.ml
@@ -180,6 +180,17 @@ let buffer_sink =
   let ops = Pi.sink (module Buffer_sink) in
   fun b -> Resource.T (b, ops)
 
+module Null_sink = struct
+  type t = unit
+
+  let single_write () bufs = Cstruct.lenv bufs
+
+  let copy t ~src = Pi.simple_copy ~single_write t ~src
+end
+
+let null_sink : sink_ty r =
+  Resource.T ((), Pi.sink (module Null_sink))
+
 type two_way_ty = [source_ty | sink_ty | shutdown_ty]
 type 'a two_way = ([> two_way_ty] as 'a) r
 

--- a/lib_eio/flow.mli
+++ b/lib_eio/flow.mli
@@ -90,9 +90,10 @@ val buffer_sink : Buffer.t -> sink_ty r
 
     To collect data as a cstruct, use {!Buf_read} instead. *)
 
-val null_sink : sink_ty r
-(** [null_sink] is a sink that consumes and discards all data written to it
-    until end-of-file. *)
+val null : [< sink_ty | source_ty] r
+(** [null] is a sink that consumes and discards all data written to it
+    until end-of-file, and a source that immediately returns end-of-file
+    (similar to the "/dev/null" device on Unix). *)
 
 (** {2 Bidirectional streams} *)
 

--- a/lib_eio/flow.mli
+++ b/lib_eio/flow.mli
@@ -90,6 +90,10 @@ val buffer_sink : Buffer.t -> sink_ty r
 
     To collect data as a cstruct, use {!Buf_read} instead. *)
 
+val null_sink : sink_ty r
+(** [null_sink] is a sink that consumes and discards all data written to it
+    until end-of-file. *)
+
 (** {2 Bidirectional streams} *)
 
 type two_way_ty = [source_ty | sink_ty | shutdown_ty]

--- a/tests/flow.md
+++ b/tests/flow.md
@@ -252,3 +252,13 @@ Even if a fiber is already ready to run, we still perform IO from time to time:
 +Got "msg"
 - : unit = ()
 ```
+
+## Null flow
+
+```ocaml
+# Eio_mock.Backend.run @@ fun () ->
+  traceln "Read Flow.null: %S" Eio.Flow.(read_all null);
+  Eio.Flow.(copy_string "hello" null);;
++Read Flow.null: ""
+- : unit = ()
+```


### PR DESCRIPTION
Noticed this might be useful from Forester's eio utils via @jonsterling at https://git.sr.ht/~jonsterling/ocaml-forester/tree/main/item/lib/compiler/Eio_util.ml