### PR TITLE
Clean up dir_path handling

### DIFF
--- a/lib_eio_linux/fs.ml
+++ b/lib_eio_linux/fs.ml
@@ -49,11 +49,14 @@ module rec Dir : sig
 end = struct
   type t = {
     fd : Low_level.dir_fd;
+    dir_path : string;
     label : string;
-    path : string;
   }
 
-  let v ~label ~path fd = { fd; label; path }
+  let v ~label ~path:dir_path fd =
+    (* Avoid having "" and "." meaning the same thing, so there are fewer cases to test *)
+    let dir_path = if dir_path = "." then "" else dir_path in
+    { fd; dir_path; label }
 
   let open_in t ~sw path =
     let fd = Low_level.openat ~sw t.fd path
@@ -81,7 +84,7 @@ end = struct
 
   let native_internal t path =
     if Filename.is_relative path then (
-      let p = Filename.concat t.path path in
+      let p = Filename.concat t.dir_path path in
       if p = "" then "."
       else if p = "." then p
       else if Filename.is_implicit p then "./" ^ p

--- a/lib_eio_posix/fs.ml
+++ b/lib_eio_posix/fs.ml
@@ -67,7 +67,10 @@ end = struct
 
   let fd t = t.fd
 
-  let v ~label ~path:dir_path fd = { fd; dir_path; label }
+  let v ~label ~path:dir_path fd =
+    (* Avoid having "" and "." meaning the same thing, so there are fewer cases to test *)
+    let dir_path = if dir_path = "." then "" else dir_path in
+    { fd; dir_path; label }
 
   let open_in t ~sw path =
     let fd = Err.run (Low_level.openat ~mode:0 ~sw t.fd path) Low_level.Open_flags.rdonly in
@@ -140,10 +143,7 @@ end = struct
 
   let native_internal t path =
     if Filename.is_relative path then (
-      let p =
-        if t.dir_path = "." then path
-        else Filename.concat t.dir_path path
-      in
+      let p = Filename.concat t.dir_path path in
       if p = "" then "."
       else if p = "." then p
       else if Filename.is_implicit p then "./" ^ p

--- a/tests/fs.md
+++ b/tests/fs.md
@@ -1408,6 +1408,12 @@ Exception: Failure "Simulated error".
   test (env#fs / "foo/bar");
   test env#cwd;
   test (env#cwd / "..");
+  let test_subtree base sub =
+    Eio.Path.with_subtree (base / sub) (fun x ->
+       traceln "subtree (%a / %S) -> %a" Eio.Path.pp base sub Fmt.(Dump.option string) (Eio.Path.native x)
+    )
+  in
+  test_subtree env#fs ".";
   let sub = env#cwd / "native-sub" in
   Eio.Path.mkdir sub ~perm:0o700;
   Eio.Path.with_subtree sub @@ fun sub ->
@@ -1423,6 +1429,7 @@ Exception: Failure "Simulated error".
 +<fs:foo/bar> -> Some ./foo/bar
 +<cwd> -> Some .
 +<cwd:..> -> Some ./..
++subtree (<fs> / ".") -> Some .
 +<native-sub> -> Some ./native-sub/
 +<native-sub:foo.txt> -> Some ./native-sub/foo.txt
 +<native-sub:.> -> Some ./native-sub/.


### PR DESCRIPTION
It wasn't clear whether `dir_path` would be "" or "." for the current directory:

- `eio_linux` was using "" for `cwd` and `fs`.
- `eio_posix` was using "." for `cwd` and `fs`.

Force it to "" in both cases so there are fewer things to test.

The only difference should be printing of native paths for the subtree "./.":

    ./          # Before with eio_linux
    ././        # Before with eio_posix
    .           # After (both)

(from https://github.com/ocaml-multicore/eio/pull/919#discussion_r3722069825)

Note: I didn't touch `eio_windows` as I don't have an easy way to test that.