### PR TITLE
Fix handling of empty paths when using fs unconfined

### DIFF
--- a/lib_eio_linux/fs.ml
+++ b/lib_eio_linux/fs.ml
@@ -35,7 +35,7 @@ let with_dir dir_fd path fn =
     ~access:`R
     ~perm:0
     ~flags:Uring.Open_flags.(cloexec + path + directory)
-    dir_fd (if path = "" then "." else path)
+    dir_fd path
   |> fn
 
 module rec Dir : sig
@@ -89,7 +89,7 @@ end = struct
     ) else path
 
   let open_subtree t ~sw path =
-    let fd = Low_level.openat ~sw ~seekable:false t.fd (if path = "" then "." else path)
+    let fd = Low_level.openat ~sw ~seekable:false t.fd path
         ~access:`R
         ~flags:Uring.Open_flags.(cloexec + path + directory)
         ~perm:0
@@ -102,7 +102,6 @@ end = struct
 
   let read_dir t path =
     Switch.run ~name:"read_dir" @@ fun sw ->
-    let path = if path = "" then "." else path in
     let fd =
       Low_level.openat ~sw t.fd path
         ~seekable:false
@@ -114,7 +113,6 @@ end = struct
 
   let with_dir_entries t path fn =
     Switch.run ~name:"with_dir_entries" @@ fun sw ->
-    let path = if path = "" then "." else path in
     let fd =
       Low_level.openat ~sw t.fd path
         ~seekable:false

--- a/lib_eio_linux/low_level.ml
+++ b/lib_eio_linux/low_level.ml
@@ -343,6 +343,7 @@ let rec openat2 ~sw ?seekable ~access ~flags ~perm ~resolve ?dir path =
   | Some dir -> Fd.use_exn "openat2" dir (fun x -> use (Some x))
 
 let openat ~sw ?seekable ~access ~flags ~perm dir path =
+  let path = if path = "" then "." else path in
   match dir with
   | FD dir -> openat2 ~sw ?seekable ~access ~flags ~perm ~resolve:Uring.Resolve.beneath ~dir path
   | Cwd -> openat2 ~sw ?seekable ~access ~flags ~perm ~resolve:Uring.Resolve.beneath path
@@ -538,7 +539,7 @@ let statx ~mask ~follow fd path buf =
     statx_raw ~mask ~fd:parent leaf buf flags
   | Cwd | FD _ ->
     Switch.run ~name:"statx" @@ fun sw ->
-    let fd = openat ~sw ~seekable:false fd (if path = "" then "." else path)
+    let fd = openat ~sw ~seekable:false fd path
         ~access:`R
         ~flags:Uring.Open_flags.(cloexec + path)
         ~perm:0
@@ -562,7 +563,7 @@ let unlink ~rmdir dir path =
   with_parent_dir "unlink" dir path @@ fun parent leaf ->
   let res = Sched.enter "unlink" (enqueue_unlink (rmdir, parent, leaf)) in
   match Res.unit_result res with
-  | Error e -> raise @@ Err.v e "unlinkat" ""
+  | Error e -> raise @@ Err.v e "unlinkat" leaf
   | Ok () -> ()
 
 let rename old_dir old_path new_dir new_path =

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -355,7 +355,9 @@ module Resolve = struct
      use [with_parent_loop] instead. *)
   let with_parent op fd path fn = (* todo: use o_resolve_beneath if available *)
     match fd with
-    | Fs -> fn None path
+    | Fs ->
+      let path = if path = "" then "." else path in
+      fn None path
     | Cwd -> with_parent_loop path (fun x y -> Ok (fn x y))
     | Fd dirfd ->
       Fd.use_exn op dirfd @@ fun dirfd ->
@@ -395,7 +397,9 @@ let open_dir_handle label dirfd path =
     | exception (Unix.Unix_error ((ELOOP | ENOTDIR | EMLINK | EUNKNOWNERR _), _, _) as e) -> Error (`Symlink (Some e))
   in
   match dirfd with
-  | Fs -> Unix.opendir path
+  | Fs ->
+    let path = if path = "" then "." else path in
+    Unix.opendir path
   | Cwd -> use_confined None
   | Fd dirfd ->
     Fd.use_exn label dirfd @@ fun dirfd ->
@@ -557,6 +561,7 @@ let chown ~follow ?(uid=(-1L)) ?(gid=(-1L)) dirfd path =
   match dirfd with
   | Fs ->
     let flags = if follow then 0 else Config.at_symlink_nofollow in
