### PR TITLE
Implement Eio.Path.native as a Pi backend and add Windows support

### DIFF
--- a/lib_eio/utils/eio_utils.ml
+++ b/lib_eio/utils/eio_utils.ml
@@ -7,3 +7,4 @@ module Suspended = Suspended
 module Zzz = Zzz
 module Dla = Dla
 module Posix_path = Posix_path
+module Nt_path = Nt_path

--- a/lib_eio/utils/nt_path.ml
+++ b/lib_eio/utils/nt_path.ml
@@ -1,0 +1,99 @@
+(* Windows path syntax. *)
+
+let is_drive_letter = function 'A' .. 'Z' | 'a' .. 'z' -> true | _ -> false
+let is_sep c = c = '\\' || c = '/'
+
+(* A recognizer matches at position [i] of [s] and returns the position
+   one past the match, or [None] if it doesn't match. *)
+type recognizer = string -> int -> int option
+
+let charp f : recognizer =
+  fun s i -> if i < String.length s && f s.[i] then Some (i + 1) else None
+
+let ( *> ) (p : recognizer) (q : recognizer) : recognizer =
+  fun s i -> Option.bind (p s i) (q s)
+
+let ( <|> ) (p : recognizer) (q : recognizer) : recognizer =
+  fun s i -> match p s i with Some _ as r -> r | None -> q s i
+
+let opt p : recognizer = p <|> (fun _ i -> Some i)
+
+(* Zero or more matches of [p]. *)
+let rec many p : recognizer = fun s i ->
+  match p s i with Some j -> many p s j | None -> Some i
+
+let chr c = charp (Char.equal c)
+let sep = charp is_sep
+let bslash = chr '\\'
+let qmark = chr '?'
+
+(* The (possibly empty) run of non-separator characters at [i]. *)
+let component = many (charp (fun c -> not (is_sep c)))
+
+(* A component whose text satisfies [f]. *)
+let component_is f : recognizer = fun s i ->
+  match component s i with
+  | Some e when f (String.sub s i (e - i)) -> Some e
+  | _ -> None
+
+(* The component after this one. [opt sep] rather than [sep] so that a
+   malformed prefix is cut at whatever exists. *)
+let next = opt sep *> component
+
+let drive = charp is_drive_letter *> chr ':'
+let q_or_dot = component_is (fun c -> c = "?" || c = ".")
+let unc_kw = component_is (fun c -> String.uppercase_ascii c = "UNC")
+
+(* The "C:", "\\server\share", "\\.\device", "\\?\..." or "\??\..."
+   volume prefix of a path. *)
+let volume_prefix =
+  drive                                                  (* C: *)
+  <|> (sep *> sep *> q_or_dot *> opt sep *> unc_kw
+       *> next *> next)                                  (* \\?\UNC\server\share *)
+  <|> (sep *> sep *> component *> next)                  (* \\server\share, \\?\C: or \\.\device *)
+  <|> (bslash *> qmark *> qmark *> component *> next)    (* \??\C: - the NT object-manager form (backslash only) *)
+
+let volume_end s = Option.value (volume_prefix s 0) ~default:0
+let volume s = String.sub s 0 (volume_end s)
+
+(* Win32 does no normalization in the verbatim and NT namespaces. *)
+let verbatim_prefix = bslash *> (bslash <|> qmark) *> qmark
+let verbatim s = Option.is_some (verbatim_prefix s 0)
+
+(* [is_relative p] is [true] unless [p] begins with a volume or a separator. *)
+let is_relative s = Option.is_none ((volume_prefix <|> sep) s 0)
+
+let split p =
+  let vend = volume_end p in
+  let sep_at = if verbatim p then Char.equal '\\' else is_sep in
+  let sep_at i = sep_at p.[i] in
+  (* Trailing separators are ignored; one is kept for a bare root. *)
+  let rec trim i = if i > vend + 1 && sep_at (i - 1) then trim (i - 1) else i in
+  let stop = trim (String.length p) in
+  if stop <= vend || (stop = vend + 1 && sep_at vend) then None
+  else
+    let rec rsep i = if i < vend then None else if sep_at i then Some i else rsep (i - 1) in
+    match rsep (stop - 1) with
+    | None -> Some (volume p, String.sub p vend (stop - vend))
+    | Some idx ->
+      let basename = String.sub p (idx + 1) (stop - idx - 1) in
+      let dirname =
+        (* keep the root separator itself *)
+        String.sub p 0 (if idx = vend then vend + 1 else trim idx)
+      in
+      Some (dirname, basename)
+
+let concat a b =
+  let l = String.length a in
+  if l = 0 then b
+  else if (if verbatim a then a.[l - 1] = '\\' else is_sep a.[l - 1]) then a ^ b
+  else if drive a 0 = Some l then
+    a ^ b   (* a bare drive is drive-relative: adding a separator would change its meaning *)
+  else a ^ "\\" ^ b
+
+let join p1 p2 =
+  match p1, p2 with
+  | p1, "" -> concat p1 p2
+  | _, p2 when not (is_relative p2) -> p2
+  | ".", p2 -> p2
+  | p1, p2 -> concat p1 p2

--- a/lib_eio/utils/nt_path.mli
+++ b/lib_eio/utils/nt_path.mli
@@ -1,0 +1,9 @@
+(** Windows path syntax.
+
+    - [join dir step] appends [step] to [dir] using ["\\"] as the directory separator,
+      unless [dir] already ends in a separator. After a bare drive ([C:]) no
+      separator is added, to keep the path drive-relative.
+
+    - [split]: Volume prefixes ([C:], [\\server\share], [\\?\...], [\??\...]) are never split. *)
+
+include Eio.Fs.Pi.PATH

--- a/lib_eio_windows/fs.ml
+++ b/lib_eio_windows/fs.ml
@@ -26,6 +26,9 @@ open Eio.Std
 
 module Fd = Eio_unix.Fd
 
+(* NT object-manager namespace prefix, required by NtCreateFile. *)
+let nt_prefix = "\\??\\"
+
 module rec Dir : sig
   include Eio.Fs.Pi.DIR
 
@@ -57,17 +60,22 @@ end = struct
         let dir_path = Err.run Low_level.realpath t.dir_path in
         let full = Err.run Low_level.realpath (Filename.concat dir_path path) in
         let prefix_len = String.length dir_path + 1 in
-        (* \\??\\ Is necessary with NtCreateFile. *)
         if String.length full >= prefix_len && String.sub full 0 prefix_len = dir_path ^ Filename.dir_sep then begin
-          "\\??\\" ^ full
+          nt_prefix ^ full
         end else if full = dir_path then
-          "\\??\\" ^ full
+          nt_prefix ^ full
         else
           raise @@ Eio.Fs.err (Permission_denied (Err.Outside_sandbox (full, dir_path)))
       ) else (
         raise @@ Eio.Fs.err (Permission_denied Err.Absolute_path)
       )
     ) else path
