### PR TITLE
Add index.mld for eio

### DIFF
--- a/lib_eio/dune
+++ b/lib_eio/dune
@@ -3,3 +3,6 @@
   (public_name eio)
   (flags (:standard -open Eio__core -open Eio__core.Private))
   (libraries eio__core cstruct lwt-dllist fmt bigstringaf optint mtime))
+
+(documentation
+  (package eio))

--- a/lib_eio/eio.mli
+++ b/lib_eio/eio.mli
@@ -11,7 +11,7 @@
     provided by an Eio {e backend}.
     Applications can use {!Eio_main.run} to run a suitable loop.
 
-    See {{:https://github.com/ocaml-multicore/eio}} for a tutorial. *)
+    See the {{:https://github.com/ocaml-multicore/eio/blob/main/README.md} Tutorial} for an introduction. *)
 
 (** Commonly used standard features. This module is intended to be [open]ed. *)
 module Std = Std

--- a/lib_eio/index.mld
+++ b/lib_eio/index.mld
@@ -1,0 +1,40 @@
+{0 Eio}
+
+Eio provides support for concurrency (juggling many tasks) and
+parallelism (using multiple CPU cores for performance).
+
+See the {{:https://github.com/ocaml-multicore/eio/blob/main/README.md} Tutorial} for an introduction.
+
+The main {!Eio} module provides:
+
+- {{!Eio.Fiber} Fiber}, {{!Eio.Switch} Switch}, {{!Eio.Cancel} Cancel} (managing fibers)
+- {{!Eio.Stdenv} Stdenv} (getting access to host resources)
+- {{!Eio.Path} Path}, {{!Eio.File} File} (managing files and directories)
+- {{!Eio.Flow} Flow}, {{!Eio.Buf_read} Buf_read}, {{!Eio.Buf_write} Buf_write} (text streams)
+- {{!Eio.Net} Net} (networking)
+- {{!Eio.Process} Process} (running other programs)
+- {{!Eio.Time} Time} (clocks and timeouts)
+- {{!Eio.Promise} Promise}, {{!Eio.Semaphore} Semaphore}, {{!Eio.Mutex} Mutex}, {{!Eio.Condition} Condition}, {{!Eio.Lazy} Lazy} (concurrency primitives)
+- {{!Eio.Stream} Stream}, {{!Eio.Pool} Pool} (collections)
+- {{!Eio.Domain_manager} Domain_manager}, {{!Eio.Executor_pool} Executor_pool} (using multiple domains)
+- {{!Eio.Std} Std} ([open Eio.Std] to get access to some common modules)
+- Less commonly-used: {{!Eio.Fs} Fs}, {{!Eio.Exn} Exn}, {{!Eio.Debug} Debug}, {{!Eio.Resource} Resource}
+
+{2 Extended Unix APIs}
+
+{!Eio_unix} provides low-level access to file-descriptors, system threads, etc.
+
+{2 Mocks}
+
+{!Eio_mock} is dummy backend for testing.
+
+{2 Tracing}
+
+{!Eio_runtime_events} read and write event traces.
+
+{2 Private}
+
+These are for backend implementors only:
+
+- {!Eio.Private}
+- {!Eio_utils}

--- a/lib_eio/index.mld
+++ b/lib_eio/index.mld
@@ -17,16 +17,17 @@ The main {!Eio} module provides:
 - {{!Eio.Promise} Promise}, {{!Eio.Semaphore} Semaphore}, {{!Eio.Mutex} Mutex}, {{!Eio.Condition} Condition}, {{!Eio.Lazy} Lazy} (concurrency primitives)
 - {{!Eio.Stream} Stream}, {{!Eio.Pool} Pool} (collections)
 - {{!Eio.Domain_manager} Domain_manager}, {{!Eio.Executor_pool} Executor_pool} (using multiple domains)
+- {{!Eio.Exn} Exn} (exceptions with context)
 - {{!Eio.Std} Std} ([open Eio.Std] to get access to some common modules)
-- Less commonly-used: {{!Eio.Fs} Fs}, {{!Eio.Exn} Exn}, {{!Eio.Debug} Debug}, {{!Eio.Resource} Resource}
+- Less commonly-used: {{!Eio.Fs} Fs}, {{!Eio.Debug} Debug}, {{!Eio.Resource} Resource}
 
 {2 Extended Unix APIs}
 
-{!Eio_unix} provides low-level access to file-descriptors, system threads, etc.
+{!Eio_unix} provides low-level but portable access to file-descriptors, threads and other system resources.
 
 {2 Mocks}
 
-{!Eio_mock} is dummy backend for testing.
+{!Eio_mock} is a dummy backend for testing.
 
 {2 Tracing}
 


### PR DESCRIPTION
The default auto-generated index is hard to navigate.

Before:
<img width="2030" height="1250" alt="before" src="https://github.com/user-attachments/assets/faa4a6de-e7a4-451a-af7e-470a5421412d" />

After:
<img width="2030" height="1865" alt="after" src="https://github.com/user-attachments/assets/1a71a931-c20a-47b4-b2ff-73a785848389" />
