### PR TITLE
pty: on Linux (and others) convert tty EIO errors to End_of_file

### DIFF
--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -193,6 +193,7 @@ let read_upto ?file_offset:off fd buf amount =
   match Uring.Res.int_result res with
   | Ok 0 -> raise End_of_file
   | Ok n -> n
+  | Error Unix.EIO when Unix.isatty fd -> raise End_of_file
   | Error e -> raise @@ Err.v e "read" ""
 
 let rec read_exactly ?file_offset fd buf len =
@@ -221,6 +222,7 @@ let readv ?file_offset fd bufs =
   match Uring.Res.int_result res with
   | Ok 0 -> raise End_of_file
   | Ok n -> n
+  | Error Unix.EIO when Unix.isatty fd -> raise End_of_file
   | Error e -> raise @@ Err.v e "readv" ""
 
 let writev_single ?file_offset fd bufs =

--- a/lib_eio_posix/flow.ml
+++ b/lib_eio_posix/flow.ml
@@ -87,6 +87,7 @@ module Impl = struct
     match Low_level.readv t [| buf |] with
     | 0 -> raise End_of_file
     | got -> got
+    | exception (Unix.Unix_error (EIO,_,_)) when Eio_unix.Fd.use_exn "isatty" t Unix.isatty -> raise End_of_file
     | exception (Unix.Unix_error (code, name, arg)) -> raise (Err.v code name arg)
 
   let shutdown t cmd =

--- a/tests/pty.md
+++ b/tests/pty.md
@@ -100,6 +100,28 @@ output however. The trailing `read` is released when the switch exits.
 - : string list = ["line 1"; "line 2"; "line 3"]
 ```
 
+Reading from the `pty` end raises `End_of_file` once no process holds the
+terminal end open.
+
+```ocaml
+# run @@ fun env ->
+  Switch.run @@ fun sw ->
+  let t = Pty.open_pty ~sw () in
+  let child =
+    Eio_unix.Process.spawn_unix ~sw env#process_mgr
+      ~login_tty:(Pty.tty t)
+      ~fds:[]
+      ["sh"; "-c"; "echo finished"]
+  in
+  let r = Eio.Buf_read.of_flow (Pty.source t) ~max_size:1024 in
+  let line = Eio.Buf_read.line r in
+  ignore (Eio.Process.await child : Eio.Process.exit_status);
+  Eio_unix.Fd.close (Pty.tty t);
+  let rest = Eio.Flow.read_all (Pty.source t) in
+  (line, rest);;
+- : string * string = ("finished", "")
+```
+
 Input can be sent to the child by writing to the `pty` end with {!Pty.sink}.
 Here we turn off the terminal's input echo, send it a line, and read the response:
 


### PR DESCRIPTION
This just converts EIO errors on isatty() over to End_of_file, rather than wrapping pty fds specifically. Seems cleaner to not leak errors from the backends.

fixes #902 