+
+  let strip_nt_prefix p =
+    let n = String.length nt_prefix in
+    if String.starts_with ~prefix:nt_prefix p
+    then String.sub p n (String.length p - n)
+    else p
 
   let with_parent_dir t path fn =
     if t.sandbox then (
@@ -206,10 +214,22 @@ end = struct
 
   let pp f t = Fmt.string f (String.escaped t.label)
 
-  let native _t _path =
-    failwith "TODO: Windows native"
+  let native_internal t path =
+    if Filename.is_relative path then (
+      let p =
+        if t.dir_path = "." then path
+        else Filename.concat (strip_nt_prefix t.dir_path) path
+      in
+      if p = "" then "."
+      else if p = "." then p
+      else if Filename.is_implicit p then ".\\" ^ p
+      else p
+    ) else path
 
-  include Eio_utils.Posix_path    (* todo: replace with Windows syntax *)
+  let native t path =
+    Some (native_internal t path)
+
+  include Eio_utils.Nt_path
 end
 and Handler : sig
   val v : (Dir.t, [`Dir | `Close]) Eio.Resource.handler

--- a/lib_eio_windows/test/test_fs.ml
+++ b/lib_eio_windows/test/test_fs.ml
@@ -66,6 +66,52 @@ let test_create_and_read env () =
   Path.save ~create:(`Exclusive 0o666) path data;
   Alcotest.(check string) "same data" data (Path.load path)
 
+(* An absolute Windows path replaces the directory part, as "/" does. *)
+let test_absolute_join env () =
+  let fs = Eio.Stdenv.fs env in
+  let check p expected =
+    let (_, got) = fs / "sub" / p in
+    Alcotest.(check string) p expected got
+  in
+  check "C:\\foo" "C:\\foo";
+  check "C:/foo" "C:/foo";
+  check "C:foo" "C:foo";   (* drive-relative also replaces *)
+  check "\\foo" "\\foo";
+  check "\\\\server\\share" "\\\\server\\share";
+  check "/foo" "/foo";
+  check "rel" "sub\\rel"
+
+(* Splitting a path and re-joining with (/) refers to the same location. *)
+let test_split_join env () =
+  let fs = Eio.Stdenv.fs env in
+  let check p expected =
+    match Path.split (fs / p) with
+    | None -> Alcotest.failf "%s: no split" p
+    | Some (dir, base) -> Alcotest.(check string) p expected (snd (dir / base))
+  in
+  check "C:\\a\\b" "C:\\a\\b";
+  check "C:\\b" "C:\\b";
+  check "C:x" "C:x";              (* drive-relative: no separator added *)
+  check "\\\\srv\\share\\x" "\\\\srv\\share\\x";
+  check "\\\\?\\C:\\a\\b" "\\\\?\\C:\\a\\b"   (* verbatim: keeps "\\" *)
+
+let test_native env () =
+  let cwd = Eio.Stdenv.cwd env in
+  (* Lexical, so nothing needs to exist. *)
+  Alcotest.(check string) "relative" ".\\foo" (Path.native_exn (cwd / "foo"));
+  Alcotest.(check string) "parent" ".\\.." (Path.native_exn (cwd / ".."));
+  Alcotest.(check string) "empty" "." (Path.native_exn cwd);
+  Alcotest.(check string) "fs relative" ".\\foo" (Path.native_exn (Eio.Stdenv.fs env / "foo"));
+  Alcotest.(check string) "absolute" "C:\\foo" (Path.native_exn (Eio.Stdenv.fs env / "C:\\foo"));
+  (* A subtree records its directory in NT form; native must yield the Win32 form. *)
+  Path.mkdir (cwd / "native-sub") ~perm:0o700;
+  Fun.protect ~finally:(fun () -> Path.rmdir (cwd / "native-sub")) @@ fun () ->
+  Path.with_open_dir (cwd / "native-sub") @@ fun sub ->
+  let p = Path.native_exn (sub / "foo.txt") in
+  Alcotest.(check bool) "sub absolute" false (Filename.is_relative p);
+  Alcotest.(check bool) "no NT prefix" false (String.starts_with ~prefix:"\\??\\" p);
+  Alcotest.(check string) "sub basename" "foo.txt" (Filename.basename p)
+
 let test_cwd_no_access_abs env () =
   let cwd = Eio.Stdenv.cwd env in
   let temp = Filename.temp_file "eio" "win" in
@@ -269,6 +315,9 @@ let test_remove_dir env () =
 
 let tests env = [
   "create-write-read", `Quick, test_create_and_read env;
+  "absolute-join", `Quick, test_absolute_join env;
+  "split-join", `Quick, test_split_join env;
+  "native", `Quick, test_native env;
   "cwd-abs-path", `Quick, test_cwd_no_access_abs env;
   "create-exclusive", `Quick, test_exclusive env;
   "create-if_missing", `Quick, test_if_missing env;

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -345,6 +345,193 @@ let split_join s =
 - : string = "bar"
 ```
 
+# Split and join on Windows
+
+```ocaml
+let split = Eio_utils.Nt_path.split
+let join = Eio_utils.Nt_path.join
+```
+
+`join` puts a "\" between the two parts, unless the first already ends with a
+separator:
+
+```ocaml
+# join "a" "b";;
+- : string = "a\\b"
+
+# join "a\\" "b";;
+- : string = "a\\b"
+
+# join "a/" "b";;
+- : string = "a/b"
+
+# join "a" "";;
+- : string = "a\\"
+
+# join "" "b";;
+- : string = "b"
+
+# join "." "b";;
+- : string = "b"
+```
+
+A directory that is a root already ends in a separator.
+A bare drive is the exception. `C:x` names a file in the cwd
+of drive C, whereas `C:\x` is at the drive's root.
+
+```ocaml
+# join "C:\\" "b";;
+- : string = "C:\\b"
+
+# join "C:" "x";;
+- : string = "C:x"
+
+# join "\\" "x";;
+- : string = "\\x"
+
+# join "\\\\srv\\share\\" "x";;
+- : string = "\\\\srv\\share\\x"
+
+# join "\\\\?\\C:\\" "b";;
+- : string = "\\\\?\\C:\\b"
+
+# join "\\??\\C:\\a" "b";;
+- : string = "\\??\\C:\\a\\b"
+```
+
+A path that names its own root replaces the directory rather than extending it.
+This also covers drive-relative (`C:x`) and rooted (`\x`) paths.  Such a path
+may be rejected when opened, unless it is being used with an unrestricted `fs`:
+
+```ocaml
+# join "a" "C:\\b";;
+- : string = "C:\\b"
+
+# join "a" "C:/b";;
+- : string = "C:/b"
+
+# join "a" "C:b";;
+- : string = "C:b"
+
+# join "a" "C:";;
+- : string = "C:"
+
+# join "a" "\\b";;
+- : string = "\\b"
+
+# join "a" "/b";;
+- : string = "/b"
+
+# join "a" "\\\\srv\\share";;
+- : string = "\\\\srv\\share"
+
+# join "a" "\\\\?\\C:\\b";;
+- : string = "\\\\?\\C:\\b"
+
+# join "a" "\\??\\C:\\b";;
+- : string = "\\??\\C:\\b"
+
+# join "a" "\\\\.\\NUL";;
+- : string = "\\\\.\\NUL"
+```
+
+Either / or \ separator ends a component. Trailing separators are ignored:
+
+```ocaml
+# split "a\\b";;
+- : (string * string) option = Some ("a", "b")
+
+# split "a/b\\c";;
+- : (string * string) option = Some ("a/b", "c")
+
+# split "a\\b\\\\";;
+- : (string * string) option = Some ("a", "b")
+
+# split "a";;
+- : (string * string) option = Some ("", "a")
+
+# split "";;
+- : (string * string) option = None
+```
+
+The volume prefix is never split, nor is a separator that follows it
+since removing it would change an absolute path into a drive-relative on:
+
+```ocaml
+# split "\\x";;
+- : (string * string) option = Some ("\\", "x")
+
+# split "\\";;
+- : (string * string) option = None
+
+# split "C:\\a\\b";;
+- : (string * string) option = Some ("C:\\a", "b")
+
+# split "C:\\b";;
+- : (string * string) option = Some ("C:\\", "b")
+
+# split "C:\\";;
+- : (string * string) option = None
+
+# split "C:x";;
+- : (string * string) option = Some ("C:", "x")
+
+# split "C:";;
+- : (string * string) option = None
+
+# split "\\\\srv\\share\\x";;
+- : (string * string) option = Some ("\\\\srv\\share\\", "x")
+
+# split "\\\\srv\\share";;
+- : (string * string) option = None
+
+# split "\\\\.\\NUL";;
+- : (string * string) option = None
+```
+
+Win32 passes verbatim (`\\?\`) and NT (`\??\`) paths through without any
+normalisation. This is only the case with "\" so using "/" is an ordinary
+character rather than a separator. The NT form needs backslashes for the same reason:
+
+```ocaml
+# split "\\\\?\\C:\\a/b";;
+- : (string * string) option = Some ("\\\\?\\C:\\", "a/b")
+
+# split "\\\\?\\UNC\\srv\\share\\x";;
+- : (string * string) option = Some ("\\\\?\\UNC\\srv\\share\\", "x")
+
+# split "\\??\\C:\\a\\b";;
+- : (string * string) option = Some ("\\??\\C:\\a", "b")
+
+# split "/??/C:/x";;
+- : (string * string) option = Some ("/??/C:", "x")
+```
+
+Joining the two parts of a split should give back the original path:
+
+```ocaml
+# List.filter (fun p -> Option.map (fun (d, b) -> join d b) (split p) <> Some p) [
+    "a\\b";
+    "C:\\a\\b";
+    "C:\\b";
+    "C:x";
+    "\\x";
+    "\\\\srv\\share\\x";
+    "\\\\?\\C:\\a\\b";
+    "\\\\?\\C:\\a/b";
+    "\\\\?\\UNC\\srv\\share\\x";
+    "\\??\\C:\\a\\b";
+  ];;
+- : string list = []
+```
+
+Components separated by "/" can come back separated by "\".
+
+```ocaml
+# split "a/b" |> Option.map (fun (d, b) -> join d b);;
+- : string option = Some "a\\b"
+```
+
 # Mkdirs
 
 Recursively creating directories with `mkdirs`.


### PR DESCRIPTION
This is split off from @avsm's #908 and rebased on top of #913 and #915.

Incorporates the approach from ocaml-multicore/eio#738.

I haven't reviewed it yet.