### PR TITLE
Add "available" to opam files

### DIFF
--- a/eio_posix.opam
+++ b/eio_posix.opam
@@ -32,6 +32,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os != "win32"]
 x-extra-doc-deps: [
   "eio_main" {= version}
 ]

--- a/eio_posix.opam.template
+++ b/eio_posix.opam.template
@@ -1,3 +1,4 @@
+available: [os != "win32"]
 x-extra-doc-deps: [
   "eio_main" {= version}
 ]

--- a/eio_windows.opam
+++ b/eio_windows.opam
@@ -30,7 +30,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
-#available: [os = "win32"]
+available: [os = "win32"]
 x-extra-doc-deps: [
   "eio_main" {= version}
 ]

--- a/eio_windows.opam.template
+++ b/eio_windows.opam.template
@@ -1,4 +1,4 @@
-#available: [os = "win32"]
+available: [os = "win32"]
 x-extra-doc-deps: [
   "eio_main" {= version}
 ]


### PR DESCRIPTION
- `eio_windows` should only install on Windows. This was previously commented out due to a CI limitation, but ocaml-ci now has Windows support.
- `eio_posix` should not install on Windows.