### PR TITLE
eio_linux: don't return an empty getdents batch before end-of-file

### DIFF
--- a/lib_eio_linux/eio_stubs.c
+++ b/lib_eio_linux/eio_stubs.c
@@ -142,29 +142,32 @@ CAMLprim value caml_eio_getdents(value v_fd) {
   char buf[DIRENT_BUF_SIZE];
   struct dirent64 *d;
   int nread, pos;
-  caml_enter_blocking_section();
-  nread = syscall(SYS_getdents64, Int_val(v_fd), buf, DIRENT_BUF_SIZE);
-  caml_leave_blocking_section();
-  if (nread == -1) uerror("getdents", Nothing);
 
   result = Val_emptylist;
 
-  for (pos = 0; pos < nread;) {
-    d = (struct dirent64 *) (buf + pos);
-    pos += d->d_reclen;
+  do {
+    caml_enter_blocking_section();
+    nread = syscall(SYS_getdents64, Int_val(v_fd), buf, DIRENT_BUF_SIZE);
+    caml_leave_blocking_section();
+    if (nread == -1) uerror("getdents", Nothing);
 
-    if (strcmp(d->d_name, ".") == 0 || strcmp(d->d_name, "..") == 0)
-      continue;
+    for (pos = 0; pos < nread;) {
+      d = (struct dirent64 *) (buf + pos);
+      pos += d->d_reclen;
 
-    ventry = caml_alloc(2, 0);
-    Store_field(ventry, 0, eio_unix_file_type_of_dtype(d->d_type));
-    Store_field(ventry, 1, caml_copy_string_of_os(d->d_name));
+      if (strcmp(d->d_name, ".") == 0 || strcmp(d->d_name, "..") == 0)
+        continue;
 
-    cons = caml_alloc(2, 0);
-    Store_field(cons, 0, ventry);  // Head
-    Store_field(cons, 1, result);  // Tail
-    result = cons;
-  }
+      ventry = caml_alloc(2, 0);
+      Store_field(ventry, 0, eio_unix_file_type_of_dtype(d->d_type));
+      Store_field(ventry, 1, caml_copy_string_of_os(d->d_name));
+
+      cons = caml_alloc(2, 0);
+      Store_field(cons, 0, ventry);  // Head
+      Store_field(cons, 1, result);  // Tail
+      result = cons;
+    }
+  } while (nread > 0 && result == Val_emptylist);
 
   CAMLreturn(result);
 }


### PR DESCRIPTION
Since the ./.. filtering moved into the C stub in 1f7b135810af663b75, a batch containing _only_ those entries returned an empty list, which also marks the end of the directory structure. While this is harmless for local filesystems, it can be a problem on FUSE where the protocol allows for shorter returns. 

Therefore, we now loop within the stub until we have at least one real dirent or eof. Could also fix it by signaling eof by other means, but that involves an allocation or an exception. Blocking in a loop seems reasonable.