### PR TITLE
Net.getaddrinfo: include the query in error messages

### DIFF
--- a/lib_eio/mock/net.ml
+++ b/lib_eio/mock/net.ml
@@ -3,6 +3,8 @@ open Eio.Std
 type ty = [`Generic | `Mock] Eio.Net.ty
 type t = ty r
 
+let pp_maybe_quote f s = Eio.Process.pp_args f [s]
+
 module Impl = struct
   type tag = [`Generic]
 
@@ -53,7 +55,7 @@ module Impl = struct
     socket
 
   let getaddrinfo t ~service node =
-    traceln "%s: getaddrinfo ~service:%s %s" t.label service node;
+    traceln "%s: getaddrinfo ~service:%a %a" t.label pp_maybe_quote service pp_maybe_quote node;
     Handler.run t.on_getaddrinfo
 
   let getnameinfo t sockaddr =

--- a/lib_eio/net.ml
+++ b/lib_eio/net.ml
@@ -524,19 +524,28 @@ let getaddrinfo_full (type tag) ~filter ?(service="") (t:[> tag ty] r) hostname 
   | [] -> raise @@ err (Address_lookup_failed NONAME)
   | xs -> xs
 
+
+let getaddrinfo_full_ctx ~filter ?service t hostname =
+  try getaddrinfo_full ~filter ?service t hostname
+  with Exn.Io _ as ex ->
+    let bt = Printexc.get_raw_backtrace () in
+    match service with
+    | None -> Exn.reraise_with_context ex bt "looking up %S" hostname
+    | Some service -> Exn.reraise_with_context ex bt "looking up %S (service %S)" hostname service
+
 let getaddrinfo ?service t hostname =
-  getaddrinfo_full ?service t hostname
+  getaddrinfo_full_ctx ?service t hostname
     ~filter:Option.some 
 
 let getaddrinfo_stream ?service t hostname =
-  getaddrinfo_full ?service t hostname
+  getaddrinfo_full_ctx ?service t hostname
     ~filter:(function
         | #Sockaddr.stream as x -> Some x
         | _ -> None
       )
 
 let getaddrinfo_datagram ?service t hostname =
-  getaddrinfo_full ?service t hostname
+  getaddrinfo_full_ctx ?service t hostname
     ~filter:(function
         | #Sockaddr.datagram as x -> Some x
         | _ -> None

--- a/tests/network.md
+++ b/tests/network.md
@@ -712,6 +712,19 @@ CI shows `AGAIN` rather than `NONAME`):
 Exception: Failure "Address_lookup_failed".
 ```
 
+We still get an error if the backend tried to return an empty list:
+
+```ocaml
+# Eio_mock.Backend.run @@ fun () ->
+  let net = Eio_mock.Net.make "mocknet" in
+  Eio_mock.Net.on_getaddrinfo net [`Return []];
+  Eio.Net.getaddrinfo net "example.org";;
++mocknet: getaddrinfo ~service:"" example.org
+Exception:
+Eio.Io Net Address_lookup_failed NONAME (name or service is not known),
+  looking up "example.org"
+```
+
 ## getnameinfo
 
 ```ocaml


### PR DESCRIPTION
Example error:

    Eio.Io Net Address_lookup_failed NONAME (name or service is not known),
      looking up "example.org"

Also, add quotes if needed in mock network getaddrinfo trace message, so that e.g.

    mocknet: getaddrinfo ~service: example.org

becomes

    mocknet: getaddrinfo ~service:"" example.org