### PR TITLE
Fix (harmless) gcc warning calloc-transposed-args

### DIFF
--- a/lib_eio/unix/fork_action.c
+++ b/lib_eio/unix/fork_action.c
@@ -97,7 +97,7 @@ CAMLprim value eio_unix_make_string_array(value v_len) {
 
   v_str_array = caml_alloc_custom_mem(&string_array_ops, sizeof(char ***), total);
 
-  char **c = calloc(sizeof(char *), n + 1);
+  char **c = calloc(n + 1, sizeof(char *));
   String_array_val(v_str_array) = c;
   if (!c)
     caml_raise_out_of_memory();


### PR DESCRIPTION
    fork_action.c:101:28: warning: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
      101 |   char **c = calloc(sizeof(char *), n + 1);
          |                            ^~~~
    fork_action.c:101:28: note: earlier argument should specify number of elements, later size of each element

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=112364.