### PR TITLE
use a bigger stack buffer for getdents to speed up bigger dirs

### DIFF
--- a/lib_eio_linux/eio_stubs.c
+++ b/lib_eio_linux/eio_stubs.c
@@ -56,8 +56,8 @@ struct caml_eio_clone_args {
   uint64_t tls;
 };
 
-// Make sure we have enough space for at least one entry.
-#define DIRENT_BUF_SIZE (PATH_MAX + sizeof(struct dirent64))
+// Large enough that even big directories need few getdents64 calls.
+#define DIRENT_BUF_SIZE 65536
 
 CAMLprim value caml_eio_eventfd(value v_initval) {
   int ret;


### PR DESCRIPTION
on large directories (with ~1m files) this makes directory traversal ~30% faster as the number of syscalls needed drops by an order of magnitude as the buffer is filled up with multiple entries. It also helps a lot on network filesystems (Ceph in my case)

64KB is still a reasonable stack usage for small directories (which wont take long to traverse) so I'm just bumping up the default rather than do a dynamic allocation.