### PR TITLE
eio_linux: fix chmod test on Ubuntu 22.04

### DIFF
--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -707,13 +707,16 @@ let chmod ~follow ~mode dirfd path =
           Eio_unix.Private.chmod ~mode fd ""
             ~flags:(Uring.Statx.Flags.empty_path :> int)
         with
-        | Unix.Unix_error ((ENOSYS | EOPNOTSUPP | EINVAL), _, _) as ex ->
+        | Unix.Unix_error ((ENOSYS | EOPNOTSUPP | EINVAL) as orig_code, orig_fn, orig_arg) ->
           (* For Linux before 6.6 *)
           try
             Eio_unix.Fd.use_exn "chmod" fd @@ fun fd ->
             let fd : int = Obj.magic fd in
             Unix.chmod (Printf.sprintf "/proc/self/fd/%d" fd) mode
-          with Unix.Unix_error _ -> raise ex (* The original error is less confusing *)
+          with Unix.Unix_error _ ->
+            (* The original error is less confusing *)
+            let unix_error = Eio_unix.Unix_error (orig_code, orig_fn, orig_arg) in
+            raise @@ Eio.Exn.create (Eio.Exn.Not_available unix_error)
       )
   with Unix.Unix_error (code, name, arg) -> raise @@ Err.v code name arg
 


### PR DESCRIPTION
`EINVAL` from `chmod` should also be reported as `Not_available`.

On ubuntu-22.04-5.5_opam-2.5, I saw this:
```diff
@@ -954,7 +954,8 @@ Test chmod on a symlink, on platforms that allow it:
assert ((Eio.Path.stat ~follow:false path).perm = 0o660)
with Eio.Io (Eio.Exn.Not_available _, _) ->
()  (* Some systems don't support this, e.g. Linux *)
-- : unit = ()
+Exception: Eio.Io _,
+  chmoding file <cwd:symlink>
```

(in the #901, this error was masked because that build failed with `ENOMEM` instead)