+    let path = if path = "" then "." else path in
     Eio_unix.Private.chown_unix ~flags ~uid ~gid at_fdcwd path 
   | Cwd -> use_confined None
   | Fd dirfd -> Fd.use_exn "chown" dirfd @@ fun dirfd -> use_confined (Some dirfd)
@@ -579,6 +584,7 @@ let chmod ~follow ~mode dirfd path =
   match dirfd with
   | Fs ->
     let flags = if follow then 0 else Config.at_symlink_nofollow in
+    let path = if path = "" then "." else path in
     Eio_unix.Private.chmod_unix at_fdcwd path ~mode ~flags
   | Cwd -> use_confined None
   | Fd dirfd -> Fd.use_exn "chmod" dirfd @@ fun dirfd -> use_confined (Some dirfd)

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -528,6 +528,7 @@ let fstatat ~buf ~follow dirfd path =
   match dirfd with
   | Fs ->
     let flags = if follow then 0 else Config.at_symlink_nofollow in
+    let path = if path = "" then "." else path in
     eio_fstatat buf at_fdcwd path flags
   | Cwd -> fstatat_confined ~buf ~follow None path
   | Fd dirfd ->

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -593,6 +593,17 @@ Create a sandbox, write a file with it, then read it from outside:
 
 # Unconfined FS access
 
+`mkdirs` works with FS too (checks `stat` copes with empty path):
+
+```ocaml
+# run ~clear:["foo"] @@ fun env ->
+  let fs = env#fs in
+  let path = (fs / "foo/bar") in
+  Path.mkdirs path ~perm:0o700;
+  Eio.Path.is_directory path
+- : bool = true
+```
+
 We create a directory and chdir into it.
 Using `cwd` we can't access the parent, but using `fs` we can:
 

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -107,6 +107,11 @@ let try_chmod path ~follow ~perm =
   match Eio.Path.chmod ~follow path ~perm with
   | () -> traceln "chmod %a to %o -> ok" Path.pp path perm
   | exception ex -> traceln "@[<h>%a@]" Eio.Exn.pp ex
+
+let try_chown ?uid ?gid path ~follow =
+  match Eio.Path.chown ?uid ?gid ~follow path with
+  | () -> traceln "chown %a -> ok" Path.pp path
+  | exception ex -> traceln "@[<h>%a@]" Eio.Exn.pp ex
 ```
 
 # Basic test cases
@@ -602,6 +607,35 @@ Create a sandbox, write a file with it, then read it from outside:
   Path.mkdirs path ~perm:0o700;
   Eio.Path.is_directory path
 - : bool = true
+```
+
+Check other operations give sensible results when applied directly to `fs`:
+
+```ocaml
+# run ~clear:["foo"] @@ fun env ->
+  let fs = env#fs in
+  let tmpdir = fs / "foo" in
+  Path.mkdir tmpdir ~perm:0o700;
+  Unix.chdir "foo";
+  Fun.protect ~finally:(fun () -> Unix.chdir "..") @@ fun () ->
+  try_mkdir fs;
+  try_symlink fs ~link_to:"should-fail";
+  try_read_link fs;
+  try_stat fs;
+  try_read_dir fs;
+  try_chmod fs ~perm:0o750 ~follow:false;
+  try_chown fs ~follow:false;
+  Path.with_subtree fs @@ fun confined ->
+  try_stat confined
++Eio.Io Fs Already_exists _, creating directory <fs>
++Eio.Io Fs Already_exists _, creating symlink <fs> -> should-fail
++Eio.Io _, reading target of symlink <fs>
++<fs> -> directory
++read_dir <fs> -> []
++chmod <fs> to 750 -> ok
++chown <fs> -> ok
++<.> -> directory
+- : unit = ()
 ```
 
 We create a directory and chdir into it.


### PR DESCRIPTION
On eio_posix, `fstat fs` failed because it called `fstatat(AT_FDCWD, "", ...)` and that doesn't allow empty paths. 

The other cases look OK:

- `fstat cwd` was OK because our path resolving logic handles that.
- Eio_linux was OK because we have `AT_EMPTY_PATH` there.

This was breaking `mkdirs` if only the base directory already existed.

Fixes #906, reported by @samoht.

(Windows has some problems here too, but I think @avsm is rewriting its path handling at the moment anyway)