### PR TITLE
eta expand function applications to support oxcaml

### DIFF
--- a/lib_eio/core/cells.ml
+++ b/lib_eio/core/cells.ml
@@ -19,7 +19,7 @@ module Int63 = struct
 
   let fetch_and_add : t Atomic.t -> int -> t =
     match is_immediate with
-    | True -> Atomic.fetch_and_add
+    | True -> fun t delta -> Atomic.fetch_and_add t delta
     | False -> fetch_and_add_fallback
 end
 

--- a/lib_eio/mock/flow.ml
+++ b/lib_eio/mock/flow.ml
@@ -104,7 +104,7 @@ module Mock_flow = struct
 
   let close t =
     while not (Queue.is_empty t.on_close) do
-      Queue.take t.on_close ()
+      (Queue.take t.on_close) ()
     done;
     traceln "%s: closed" t.label
 


### PR DESCRIPTION
This has no effect in OCaml, but fixes compilation in OxCaml where eta expansion is necessary in some cases involving local inference.

See https://oxcaml.org/documentation/stack-allocation/pitfalls/