### PR TITLE
eio_posix: fix build on 32-bit platforms

### DIFF
--- a/lib_eio_posix/eio_posix_stubs.c
+++ b/lib_eio_posix/eio_posix_stubs.c
@@ -521,11 +521,14 @@ static value get_msghdr_fds(struct msghdr *msg) {
       int n_fds = (cm->cmsg_len - CMSG_LEN(0)) / sizeof(int);
       int i;
       for (i = n_fds - 1; i >= 0; i--) {
-	value fd = Val_int(fds[i]);
-	v_cons = caml_alloc_tuple(2);
-	Store_field(v_cons, 0, fd);
-	Store_field(v_cons, 1, v_list);
-	v_list = v_cons;
+        int fd = fds[i];
+#ifndef MSG_CMSG_CLOEXEC
+        fcntl(fd, F_SETFD, FD_CLOEXEC);         // For macOS
+#endif
+        v_cons = caml_alloc_tuple(2);
+        Store_field(v_cons, 0, Val_int(fd));
+        Store_field(v_cons, 1, v_list);
+        v_list = v_cons;
       }
     }
   }
@@ -564,6 +567,10 @@ CAMLprim value caml_eio_posix_recv_msg(value v_fd, value v_max_fds, value v_bufs
     .msg_controllen = controllen,
   };
   ssize_t r;
+  int flags = Int_val(v_flags);
+#ifdef MSG_CMSG_CLOEXEC
+  flags |= MSG_CMSG_CLOEXEC;
+#endif
 
   memset(cmsg, 0, controllen);
 
@@ -571,7 +578,7 @@ CAMLprim value caml_eio_posix_recv_msg(value v_fd, value v_max_fds, value v_bufs
   msg.msg_iov = iov;
 
   caml_enter_blocking_section();
-  r = recvmsg(Int_val(v_fd), &msg, Int_val(v_flags));
+  r = recvmsg(Int_val(v_fd), &msg, flags);
   caml_leave_blocking_section();
   caml_stat_free_preserving_errno(iov);
   if (r < 0) uerror("recv_msg", Nothing);

--- a/lib_eio_posix/include/discover.ml
+++ b/lib_eio_posix/include/discover.ml
@@ -4,7 +4,6 @@ let optional_flags = [
   "O_DSYNC";
   "O_RESOLVE_BENEATH";
   "O_PATH";
-  "MSG_CMSG_CLOEXEC";
 ]
 
 let () =

--- a/lib_eio_posix/low_level.ml
+++ b/lib_eio_posix/low_level.ml
@@ -124,10 +124,9 @@ let recv_msg fd buf =
 let recv_msg_with_fds ~sw ~max_fds fd buf =
   let addr, got, fds =
     Fd.use_exn "recv_msg" fd @@ fun fd ->
-    let flags = Option.value Config.msg_cmsg_cloexec ~default:0 in
+    let flags = 0 in
     do_nonblocking Read "recv_msg" (fun fd -> eio_recv_msg fd max_fds buf flags) fd
   in
-  if Config.msg_cmsg_cloexec = None then List.iter Unix.set_close_on_exec fds; (* For macos *)
   (addr, got, Eio_unix.Fd.of_unix_list ~sw fds)
 
 external eio_getrandom : Cstruct.buffer -> int -> int -> int = "caml_eio_posix_getrandom"


### PR DESCRIPTION
Reported by @glondu. Fixes #909.

The `MSG_CMSG_CLOEXEC` doesn't fit in an OCaml `int` on some 32-bit platforms, so just use it from C instead of passing it from OCaml. Unclear whether we really want to support eio_posix on 32-bit systems, but the fix is simple.